### PR TITLE
feat: support re-triggering pipeline on the same issue (retry flow)

### DIFF
--- a/cmd/clawflow/commands/harvest.go
+++ b/cmd/clawflow/commands/harvest.go
@@ -11,18 +11,19 @@ import (
 
 // HarvestIssue is an issue returned in the harvest output.
 type HarvestIssue struct {
-	Repo        string `json:"repo"`
-	Number      int    `json:"number"`
-	Title       string `json:"title"`
-	Body        string `json:"body"`
+	Repo         string `json:"repo"`
+	Number       int    `json:"number"`
+	Title        string `json:"title"`
+	Body         string `json:"body"`
 	WorktreePath string `json:"worktree_path,omitempty"`
 }
 
 // HarvestResult is the JSON output of clawflow harvest.
 type HarvestResult struct {
-	ToEvaluate []HarvestIssue `json:"to_evaluate"`
-	ToExecute  []HarvestIssue `json:"to_execute"`
-	ToQueue    []HarvestIssue `json:"to_queue"`
+	ToEvaluate    []HarvestIssue `json:"to_evaluate"`
+	ToExecute     []HarvestIssue `json:"to_execute"`
+	ToQueue       []HarvestIssue `json:"to_queue"`
+	RetryEligible []HarvestIssue `json:"retry_eligible"`
 }
 
 func NewHarvestCmd() *cobra.Command {
@@ -47,9 +48,10 @@ func NewHarvestCmd() *cobra.Command {
 			}
 
 			result := HarvestResult{
-				ToEvaluate: []HarvestIssue{},
-				ToExecute:  []HarvestIssue{},
-				ToQueue:    []HarvestIssue{},
+				ToEvaluate:    []HarvestIssue{},
+				ToExecute:     []HarvestIssue{},
+				ToQueue:       []HarvestIssue{},
+				RetryEligible: []HarvestIssue{},
 			}
 
 			maxConcurrent := cfg.Settings.MaxConcurrentAgents
@@ -119,6 +121,22 @@ func NewHarvestCmd() *cobra.Command {
 							inProgressCount++
 						} else {
 							result.ToQueue = append(result.ToQueue, item)
+						}
+
+					// Retry-eligible: has agent-evaluated, no in-progress, no open PR,
+					// and memory shows a prior success (merged PR)
+					case evaluated && !inProgress && !readyForAgent:
+						hasPR, err := gh.PRExistsForIssue(repoName, issue.Number)
+						if err != nil {
+							fmt.Fprintf(cmd.ErrOrStderr(), "warn: PR check failed for %s#%d: %v\n", repoName, issue.Number, err)
+						}
+						if !hasPR && HasMergedPRInMemory(repoName, issue.Number) {
+							result.RetryEligible = append(result.RetryEligible, HarvestIssue{
+								Repo:   repoName,
+								Number: issue.Number,
+								Title:  issue.Title,
+								Body:   issue.Body,
+							})
 						}
 					}
 				}

--- a/cmd/clawflow/commands/memory.go
+++ b/cmd/clawflow/commands/memory.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ func NewMemoryCmd() *cobra.Command {
 		Short: "Read and write issue processing records",
 	}
 	cmd.AddCommand(newMemoryWriteCmd())
+	cmd.AddCommand(newMemoryReadCmd())
 	return cmd
 }
 
