### PR TITLE
fix: 安装脚本将 binary 安装到系统 bin 目录，无需手动配置 PATH

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -6,7 +6,6 @@ set -e
 
 REPO="zhoushoujianwork/clawflow"
 CLAWFLOW_HOME="$HOME/.clawflow"
-BIN_DIR="$CLAWFLOW_HOME/bin"
 CONFIG_DIR="$CLAWFLOW_HOME/config"
 
 # ---------- platform detection ----------
@@ -43,13 +42,34 @@ fetch() {
   fi
 }
 
+# ---------- resolve install dir ----------
+# Prefer /usr/local/bin (system-wide, no PATH setup needed).
+# Fall back to ~/.local/bin if we don't have write access.
+if [[ -w /usr/local/bin ]]; then
+  BIN_DIR="/usr/local/bin"
+elif sudo -n true 2>/dev/null; then
+  BIN_DIR="/usr/local/bin"
+  USE_SUDO=1
+else
+  BIN_DIR="$HOME/.local/bin"
+fi
+
 # ---------- create directories ----------
-mkdir -p "$BIN_DIR" "$CONFIG_DIR" "$CLAWFLOW_HOME/memory/repos"
+mkdir -p "$CONFIG_DIR" "$CLAWFLOW_HOME/memory/repos"
+if [[ "$BIN_DIR" == "$HOME/.local/bin" ]]; then
+  mkdir -p "$BIN_DIR"
+fi
 
 # ---------- download binary ----------
 echo "  [dl] downloading ${ASSET}..."
-fetch "$DOWNLOAD_URL" "$BIN_DIR/clawflow"
-chmod +x "$BIN_DIR/clawflow"
+TMP_BIN="$(mktemp)"
+fetch "$DOWNLOAD_URL" "$TMP_BIN"
+chmod +x "$TMP_BIN"
+if [[ -n "${USE_SUDO:-}" ]]; then
+  sudo mv "$TMP_BIN" "$BIN_DIR/clawflow"
+else
+  mv "$TMP_BIN" "$BIN_DIR/clawflow"
+fi
 echo "  [ok] binary → $BIN_DIR/clawflow"
 
 # ---------- detect agent & install SKILL.md ----------
@@ -87,9 +107,17 @@ fi
 
 # ---------- init config (skip if already exists) ----------
 if [[ ! -f "$CONFIG_DIR/repos.yaml" ]]; then
-  fetch "https://raw.githubusercontent.com/${REPO}/main/config/repos.yaml" \
-        "$CONFIG_DIR/repos.yaml"
-  echo "  [ok] config → $CONFIG_DIR/repos.yaml"
+  cat > "$CONFIG_DIR/repos.yaml" << 'YAML'
+# ClawFlow monitored repositories
+# Add repos you want ClawFlow to watch for issues.
+#
+# Example:
+# repos:
+#   - repo: owner/repo-name
+#     enabled: true
+repos: []
+YAML
+  echo "  [ok] config → $CONFIG_DIR/repos.yaml (default template)"
 else
   echo "  [skip] config already exists — keeping your version"
 fi
@@ -103,20 +131,21 @@ installed_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 YAML
 echo "  [ok] install record saved"
 
-# ---------- PATH setup ----------
-PATH_LINE='export PATH="$HOME/.clawflow/bin:$PATH"'
-SHELL_RC=""
-case "${SHELL:-}" in
-  */zsh)  SHELL_RC="$HOME/.zshrc" ;;
-  */bash) SHELL_RC="$HOME/.bashrc" ;;
-esac
+# ---------- PATH setup (only needed for ~/.local/bin) ----------
+NEED_SOURCE=""
+if [[ "$BIN_DIR" == "$HOME/.local/bin" ]]; then
+  PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+  SHELL_RC=""
+  case "${SHELL:-}" in
+    */zsh)  SHELL_RC="$HOME/.zshrc" ;;
+    */bash) SHELL_RC="$HOME/.bashrc" ;;
+  esac
 
-if [[ -n "$SHELL_RC" ]] && ! grep -q '.clawflow/bin' "$SHELL_RC" 2>/dev/null; then
-  printf '\n# ClawFlow\n%s\n' "$PATH_LINE" >> "$SHELL_RC"
-  echo "  [ok] PATH added to $SHELL_RC"
-  NEED_SOURCE="$SHELL_RC"
-else
-  NEED_SOURCE=""
+  if [[ -n "$SHELL_RC" ]] && ! grep -q '.local/bin' "$SHELL_RC" 2>/dev/null; then
+    printf '\n# ClawFlow\n%s\n' "$PATH_LINE" >> "$SHELL_RC"
+    echo "  [ok] PATH added to $SHELL_RC"
+    NEED_SOURCE="$SHELL_RC"
+  fi
 fi
 
 # ---------- done ----------


### PR DESCRIPTION
## Summary

将安装脚本的默认安装路径从 ~/.clawflow/bin/ 改为各操作系统的标准系统 bin 目录（macOS/Linux: /usr/local/bin），安装后无需手动 export PATH 即可直接使用 clawflow 命令。同时补充缺少的默认配置文件初始化逻辑。

## Changes

- get.sh: 安装目标路径改为 /usr/local/bin（需要 sudo）或回退到 ~/.local/bin（无 sudo 权限时）
- get.sh: 默认 repos.yaml 改为内联生成，不再依赖远程 config/ 文件（修复 404 错误）
- PATH 设置仅在回退到 ~/.local/bin 时才写入 shell rc 文件

## Test plan

- [ ] 运行安装脚本后，clawflow 命令无需 export PATH 即可直接使用
- [ ] ~/.clawflow/config/repos.yaml 在首次安装后自动创建（不再 404）

Fixes #13

---
🤖 Created by [ClawFlow](https://github.com/zhoushoujianwork/clawflow) — automated issue → fix → PR pipeline