### PR TITLE
fix: remove trigger labels after operator completes with outcome

### DIFF
--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -142,6 +142,16 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 			return body, fmt.Errorf("add outcome label %q: %w", outcome, err)
 		} else {
 			fmt.Fprintf(os.Stderr, "  ✓ outcome label %q added\n", outcome)
+			// Remove trigger labels now that the operator has completed with an outcome.
+			// This prevents trigger labels like "ready-for-agent" from lingering after
+			// the operator finishes.
+			if len(op.Trigger.LabelsRequired) > 0 {
+				if err := v.RemoveLabel(opts.Repo, sub.Number, op.Trigger.LabelsRequired...); err != nil {
+					fmt.Fprintf(os.Stderr, "  ⚠ trigger label cleanup failed: %v\n", err)
+				} else {
+					fmt.Fprintf(os.Stderr, "  ✓ trigger labels removed: %v\n", op.Trigger.LabelsRequired)
+				}
+			}
 		}
 	}
 

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -399,6 +399,45 @@ func TestRun_OutcomeMarker_None_BackCompat(t *testing.T) {
 	}
 }
 
+func TestRun_OutcomeMarker_RemovesTriggerLabels(t *testing.T) {
+	op := &Operator{
+		Name:      "implement",
+		LockLabel: "agent-running",
+		Trigger: Trigger{
+			LabelsRequired: []string{"ready-for-agent"},
+		},
+		Outcomes: []string{"agent-implemented", "agent-failed", "agent-skipped"},
+	}
+	sub := &Subject{Number: 10, Labels: []string{"ready-for-agent"}}
+	v := newFakeVCS()
+
+	body := "## ✅ ClawFlow fix complete\n\nPR opened\n\n<!-- clawflow:outcome=agent-implemented -->\n"
+	_, err := Run(context.Background(), op, sub, v, RunOptions{
+		Repo: "r",
+		RunFunc: func(context.Context, string, string, time.Duration, io.Writer, string) (string, error) {
+			return body, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	// Outcome label should be added
+	if !slices.Contains(v.labels[10], "agent-implemented") {
+		t.Errorf("agent-implemented should be added; labels = %v", v.labels[10])
+	}
+
+	// Trigger label should be removed
+	if slices.Contains(v.labels[10], "ready-for-agent") {
+		t.Errorf("ready-for-agent trigger label should be removed; labels = %v", v.labels[10])
+	}
+
+	// Should have called RemoveLabel twice: once for lock, once for trigger labels
+	if v.removeLabelCals != 2 {
+		t.Errorf("RemoveLabel called %d times, want 2 (lock + trigger)", v.removeLabelCals)
+	}
+}
+
 func TestParseOutcome_Direct(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Fixes #40

This PR fixes the bug where trigger labels like `ready-for-agent` weren't being cleaned up after the implement operator completed.

## Changes
- Modified `internal/operator/runner.go` to remove trigger labels (from `op.Trigger.LabelsRequired`) after successfully adding an outcome label
- Added test `TestRun_OutcomeMarker_RemovesTriggerLabels` to verify the cleanup behavior

## Behavior
After an operator completes with an outcome:
1. Outcome label is added (e.g., `agent-implemented`)
2. Trigger labels are removed (e.g., `ready-for-agent`)
3. Lock label is removed (existing behavior)

This ensures issues don't accumulate stale trigger labels after operators finish their work.