@@ -27,7 +29,7 @@ func newMemoryWriteCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "write",
-		Short: "Write a processing record for an issue",
+		Short: "Append a processing record for an issue",
 		Example: `  clawflow memory write --repo owner/repo --issue 7 --status success --pr-url https://...
   clawflow memory write --repo owner/repo --issue 7 --status failed --reason "timeout"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -42,13 +44,30 @@ func newMemoryWriteCmd() *cobra.Command {
 			}
 
 			path := fmt.Sprintf("%s/issue-%d.md", dir, issue)
-			content := buildMemoryRecord(repo, issue, status, prURL, reason)
+
+			// Determine attempt number by reading existing file
+			attemptNum := 1
+			if existing, err := os.ReadFile(path); err == nil {
+				attemptNum = countAttempts(string(existing)) + 1
+			}
+
+			section := buildAttemptSection(attemptNum, status, prURL, reason)
+
+			var content string
+			if attemptNum == 1 {
+				// First attempt: write header + section
+				content = fmt.Sprintf("# %s#%d\n\n%s", repo, issue, section)
+			} else {
+				// Subsequent attempts: append section
+				existing, _ := os.ReadFile(path)
+				content = strings.TrimRight(string(existing), "\n") + "\n\n" + section
+			}
 
 			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 				return fmt.Errorf("cannot write memory record: %w", err)
 			}
 
-			fmt.Printf("memory record written: %s\n", path)
+			fmt.Printf("memory record written (attempt %d): %s\n", attemptNum, path)
 			return nil
 		},
 	}
@@ -64,9 +83,84 @@ func newMemoryWriteCmd() *cobra.Command {
 	return cmd
 }
 
-func buildMemoryRecord(repo string, issue int, status, prURL, reason string) string {
+func newMemoryReadCmd() *cobra.Command {
+	var repo string
+	var issue int
+
+	cmd := &cobra.Command{
+		Use:   "read",
+		Short: "Read the memory record for an issue",
+		Example: `  clawflow memory read --repo owner/repo --issue 7`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := config.RepoSlug(repo)
+			path := fmt.Sprintf("%s/issue-%d.md", config.MemoryDir(slug), issue)
+			data, err := os.ReadFile(path)
+			if os.IsNotExist(err) {
+				fmt.Println("(no memory record)")
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(data))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
+	cmd.Flags().IntVar(&issue, "issue", 0, "issue number (required)")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("issue")
+	return cmd
+}
+
+// countAttempts counts how many "## Attempt N" sections exist in content.
+func countAttempts(content string) int {
+	count := 0
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "## Attempt ") {
+			count++
+		}
+	}
+	return count
+}
+
+// ReadMemoryFile reads the raw memory file for an issue, returning empty string if not found.
+func ReadMemoryFile(repo string, issue int) string {
+	slug := config.RepoSlug(repo)
+	path := fmt.Sprintf("%s/issue-%d.md", config.MemoryDir(slug), issue)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// HasMergedPRInMemory returns true if the memory record contains a success entry
+// (indicating a previously merged PR).
+func HasMergedPRInMemory(repo string, issue int) bool {
+	content := ReadMemoryFile(repo, issue)
+	return strings.Contains(content, "**Status:** success")
+}
+
+func buildAttemptSection(attempt int, status, prURL, reason string) string {
 	ts := time.Now().UTC().Format("2006-01-02T15:04:05Z")
 
+	var details string
+	switch status {
+	case "success":
+		details = fmt.Sprintf("**PR:** %s", prURL)
+	default:
+		details = fmt.Sprintf("**Reason:** %s", reason)
+	}
+
+	return fmt.Sprintf("## Attempt %d\n**Status:** %s  \n**Time:** %s  \n%s\n",
+		attempt, status, ts, details)
+}
+
+// buildMemoryRecord is kept for backward compatibility but no longer used internally.
+func buildMemoryRecord(repo string, issue int, status, prURL, reason string) string {
+	ts := time.Now().UTC().Format("2006-01-02T15:04:05Z")
 	switch status {
 	case "success":
 		return fmt.Sprintf("# %s#%d\n\n**Status:** success  \n**Time:** %s  \n**PR:** %s\n", repo, issue, ts, prURL)

--- a/cmd/clawflow/commands/retry.go
+++ b/cmd/clawflow/commands/retry.go
@@ -1,0 +1,113 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	gh "github.com/zhoushoujianwork/clawflow/internal/github"
+)
+
+func NewRetryCmd() *cobra.Command {
+	var repo string
+	var issue int
+
+	cmd := &cobra.Command{
+		Use:   "retry",
+		Short: "Re-trigger the pipeline for a previously processed issue",
+		Example: `  clawflow retry --repo owner/repo --issue 7`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// 1. Remove blocking labels so issue re-enters to_evaluate
+			labelsToRemove := []string{"agent-evaluated", "agent-failed", "agent-skipped"}
+			for _, label := range labelsToRemove {
+				if err := gh.RemoveLabel(repo, issue, label); err != nil {
+					// Ignore "label not found" errors — label may not exist
+					if !isLabelNotFoundErr(err) {
+						fmt.Fprintf(os.Stderr, "warn: cannot remove label %q: %v\n", label, err)
+					}
+				} else {
+					fmt.Printf("label %q removed from %s#%d\n", label, repo, issue)
+				}
+			}
+
+			// 2. Read existing memory to find previous PR URL
+			prevPRURL := extractLastPRURL(ReadMemoryFile(repo, issue))
+
+			// 3. Append retry entry to memory record
+			slug := config.RepoSlug(repo)
+			dir := config.MemoryDir(slug)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("cannot create memory dir: %w", err)
+			}
+			path := fmt.Sprintf("%s/issue-%d.md", dir, issue)
+
+			attemptNum := 1
+			if existing, err := os.ReadFile(path); err == nil {
+				attemptNum = countAttempts(string(existing)) + 1
+			}
+
+			ts := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+			section := fmt.Sprintf("## Attempt %d\n**Status:** in-progress  \n**Time:** %s  \n**Reason:** retry initiated\n",
+				attemptNum, ts)
+
+			var content string
+			if attemptNum == 1 {
+				content = fmt.Sprintf("# %s#%d\n\n%s", repo, issue, section)
+			} else {
+				existing, _ := os.ReadFile(path)
+				content = strings.TrimRight(string(existing), "\n") + "\n\n" + section
+			}
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				fmt.Fprintf(os.Stderr, "warn: cannot write memory record: %v\n", err)
+			}
+
+			// 4. Post comment on the issue
+			commentBody := buildRetryComment(prevPRURL)
+			if err := gh.PostIssueComment(repo, issue, commentBody); err != nil {
+				fmt.Fprintf(os.Stderr, "warn: cannot post comment: %v\n", err)
+			}
+
+			fmt.Printf("retry initiated for %s#%d — issue will re-enter to_evaluate on next harvest\n", repo, issue)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
+	cmd.Flags().IntVar(&issue, "issue", 0, "issue number (required)")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("issue")
+	return cmd
+}
+
+func buildRetryComment(prevPRURL string) string {
+	prev := "(none)"
+	if prevPRURL != "" {
+		prev = prevPRURL
+	}
+	return fmt.Sprintf("## 🔄 ClawFlow Retry Initiated\n\nThis issue has been re-queued for processing.\n\n**Previous attempt:** %s\n\nThe issue will re-enter the evaluation queue on the next harvest cycle.\n\n---\n🤖 Powered by [ClawFlow](https://github.com/zhoushoujianwork/clawflow)", prev)
+}
+
+// extractLastPRURL finds the last PR URL in a memory record.
+func extractLastPRURL(content string) string {
+	last := ""
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "**PR:**") {
+			last = strings.TrimSpace(strings.TrimPrefix(line, "**PR:**"))
+		}
+	}
+	return last
+}
+
+// isLabelNotFoundErr returns true if the error indicates the label doesn't exist on the issue.
+func isLabelNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Label does not exist") ||
+		strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "Could not remove label")
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -27,6 +27,7 @@ The AI skill (SKILL.md) handles evaluation and sub-agent orchestration.`,
 	root.AddCommand(NewUpdateCmd())
 	root.AddCommand(NewRepoCmd())
 	root.AddCommand(NewConfigCmd())
