### PR TITLE
feat: 支持 clawflow-saas worker 模式 — login + worker start 命令

### DIFF
--- a/cmd/clawflow/commands/config.go
+++ b/cmd/clawflow/commands/config.go
@@ -15,6 +15,7 @@ func NewConfigCmd() *cobra.Command {
 	cmd.AddCommand(newConfigSetTokenCmd())
 	cmd.AddCommand(newConfigSetGitLabTokenCmd())
 	cmd.AddCommand(newConfigShowCmd())
+	cmd.AddCommand(newConfigSetCmd())
 	return cmd
 }
 
@@ -153,4 +154,47 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func newConfigSetCmd() *cobra.Command {
+	var saasURL, token string
+
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Manually configure SaaS URL and worker token",
+		Long: `Writes saas_url and worker_token to ~/.clawflow/config/worker.yaml.
+Use this instead of 'clawflow login' when you already have a worker token.`,
+		Example: "  clawflow config set --saas-url https://clawflow.daboluo.cc --token cfw_xxx",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if saasURL == "" && token == "" {
+				return fmt.Errorf("at least one of --saas-url or --token is required")
+			}
+			wc, err := config.LoadWorkerConfig()
+			if err != nil {
+				return fmt.Errorf("load worker config: %w", err)
+			}
+			if saasURL != "" {
+				wc.SaasURL = saasURL
+			}
+			if token != "" {
+				wc.WorkerToken = token
+			}
+			if err := wc.Save(); err != nil {
+				return fmt.Errorf("save worker config: %w", err)
+			}
+			fmt.Printf("Worker config saved to ~/.clawflow/config/worker.yaml\n")
+			if wc.SaasURL != "" {
+				fmt.Printf("  saas_url:     %s\n", wc.SaasURL)
+			}
+			if wc.WorkerToken != "" {
+				n := len(wc.WorkerToken)
+				fmt.Printf("  worker_token: %s***\n", wc.WorkerToken[:max(0, n-4)])
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&saasURL, "saas-url", "", "ClawFlow SaaS base URL")
+	cmd.Flags().StringVar(&token, "token", "", "Worker token (cfw_xxx)")
+	return cmd
 }

