### PR TITLE
feat(operators): add `clawflow operators doctor` subcommand

### DIFF
--- a/cmd/clawflow/commands/operators.go
+++ b/cmd/clawflow/commands/operators.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/operator"
 )
 
 // NewOperatorsCmd wires `clawflow operators …` — registry introspection.
@@ -17,6 +18,7 @@ func NewOperatorsCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newOperatorsListCmd())
 	cmd.AddCommand(newOperatorsValidateCmd())
+	cmd.AddCommand(newOperatorsDoctorCmd())
 	return cmd
 }
 
@@ -48,6 +50,63 @@ CI to catch broken operators before they ship.`,
 			for _, op := range ops {
 				fmt.Printf("  %s  %s\n", op.Name, op.Source)
 			}
+			return nil
+		},
+	}
+}
+
+func newOperatorsDoctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Validate operators and detect cross-operator conflicts",
+		Long: `Loads every operator (built-in + ~/.clawflow/skills/), validates
+frontmatter, and checks for cross-operator conflicts: overlapping triggers
+(same target + labels_required), empty descriptions, and missing outcome
+declarations. Exits non-zero if any ERROR-level diagnostic is found.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reg, err := loadRegistry()
+			if err != nil {
+				return fmt.Errorf("operator load failed: %w", err)
+			}
+			ops := reg.All()
+			if len(ops) == 0 {
+				return fmt.Errorf("no operators registered (embed.FS empty?)")
+			}
+
+			home, _ := os.UserHomeDir()
+			w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(w, "NAME\tSOURCE\tSTATUS")
+			for _, op := range ops {
+				src := op.Source
+				if home != "" && strings.HasPrefix(src, home) {
+					src = "~" + strings.TrimPrefix(src, home)
+				}
+				fmt.Fprintf(w, "%s\t%s\tok\n", op.Name, src)
+			}
+			_ = w.Flush()
+
+			diags := reg.Diagnose()
+			if len(diags) == 0 {
+				fmt.Printf("\n✓ %d operator(s), no issues found\n", len(ops))
+				return nil
+			}
+
+			fmt.Println()
+			dw := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+			fmt.Fprintln(dw, "SEVERITY\tOPERATOR\tMESSAGE")
+			hasError := false
+			for _, d := range diags {
+				fmt.Fprintf(dw, "%s\t%s\t%s\n", d.Severity, d.Operator, d.Message)
+				if d.Severity == operator.SeverityError {
+					hasError = true
+				}
+			}
+			_ = dw.Flush()
+
+			if hasError {
+				return fmt.Errorf("%d operator(s) loaded, but conflicts detected", len(ops))
+			}
+			fmt.Printf("\n✓ %d operator(s), %d warning(s)\n", len(ops), len(diags))
 			return nil
 		},
 	}

--- a/internal/operator/registry.go
+++ b/internal/operator/registry.go
@@ -92,3 +92,71 @@ func (r *Registry) Get(name string) (*Operator, bool) {
 	op, ok := r.ops[name]
 	return op, ok
 }
+
+// Severity classifies a diagnostic finding.
+type Severity int
+
+const (
+	SeverityError   Severity = iota
+	SeverityWarning
+)
+
+func (s Severity) String() string {
+	if s == SeverityError {
+		return "ERROR"
+	}
+	return "WARN"
+}
+
+// Diagnostic is a single finding from Diagnose().
+type Diagnostic struct {
+	Operator string
+	Severity Severity
+	Message  string
+}
+
+// Diagnose runs cross-operator validation and returns all findings.
+func (r *Registry) Diagnose() []Diagnostic {
+	var diags []Diagnostic
+	ops := r.All()
+
+	for _, op := range ops {
+		if op.Description == "" {
+			diags = append(diags, Diagnostic{
+				Operator: op.Name,
+				Severity: SeverityWarning,
+				Message:  "empty description",
+			})
+		}
+		if len(op.Outcomes) == 0 {
+			diags = append(diags, Diagnostic{
+				Operator: op.Name,
+				Severity: SeverityWarning,
+				Message:  "no outcomes declared (any label accepted)",
+			})
+		}
+	}
+
+	type triggerKey struct {
+		target string
+		labels string
+	}
+	seen := make(map[triggerKey]string)
+	for _, op := range ops {
+		sorted := make([]string, len(op.Trigger.LabelsRequired))
+		copy(sorted, op.Trigger.LabelsRequired)
+		sort.Strings(sorted)
+		k := triggerKey{target: op.Trigger.Target, labels: strings.Join(sorted, ",")}
+		if first, ok := seen[k]; ok {
+			diags = append(diags, Diagnostic{
+				Operator: op.Name,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("overlapping trigger with %q (target=%s, labels_required=[%s])", first, k.target, k.labels),
+			})
+		} else {
+			seen[k] = op.Name
+		}
+	}
+
+	return diags
+}

--- a/internal/operator/registry_test.go
+++ b/internal/operator/registry_test.go
@@ -135,3 +135,122 @@ func TestRegistry_Get(t *testing.T) {
 		t.Error("Get on empty registry should return ok=false")
 	}
 }