+	root.AddCommand(NewRetryCmd())
 	root.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print version",

--- a/cmd/clawflow/commands/status.go
+++ b/cmd/clawflow/commands/status.go
@@ -35,7 +35,9 @@ func NewStatusCmd() *cobra.Command {
 					continue
 				}
 
-				var toEvaluate, toExecute, inProgress, skipped, failed int
+				var toEvaluate, toExecute, inProgress, skipped, failed, retryEligible int
+				var retryIssues []gh.Issue
+
 				for _, issue := range issues {
 					switch {
 					case issue.HasLabel("in-progress"):
@@ -48,6 +50,13 @@ func NewStatusCmd() *cobra.Command {
 						toExecute++
 					case !issue.HasLabel("agent-evaluated"):
 						toEvaluate++
+					case issue.HasLabel("agent-evaluated") && !issue.HasLabel("in-progress") && !issue.HasLabel("ready-for-agent"):
+						// Check if retry-eligible: no open PR + memory has prior success
+						hasPR, _ := gh.PRExistsForIssue(repoName, issue.Number)
+						if !hasPR && HasMergedPRInMemory(repoName, issue.Number) {
+							retryEligible++
+							retryIssues = append(retryIssues, issue)
+						}
 					}
 				}
 
@@ -56,6 +65,13 @@ func NewStatusCmd() *cobra.Command {
 				fmt.Printf("    处理中:  %d\n", inProgress)
 				fmt.Printf("    已跳过:  %d\n", skipped)
 				fmt.Printf("    已失败:  %d\n", failed)
+				if retryEligible > 0 {
+					fmt.Printf("    可重试:  %d\n", retryEligible)
+					for _, issue := range retryIssues {
+						fmt.Printf("      #%d %s  (run: clawflow retry --repo %s --issue %d)\n",
+							issue.Number, issue.Title, repoName, issue.Number)
+					}
+				}
 				fmt.Println()
 			}
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -135,3 +135,9 @@ func injectToken(cmd *exec.Cmd) {
 		}
 	}
 }