--- a/cmd/clawflow/commands/login.go
+++ b/cmd/clawflow/commands/login.go
@@ -1,0 +1,187 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+func NewLoginCmd() *cobra.Command {
+	var saasURL string
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "OAuth login to ClawFlow SaaS and obtain a worker token",
+		Long: `Opens a browser for GitHub/GitLab OAuth, receives the callback on localhost,
+exchanges the code for a JWT, then generates a worker token (cfw_xxx) and writes
+saas_url + worker_token to ~/.clawflow/config/worker.yaml.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogin(saasURL)
+		},
+	}
+
+	cmd.Flags().StringVar(&saasURL, "saas-url", "", "ClawFlow SaaS base URL (required)")
+	_ = cmd.MarkFlagRequired("saas-url")
+	return cmd
+}
+
+func runLogin(saasURL string) error {
+	// 1. Start a local HTTP server to receive the OAuth callback.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("cannot start callback server: %w", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", port)
+
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	srv := &http.Server{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errCh <- fmt.Errorf("no code in callback: %s", r.URL.RawQuery)
+			http.Error(w, "missing code", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintln(w, "<html><body><h2>Login successful — you can close this tab.</h2></body></html>")
+		codeCh <- code
+	})
+	srv.Handler = mux
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			errCh <- err
+		}
+	}()
+
+	// 2. Build the OAuth URL and open the browser.
+	authURL := fmt.Sprintf("%s/api/auth/github?redirect_uri=%s", saasURL, redirectURI)
+	fmt.Printf("Opening browser for OAuth login...\n  %s\n\n", authURL)
+	_ = openBrowser(authURL)
+
+	// 3. Wait for the callback (2-minute timeout).
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	var code string
+	select {
+	case code = <-codeCh:
+	case err := <-errCh:
+		return fmt.Errorf("OAuth callback error: %w", err)
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting for OAuth callback")
+	}
+	_ = srv.Shutdown(context.Background())
+
+	// 4. Exchange code for JWT.
+	jwt, err := exchangeCodeForJWT(saasURL, code, redirectURI)
+	if err != nil {
+		return fmt.Errorf("JWT exchange failed: %w", err)
+	}
+
+	// 5. Generate worker token.
+	workerToken, err := generateWorkerToken(saasURL, jwt)
+	if err != nil {
+		return fmt.Errorf("worker token generation failed: %w", err)
+	}
+
+	// 6. Persist config.
+	wc := &config.WorkerConfig{
+		SaasURL:     saasURL,
+		WorkerToken: workerToken,
+	}
+	if err := wc.Save(); err != nil {
+		return fmt.Errorf("save worker config: %w", err)
+	}
+
+	fmt.Printf("Login successful.\n")
+	fmt.Printf("  saas_url:     %s\n", saasURL)
+	fmt.Printf("  worker_token: %s***\n", workerToken[:min(8, len(workerToken))])
+	fmt.Printf("  config:       ~/.clawflow/config/worker.yaml\n")
+	fmt.Println("\nRun: clawflow worker start")
+	return nil
+}
+
+func exchangeCodeForJWT(saasURL, code, redirectURI string) (string, error) {
+	body, _ := json.Marshal(map[string]string{
+		"code":         code,
+		"redirect_uri": redirectURI,
+	})
+	resp, err := http.Post(saasURL+"/api/auth/github", "application/json", bytes.NewReader(body)) //nolint:gosec
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("status %d: %s", resp.StatusCode, b)
+	}
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.Token == "" {
+		return "", fmt.Errorf("empty token in response")
+	}
+	return result.Token, nil
+}
+
+func generateWorkerToken(saasURL, jwt string) (string, error) {
+	req, _ := http.NewRequest("POST", saasURL+"/api/v1/orgs/current/worker-token", nil)
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("status %d: %s", resp.StatusCode, b)
+	}
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.Token == "" {
+		return "", fmt.Errorf("empty worker token in response")
+	}
+	return result.Token, nil
+}
+
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -34,6 +34,8 @@ The AI skill (SKILL.md) handles evaluation and sub-agent orchestration.`,
 	root.AddCommand(NewUnblockScanCmd())
 	root.AddCommand(NewBillingHookCmd())
 	root.AddCommand(NewLangCmd())
+	root.AddCommand(NewLoginCmd())
+	root.AddCommand(NewWorkerCmd())
 	root.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print version",

--- a/cmd/clawflow/commands/worker.go
+++ b/cmd/clawflow/commands/worker.go
@@ -1,0 +1,227 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+func NewWorkerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "worker",
+		Short: "Manage ClawFlow SaaS worker",
+	}
+	cmd.AddCommand(newWorkerStartCmd())
+	return cmd
+}
+
+func newWorkerStartCmd() *cobra.Command {
+	var pollInterval int
+
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start polling the SaaS task queue and executing pipelines locally",
+		Long: `Polls {saas-url}/api/v1/worker/tasks, claims pending tasks, runs the local
+ClawFlow pipeline via 'claude -p "ClawFlow run"', then reports success or failure.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			wc, err := config.LoadWorkerConfig()
+			if err != nil {
+				return fmt.Errorf("load worker config: %w", err)
+			}
+			if wc.SaasURL == "" || wc.WorkerToken == "" {
+				return fmt.Errorf("worker not configured — run: clawflow login --saas-url <url>\n  or: clawflow config set --saas-url <url> --token <cfw_xxx>")
+			}
+			return runWorker(wc, pollInterval)
+		},
+	}
+
+	cmd.Flags().IntVar(&pollInterval, "poll-interval", 30, "Seconds between task polls")
+	return cmd
+}
+
+// workerTask is the shape returned by GET /api/v1/worker/tasks.
+type workerTask struct {
+	ID      string          `json:"id"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+func runWorker(wc *config.WorkerConfig, pollSecs int) error {
+	fmt.Printf("Worker started — polling %s every %ds\n", wc.SaasURL, pollSecs)
+	fmt.Println("Press Ctrl+C to stop.")
+
+	for {
+		tasks, err := fetchTasks(wc)
+		if err != nil {
+			fmt.Printf("[warn] fetch tasks: %v\n", err)
+		} else {
+			for _, t := range tasks {
+				if err := processTask(wc, t); err != nil {
+					fmt.Printf("[error] task %s: %v\n", t.ID, err)
+				}
+			}
+		}
+		time.Sleep(time.Duration(pollSecs) * time.Second)
+	}
+}
+
+func fetchTasks(wc *config.WorkerConfig) ([]workerTask, error) {
+	req, err := http.NewRequest("GET", wc.SaasURL+"/api/v1/worker/tasks", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+wc.WorkerToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, b)
+	}
+
+	var tasks []workerTask
+	if err := json.NewDecoder(resp.Body).Decode(&tasks); err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+func claimTask(wc *config.WorkerConfig, taskID string) error {
+	req, err := http.NewRequest("POST", wc.SaasURL+"/api/v1/worker/tasks/"+taskID+"/claim", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+wc.WorkerToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("claim status %d: %s", resp.StatusCode, b)
+	}
+	return nil
+}
+
+func reportComplete(wc *config.WorkerConfig, taskID, prURL string) error {
+	body, _ := json.Marshal(map[string]string{"pr_url": prURL})
+	req, err := http.NewRequest("POST", wc.SaasURL+"/api/v1/worker/tasks/"+taskID+"/complete", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+wc.WorkerToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func reportFail(wc *config.WorkerConfig, taskID, reason string) error {
+	body, _ := json.Marshal(map[string]string{"reason": reason})
+	req, err := http.NewRequest("POST", wc.SaasURL+"/api/v1/worker/tasks/"+taskID+"/fail", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+wc.WorkerToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func processTask(wc *config.WorkerConfig, t workerTask) error {
+	fmt.Printf("[task %s] claiming...\n", t.ID)
+	if err := claimTask(wc, t.ID); err != nil {
+		return fmt.Errorf("claim: %w", err)
+	}
+
+	fmt.Printf("[task %s] running pipeline...\n", t.ID)
+	out, err := runPipeline(t.Payload)
+	if err != nil {
+		reason := err.Error()
+		if len(out) > 0 {
+			reason = string(out)
+		}
+		_ = reportFail(wc, t.ID, reason)
+		return fmt.Errorf("pipeline: %w", err)
+	}
+
+	// Extract PR URL from output if present (best-effort).
+	prURL := extractPRURL(string(out))
+	fmt.Printf("[task %s] complete, pr=%s\n", t.ID, prURL)
+	return reportComplete(wc, t.ID, prURL)
+}
+
+// runPipeline invokes `claude -p "ClawFlow run"` with the task payload as stdin.
+func runPipeline(payload json.RawMessage) ([]byte, error) {
+	cmd := exec.Command("claude", "-p", "ClawFlow run")
+	cmd.Stdin = bytes.NewReader(payload)
+	return cmd.CombinedOutput()
+}
+
+// extractPRURL does a simple scan for a GitHub/GitLab PR URL in the output.
+func extractPRURL(output string) string {
+	// Look for https://github.com/.../pull/N or https://gitlab.*/merge_requests/N
+	for _, prefix := range []string{"https://github.com/", "https://gitlab."} {
+		idx := 0
+		for {
+			i := indexOf(output[idx:], prefix)
+			if i < 0 {
+				break
+			}
+			start := idx + i
+			end := start
+			for end < len(output) && output[end] != ' ' && output[end] != '\n' && output[end] != '"' {
+				end++
+			}
+			candidate := output[start:end]
+			if containsAny(candidate, "/pull/", "/merge_requests/") {
+				return candidate
+			}
+			idx = start + 1
+		}
+	}
+	return ""
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if indexOf(s, sub) >= 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/saas.go
+++ b/internal/config/saas.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
 // SaasConfig holds the connection info written by `clawflow connect`.
@@ -37,6 +39,48 @@ func (c *SaasConfig) Save() error {
 		return err
 	}
 	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// WorkerConfig holds the SaaS worker connection info written by `clawflow login`
+// or `clawflow config set --saas-url --token`.
+type WorkerConfig struct {
+	SaasURL     string `yaml:"saas_url,omitempty"`
+	WorkerToken string `yaml:"worker_token,omitempty"`
+}
+
+// workerConfigPath returns the dedicated worker config file path.
+func workerConfigPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".clawflow", "config", "worker.yaml")
+}
+
+// LoadWorkerConfig reads ~/.clawflow/config/worker.yaml.
+func LoadWorkerConfig() (*WorkerConfig, error) {
+	data, err := os.ReadFile(workerConfigPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &WorkerConfig{}, nil
+		}
+		return nil, err
+	}
+	var c WorkerConfig
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// Save writes the WorkerConfig to ~/.clawflow/config/worker.yaml (mode 0600).
+func (c *WorkerConfig) Save() error {
+	path := workerConfigPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(c)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

实现 clawflow-saas worker 模式三个命令：login（OAuth）、config set（手动配置）、worker start（轮询执行）。

## Changes

- cmd/clawflow/commands/login.go: clawflow login --saas-url，OAuth browser flow + localhost callback
- cmd/clawflow/commands/worker.go: clawflow worker start，轮询 SaaS 任务队列并本地执行
- cmd/clawflow/commands/config.go: clawflow config set --saas-url --token
- internal/config/saas.go: WorkerConfig 字段（saas_url, worker_token）

## Test plan

- go build ./... passes
- go vet ./... passes
- Manual: clawflow config set --saas-url https://example.com --token cfw_test → writes to worker.yaml

Fixes #16

---
🤖 Created by [ClawFlow](https://github.com/zhoushoujianwork/clawflow) — automated issue → fix → PR pipeline