+
+func makeSkillFull(name, desc, target, lock string, required, excluded, outcomes []string) string {
+	var b strings.Builder
+	b.WriteString("---\nname: ")
+	b.WriteString(name)
+	if desc != "" {
+		b.WriteString("\ndescription: ")
+		b.WriteString(desc)
+	}
+	b.WriteString("\noperator:\n  trigger:\n    target: ")
+	b.WriteString(target)
+	b.WriteString("\n    labels_required: [")
+	b.WriteString(strings.Join(required, ","))
+	b.WriteString("]\n    labels_excluded: [")
+	b.WriteString(strings.Join(excluded, ","))
+	b.WriteString("]\n  lock_label: ")
+	b.WriteString(lock)
+	if len(outcomes) > 0 {
+		b.WriteString("\n  outcomes: [")
+		b.WriteString(strings.Join(outcomes, ","))
+		b.WriteString("]")
+	}
+	b.WriteString("\n---\n\nprompt for ")
+	b.WriteString(name)
+	return b.String()
+}
+
+func TestDiagnose_Clean(t *testing.T) {
+	sys := fstest.MapFS{
+		"skills/a/SKILL.md": {Data: []byte(makeSkillFull("a", "does A", "issue", "lock-a", []string{"bug"}, nil, []string{"done"}))},
+		"skills/b/SKILL.md": {Data: []byte(makeSkillFull("b", "does B", "pr", "lock-b", []string{"review"}, nil, []string{"reviewed"}))},
+	}
+	reg := NewRegistry()
+	if err := reg.LoadEmbedded(sys, "skills"); err != nil {
+		t.Fatal(err)
+	}
+	diags := reg.Diagnose()
+	if len(diags) != 0 {
+		t.Errorf("expected 0 diagnostics, got %d: %+v", len(diags), diags)
+	}
+}
+
+func TestDiagnose_EmptyDescription(t *testing.T) {
+	sys := fstest.MapFS{
+		"skills/a/SKILL.md": {Data: []byte(makeSkillFull("a", "", "issue", "lock", []string{"bug"}, nil, []string{"done"}))},
+	}
+	reg := NewRegistry()
+	if err := reg.LoadEmbedded(sys, "skills"); err != nil {
+		t.Fatal(err)
+	}
+	diags := reg.Diagnose()
+	found := false
+	for _, d := range diags {
+		if d.Operator == "a" && d.Severity == SeverityWarning && strings.Contains(d.Message, "empty description") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about empty description; got %+v", diags)
+	}
+}
+
+func TestDiagnose_NoOutcomes(t *testing.T) {
+	sys := fstest.MapFS{
+		"skills/a/SKILL.md": {Data: []byte(makeSkillFull("a", "desc", "issue", "lock", []string{"bug"}, nil, nil))},
+	}
+	reg := NewRegistry()
+	if err := reg.LoadEmbedded(sys, "skills"); err != nil {
+		t.Fatal(err)
+	}
+	diags := reg.Diagnose()
+	found := false
+	for _, d := range diags {
+		if d.Operator == "a" && strings.Contains(d.Message, "no outcomes") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about no outcomes; got %+v", diags)
+	}
+}
+
+func TestDiagnose_OverlappingTriggers(t *testing.T) {
+	sys := fstest.MapFS{
+		"skills/a/SKILL.md": {Data: []byte(makeSkillFull("a", "desc", "issue", "lock-a", []string{"bug", "urgent"}, nil, []string{"done"}))},
+		"skills/b/SKILL.md": {Data: []byte(makeSkillFull("b", "desc", "issue", "lock-b", []string{"urgent", "bug"}, nil, []string{"done"}))},
+	}
+	reg := NewRegistry()
+	if err := reg.LoadEmbedded(sys, "skills"); err != nil {
+		t.Fatal(err)
+	}
+	diags := reg.Diagnose()
+	found := false
+	for _, d := range diags {
+		if d.Severity == SeverityError && strings.Contains(d.Message, "overlapping trigger") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about overlapping triggers; got %+v", diags)
+	}
+}
+
+func TestDiagnose_DifferentTargetNoOverlap(t *testing.T) {
+	sys := fstest.MapFS{
+		"skills/a/SKILL.md": {Data: []byte(makeSkillFull("a", "desc", "issue", "lock-a", []string{"bug"}, nil, []string{"done"}))},
+		"skills/b/SKILL.md": {Data: []byte(makeSkillFull("b", "desc", "pr", "lock-b", []string{"bug"}, nil, []string{"done"}))},
+	}
+	reg := NewRegistry()
+	if err := reg.LoadEmbedded(sys, "skills"); err != nil {
+		t.Fatal(err)
+	}
+	diags := reg.Diagnose()
+	for _, d := range diags {
+		if d.Severity == SeverityError {
+			t.Errorf("same labels on different targets should not conflict; got %+v", d)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #38

Adds `clawflow operators doctor` — a pre-flight check for operator authors. It loads every operator (built-in + `~/.clawflow/skills/`), validates frontmatter, and detects cross-operator conflicts:

- **Overlapping triggers**: two operators with the same `(target, labels_required)` pair (ERROR)
- **Empty description**: operator missing a description (WARN)
- **No outcomes declared**: operator accepts any label (WARN)

Output is a status table (name, source, ok) followed by a diagnostics table if issues are found. Exits non-zero on any ERROR-level finding.

### Files changed
- `internal/operator/registry.go` — `Diagnostic` type + `Diagnose()` method
- `internal/operator/registry_test.go` — 5 new tests for `Diagnose()`
- `cmd/clawflow/commands/operators.go` — `newOperatorsDoctorCmd()` wired into `operators` group