+
+// PostIssueComment posts a comment on a GitHub issue.
+func PostIssueComment(repo string, issueNumber int, body string) error {
+	_, err := gh("issue", "comment", fmt.Sprint(issueNumber), "-R", repo, "--body", body)
+	return err
+}

--- a/skills/clawflow/SKILL.md
+++ b/skills/clawflow/SKILL.md
@@ -328,7 +328,16 @@ WORKTREE_PATH=$(clawflow worktree create --repo {owner}/{repo} --issue {number})
 
 ### Step 4.3 — Spawn Sub-agent
 
-启动修复 agent，工作目录指向 worktree：
+启动修复 agent，工作目录指向 worktree。
+
+**在生成 Task Prompt 之前，先读取 previous attempts 上下文：**
+
+```bash
+# 读取该 issue 的历史记录（如有）
+PREV_ATTEMPTS=$(clawflow memory read --repo {owner}/{repo} --issue {number} 2>/dev/null || echo "")
+```
+
+如果 `PREV_ATTEMPTS` 非空，将其内容填入 `{previous_attempts_context}`；否则填入 `(no previous attempts)`。
 
 **Task Prompt Template:**
 
@@ -347,6 +356,10 @@ Issue: #{number}
 标题: {title}
 内容: {body}
 </issue>
+
+<previous_attempts>
+{previous_attempts_context}
+</previous_attempts>
 
 <instructions>
 1. 在 worktree 路径中工作（不要 clone，已有代码）


### PR DESCRIPTION
## Summary

Implements retry flow for ClawFlow pipeline, allowing issues to be re-processed after a previous attempt.

## Changes

- `cmd/clawflow/commands/memory.go`: Switch to append mode — each write adds a new Attempt section instead of overwriting
- `cmd/clawflow/commands/retry.go`: New `clawflow retry` command that resets labels and re-queues the issue
- `cmd/clawflow/commands/harvest.go`: Surface retry-eligible issues in status output
- `cmd/clawflow/commands/status.go`: Display retry-eligible issues with actionable hint
- `internal/github/client.go`: Add PostIssueComment helper
- `skills/clawflow/SKILL.md`: Inject previous attempt context into Phase 4 sub-agent prompt

## Test plan

- [ ] `go build ./...` passes
- [ ] `clawflow retry --repo owner/repo --issue N` removes agent-evaluated/agent-failed/agent-skipped labels
- [ ] Memory records append new Attempt sections instead of overwriting
- [ ] `clawflow status` shows retry-eligible issues
- [ ] `clawflow harvest` includes `retry_eligible` field in JSON output

Fixes #6

---
🤖 Created by [ClawFlow](https://github.com/zhoushoujianwork/clawflow) — automated issue → fix → PR pipeline