### PR TITLE
fix: ensure ~/.clawflow/bin dir exists before download

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ cp "$REPO_ROOT/skills/clawflow/SKILL.md" "$SKILL_DEST/SKILL.md"
 echo "  [ok] SKILL.md installed"
 
 # ---------- 2. init user data directory ----------
+mkdir -p "$CLAWFLOW_HOME/bin"
 mkdir -p "$CLAWFLOW_HOME/config"
 mkdir -p "$CLAWFLOW_HOME/memory/repos"
 
@@ -94,7 +95,6 @@ done
 if command -v go &>/dev/null; then
   echo ""
   echo "Building clawflow CLI..."
-  mkdir -p "$CLAWFLOW_HOME/bin"
   if go build -o "$CLAWFLOW_HOME/bin/clawflow" "$REPO_ROOT/cmd/clawflow/" 2>/dev/null; then
     echo "  [ok] clawflow binary installed to ~/.clawflow/bin/clawflow"
     echo "  [tip] Add to PATH: export PATH=\"\$HOME/.clawflow/bin:\$PATH\""


### PR DESCRIPTION
## Summary

修复 curl 下载时因目标目录不存在导致的失败问题。

## Root Cause

`install.sh` 中 `mkdir -p ~/.clawflow/bin` 只在 Go 可用时（step 3 build block）才执行。当用户没有安装 Go，直接用 Option B（curl 下载二进制）时，`~/.clawflow/bin/` 目录从未被创建，导致 curl 写入失败。

## Changes

- `install.sh`：将 `mkdir -p "$CLAWFLOW_HOME/bin"` 移至 step 2（无条件初始化目录块），确保无论 Go 是否可用，bin 目录始终存在。

## Test plan

- [ ] 删除 `~/.clawflow/bin/` 目录后重新运行 `install.sh`（无 Go 环境），确认目录自动创建
- [ ] 运行 Option B curl 命令，确认不报 "No such file or directory" 错误
- [ ] 运行 `clawflow update`，确认不报目录不存在错误

Fixes #9

---
🤖 Created by [ClawFlow](https://github.com/zhoushoujianwork/clawflow) — automated issue → fix → PR pipeline