### PR TITLE
feat: project dimension — multi-repo grouping with auto-injected context

### DIFF
--- a/cmd/clawflow/commands/chat.go
+++ b/cmd/clawflow/commands/chat.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/zhoushoujianwork/clawflow/internal/chat"
 	"github.com/zhoushoujianwork/clawflow/internal/claude"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 )
 
@@ -131,6 +133,16 @@ func runChat(_ context.Context, repo string, issueNum int, model string) error {
 	}
 	if err != nil {
 		return fmt.Errorf("build context: %w", err)
+	}
+
+	// Auto-inject project context: if this repo belongs to a project,
+	// prepend the project's context.md so the AI has cross-repo awareness.
+	if proj, err := project.FindProjectByRepo(repo); err == nil && proj != nil {
+		if projCtx, err := project.ReadContext(proj.Name); err == nil && projCtx != "" {
+			projectHeader := fmt.Sprintf("# Project Context: %s\n\nThis repo is part of the %q project (members: %s).\n\n%s\n\n---\n\n",
+				proj.Name, proj.Name, strings.Join(proj.Repos, ", "), projCtx)
+			systemCtx = projectHeader + systemCtx
+		}
 	}
 	tmpFile, err := os.CreateTemp("", "clawflow-chat-ctx-*.md")
 	if err != nil {

--- a/cmd/clawflow/commands/project.go
+++ b/cmd/clawflow/commands/project.go
@@ -1,0 +1,444 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/claude"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
+)
+
+// NewProjectCmd returns the `clawflow project` parent command with all
+// subcommands for managing multi-repo project groupings.
+func NewProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Manage multi-repo project groupings",
+		Long: `Projects group multiple repos under a single name and carry a shared
+context.md that is auto-injected into every 'clawflow chat' session
+for any member repo. This gives the AI cross-repo awareness without
+manual intervention.
+
+Storage: ~/.clawflow/projects/<name>/project.yaml + context.md`,
+	}
+	cmd.AddCommand(newProjectCreateCmd())
+	cmd.AddCommand(newProjectListCmd())
+	cmd.AddCommand(newProjectShowCmd())
+	cmd.AddCommand(newProjectAddRepoCmd())
+	cmd.AddCommand(newProjectRemoveRepoCmd())
+	cmd.AddCommand(newProjectGenerateCmd())
+	cmd.AddCommand(newProjectChatCmd())
+	cmd.AddCommand(newProjectDeleteCmd())
+	return cmd
+}
+
+func newProjectCreateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := project.Create(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("project %q created\n", p.Name)
+			fmt.Printf("  dir: %s\n", project.ContextPath(p.Name))
+			fmt.Println("  next: clawflow project add-repo", p.Name, "<owner/repo>")
+			return nil
+		},
+	}
+}
+
+func newProjectListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List all projects",
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projects, err := project.List()
+			if err != nil {
+				return err
+			}
+			if len(projects) == 0 {
+				fmt.Println("No projects configured.")
+				fmt.Println("Create one with: clawflow project create <name>")
+				return nil
+			}
+			fmt.Printf("%-25s %-6s %s\n", "PROJECT", "REPOS", "MEMBERS")
+			fmt.Println(strings.Repeat("─", 70))
+			for _, p := range projects {
+				members := "(none)"
+				if len(p.Repos) > 0 {
+					members = strings.Join(p.Repos, ", ")
+				}
+				fmt.Printf("%-25s %-6d %s\n", p.Name, len(p.Repos), members)
+			}
+			return nil
+		},
+	}
+}
+
+func newProjectShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <name>",
+		Short: "Show project details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := project.Get(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Project: %s\n", p.Name)
+			fmt.Printf("Created: %s\n", p.CreatedAt)
+			fmt.Printf("Updated: %s\n", p.UpdatedAt)
+			fmt.Printf("Repos (%d):\n", len(p.Repos))
+			if len(p.Repos) == 0 {
+				fmt.Println("  (none)")
+			}
+			for _, r := range p.Repos {
+				fmt.Printf("  - %s\n", r)
+			}
+			ctx, err := project.ReadContext(p.Name)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(ctx) != "" {
+				fmt.Println()
+				fmt.Println("--- context.md ---")
+				fmt.Println(ctx)
+			} else {
+				fmt.Println()
+				fmt.Println("context.md: (empty)")
+				fmt.Println("  generate with: clawflow project generate", p.Name)
+			}
+			return nil
+		},
+	}
+}
+
+func newProjectAddRepoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add-repo <project> <owner/repo>",
+		Short: "Associate a repo with a project",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := project.AddRepo(args[0], args[1]); err != nil {
+				return err
+			}
+			fmt.Printf("repo %q added to project %q\n", args[1], args[0])
+			return nil
+		},
+	}
+}
+
+func newProjectRemoveRepoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove-repo <project> <owner/repo>",
+		Short: "Disassociate a repo from a project",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := project.RemoveRepo(args[0], args[1]); err != nil {
+				return err
+			}
+			fmt.Printf("repo %q removed from project %q\n", args[1], args[0])
+			return nil
+		},
+	}
+}
+
+func newProjectGenerateCmd() *cobra.Command {
+	var model string
+	cmd := &cobra.Command{
+		Use:   "generate <name>",
+		Short: "AI-generate context.md by scanning member repos",
+		Long: `For each repo in the project that has local_path configured in
+clawflow's config, collects README, main config files (go.mod,
+package.json, Cargo.toml, etc.), and top-level directory structure.
+Builds a prompt asking Claude to produce an architecture overview,
+then writes the result to context.md.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjectGenerate(args[0], model)
+		},
+	}
+	cmd.Flags().StringVar(&model, "model", "", "claude model (default: settings chat model)")
+	return cmd
+}
+
+func newProjectChatCmd() *cobra.Command {
+	var model string
+	cmd := &cobra.Command{
+		Use:   "chat <name>",
+		Short: "Interactive chat to review/modify context.md",
+		Long: `Loads the current context.md as system context and launches an
+interactive Claude session. After the session ends, the user can
+confirm whether to update context.md with the revised version.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjectChat(args[0], model)
+		},
+	}
+	cmd.Flags().StringVar(&model, "model", "", "claude model (default: settings chat model)")
+	return cmd
+}
+
+func newProjectDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := project.Delete(args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("project %q deleted\n", args[0])
+			return nil
+		},
+	}
+}
+
+// runProjectGenerate collects repo metadata and asks Claude to produce
+// a project overview, writing the result to context.md.
+func runProjectGenerate(name, model string) error {
+	p, err := project.Get(name)
+	if err != nil {
+		return err
+	}
+	if len(p.Repos) == 0 {
+		return fmt.Errorf("project %q has no repos — add some first with: clawflow project add-repo %s <owner/repo>", name, name)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	// Collect repo info for the prompt
+	var promptParts []string
+	promptParts = append(promptParts, fmt.Sprintf("# Project: %s\n", name))
+	promptParts = append(promptParts, fmt.Sprintf("This project contains %d repositories:\n", len(p.Repos)))
+
+	scanned := 0
+	for _, repoName := range p.Repos {
+		repoCfg, ok := cfg.Repos[repoName]
+		localPath := ""
+		if ok {
+			localPath = repoCfg.LocalPath
+		}
+		if localPath == "" {
+			promptParts = append(promptParts, fmt.Sprintf("\n## %s\n(no local_path configured — skipped)\n", repoName))
+			continue
+		}
+
+		promptParts = append(promptParts, fmt.Sprintf("\n## %s\nLocal path: %s\n", repoName, localPath))
+
+		// Collect README
+		for _, readme := range []string{"README.md", "readme.md", "README"} {
+			data, err := os.ReadFile(fmt.Sprintf("%s/%s", localPath, readme))
+			if err == nil {
+				content := string(data)
+				if len(content) > 3000 {
+					content = content[:3000] + "\n... (truncated)"
+				}
+				promptParts = append(promptParts, fmt.Sprintf("\n### README\n```\n%s\n```\n", content))
+				break
+			}
+		}
+
+		// Collect config files
+		configFiles := []string{"go.mod", "package.json", "Cargo.toml", "pyproject.toml", "pom.xml", "build.gradle"}
+		for _, cf := range configFiles {
+			data, err := os.ReadFile(fmt.Sprintf("%s/%s", localPath, cf))
+			if err == nil {
+				content := string(data)
+				if len(content) > 1500 {
+					content = content[:1500] + "\n... (truncated)"
+				}
+				promptParts = append(promptParts, fmt.Sprintf("\n### %s\n```\n%s\n```\n", cf, content))
+			}
+		}
+
+		// Top-level directory listing
+		entries, err := os.ReadDir(localPath)
+		if err == nil {
+			var dirs, files []string
+			for _, e := range entries {
+				if strings.HasPrefix(e.Name(), ".") {
+					continue
+				}
+				if e.IsDir() {
+					dirs = append(dirs, e.Name()+"/")
+				} else {
+					files = append(files, e.Name())
+				}
+			}
+			promptParts = append(promptParts, "\n### Directory structure\n```\n")
+			for _, d := range dirs {
+				promptParts = append(promptParts, d+"\n")
+			}
+			for _, f := range files {
+				promptParts = append(promptParts, f+"\n")
+			}
+			promptParts = append(promptParts, "```\n")
+		}
+		scanned++
+	}
+
+	if scanned == 0 {
+		return fmt.Errorf("no repos with local_path configured — set local_path in config for at least one member repo")
+	}
+
+	promptParts = append(promptParts, `
+---
+
+Based on the repository information above, produce a project overview document in Markdown. Include:
+
+1. **Project Overview** — one paragraph describing what this project does
+2. **Repository Roles** — for each repo, its role and responsibility (2-3 sentences)
+3. **Inter-repo Dependencies** — how the repos depend on and collaborate with each other
+4. **Architecture Overview** — high-level architecture description
+
+Write the output as a standalone Markdown document suitable for context.md.
+Output ONLY the Markdown document, no preamble or explanation.`)
+
+	prompt := strings.Join(promptParts, "")
+
+	if model == "" {
+		creds, _ := config.LoadCredentials()
+		model = creds.EffectiveChatModel()
+	}
+
+	fmt.Fprintf(os.Stderr, "[clawflow] generating context.md for project %q (model=%s, %d repos scanned)...\n", name, model, scanned)
+
+	bin := claude.Resolve()
+	args := []string{
+		"--model", model,
+		"--print",
+		"-p", prompt,
+	}
+
+	cmd := exec.Command(bin, args...)
+	creds, _ := config.LoadCredentials()
+	apiKey, baseURL := "", ""
+	if creds != nil {
+		apiKey, baseURL = creds.ClaudeAPIKey, creds.ClaudeBaseURL
+	}
+	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
+	cmd.Stderr = os.Stderr
+
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("claude generate failed: %w", err)
+	}
+
+	content := strings.TrimSpace(string(output))
+	if content == "" {
+		return fmt.Errorf("claude returned empty output")
+	}
+
+	if err := project.WriteContext(name, content); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "✓ context.md written (%d bytes)\n", len(content))
+	fmt.Println(content)
+	return nil
+}
+
+// runProjectChat launches an interactive Claude session with the current
+// context.md loaded as system context, allowing the user to review and
+// modify the project overview.
+func runProjectChat(name, model string) error {
+	p, err := project.Get(name)
+	if err != nil {
+		return err
+	}
+
+	ctx, err := project.ReadContext(name)
+	if err != nil {
+		return err
+	}
+
+	if model == "" {
+		creds, _ := config.LoadCredentials()
+		model = creds.EffectiveChatModel()
+	}
+
+	// Build system context
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# Project: %s\n\n", p.Name)
+	fmt.Fprintf(&sb, "Member repos: %s\n\n", strings.Join(p.Repos, ", "))
+	if strings.TrimSpace(ctx) != "" {
+		fmt.Fprintf(&sb, "## Current context.md\n\n%s\n\n", ctx)
+	} else {
+		fmt.Fprint(&sb, "## Current context.md\n\n(empty — no overview generated yet)\n\n")
+	}
+	fmt.Fprintf(&sb, `---
+
+## Your role
+
+You are helping the user review and modify the project overview (context.md)
+for the %q project. The current content is shown above.
+
+The user may ask you to:
+- Refine or restructure the overview
+- Add details about specific repos or their relationships
+- Rewrite sections for clarity
+- Generate a new overview from scratch
+
+When the user is satisfied with changes, output the final version of context.md
+as a complete Markdown document. The user will then confirm whether to save it.
+
+## Hard constraints
+
+- Do NOT run git commands or modify any files.
+- Focus only on the project overview content.
+`, p.Name)
+
+	systemCtx := sb.String()
+
+	tmpFile, err := os.CreateTemp("", "clawflow-project-chat-*.md")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(systemCtx); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	tmpFile.Close()
+
+	sessionName := fmt.Sprintf("clawflow: project %s", name)
+
+	args := []string{
+		"--model", model,
+		"--name", sessionName,
+		"--append-system-prompt-file", tmpFile.Name(),
+	}
+
+	preCreds, _ := config.LoadCredentials()
+	useBare := preCreds != nil && preCreds.ClaudeAPIKey != ""
+	if useBare {
+		args = append(args, "--bare")
+	}
+
+	bin := claude.Resolve()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = os.TempDir()
+	creds, _ := config.LoadCredentials()
+	apiKey, baseURL := "", ""
+	if creds != nil {
+		apiKey, baseURL = creds.ClaudeAPIKey, creds.ClaudeBaseURL
+	}
+	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	fmt.Fprintf(os.Stderr, "[clawflow] project chat → %s (model=%s)\n", name, model)
+	return cmd.Run()
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -35,6 +35,7 @@ entirely in VCS labels and comments. Run 'clawflow run' once, or schedule it.`,
 	root.AddCommand(NewConfigCmd())
 	root.AddCommand(NewUpdateCmd())
 	root.AddCommand(NewInstallSkillCmd())
+	root.AddCommand(NewProjectCmd())
 	root.AddCommand(NewRespawnCmd())
 	// Helpers retained for operator use (invoked from SKILL.md bodies):
 	root.AddCommand(NewWorktreeCmd())

--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -57,6 +57,9 @@ here — run 'clawflow run' first if you want fresh data.`,
 			if cfg, err := config.Load(); err == nil {
 				_ = snapshot.WriteRepos(cfg)
 			}
+			// Refresh data/projects.json so the dashboard picks up any
+			// project changes made via the CLI since the last web start.
+			_ = snapshot.WriteProjects()
 
 			// Reconcile any "running" entries left over from an
 			// interrupted `clawflow run` (Ctrl-C, SIGTERM, machine

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,220 @@
+// Package project manages project definitions stored under
+// ~/.clawflow/projects/<name>/. A project groups multiple repos
+// and carries an AI-generated or user-edited context.md that gets
+// auto-injected into every `clawflow chat` session for member repos.
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Project is the in-memory representation of project.yaml.
+type Project struct {
+	Name      string   `yaml:"name"`
+	Repos     []string `yaml:"repos"`
+	CreatedAt string   `yaml:"created_at"`
+	UpdatedAt string   `yaml:"updated_at"`
+}
+
+// ProjectsRoot returns ~/.clawflow/projects.
+func ProjectsRoot() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".clawflow", "projects")
+}
+
+// projectDir returns the directory for a named project.
+func projectDir(name string) string {
+	return filepath.Join(ProjectsRoot(), name)
+}
+
+// yamlPath returns the project.yaml path for a named project.
+func yamlPath(name string) string {
+	return filepath.Join(projectDir(name), "project.yaml")
+}
+
+// ContextPath returns the context.md path for a named project.
+func ContextPath(name string) string {
+	return filepath.Join(projectDir(name), "context.md")
+}
+
+// Create creates a new project with the given name.
+func Create(name string) (*Project, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("project name cannot be empty")
+	}
+	dir := projectDir(name)
+	if _, err := os.Stat(yamlPath(name)); err == nil {
+		return nil, fmt.Errorf("project %q already exists", name)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create project dir: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	p := &Project{
+		Name:      name,
+		Repos:     []string{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := save(p); err != nil {
+		return nil, err
+	}
+	// Create an empty context.md so the file always exists.
+	if err := os.WriteFile(ContextPath(name), []byte(""), 0o644); err != nil {
+		return nil, fmt.Errorf("create context.md: %w", err)
+	}
+	return p, nil
+}
+
+// Get loads a project by name.
+func Get(name string) (*Project, error) {
+	data, err := os.ReadFile(yamlPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("project %q not found", name)
+		}
+		return nil, err
+	}
+	var p Project
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse project.yaml: %w", err)
+	}
+	return &p, nil
+}
+
+// List returns all projects sorted by name.
+func List() ([]*Project, error) {
+	root := ProjectsRoot()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var projects []*Project
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		p, err := Get(e.Name())
+		if err != nil {
+			continue // skip malformed
+		}
+		projects = append(projects, p)
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].Name < projects[j].Name
+	})
+	return projects, nil
+}
+
+// Delete removes a project and its directory.
+func Delete(name string) error {
+	dir := projectDir(name)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("project %q not found", name)
+	}
+	return os.RemoveAll(dir)
+}
+
+// AddRepo associates a repo with the project. Returns an error if the
+// repo is already a member of this project or belongs to another project.
+func AddRepo(name, repo string) error {
+	p, err := Get(name)
+	if err != nil {
+		return err
+	}
+	for _, r := range p.Repos {
+		if r == repo {
+			return fmt.Errorf("repo %q is already in project %q", repo, name)
+		}
+	}
+	// Enforce one-project constraint: scan all projects.
+	existing, err := FindProjectByRepo(repo)
+	if err == nil && existing != nil {
+		return fmt.Errorf("repo %q already belongs to project %q", repo, existing.Name)
+	}
+	p.Repos = append(p.Repos, repo)
+	sort.Strings(p.Repos)
+	p.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	return save(p)
+}
+
+// RemoveRepo disassociates a repo from the project.
+func RemoveRepo(name, repo string) error {
+	p, err := Get(name)
+	if err != nil {
+		return err
+	}
+	found := false
+	filtered := make([]string, 0, len(p.Repos))
+	for _, r := range p.Repos {
+		if r == repo {
+			found = true
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	if !found {
+		return fmt.Errorf("repo %q is not in project %q", repo, name)
+	}
+	p.Repos = filtered
+	p.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	return save(p)
+}
+
+// FindProjectByRepo scans all projects and returns the one containing
+// the given repo. Returns (nil, nil) if no project claims the repo.
+func FindProjectByRepo(repo string) (*Project, error) {
+	projects, err := List()
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range projects {
+		for _, r := range p.Repos {
+			if r == repo {
+				return p, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// ReadContext reads the project's context.md. Returns "" if the file
+// doesn't exist (not an error — the user may not have generated it yet).
+func ReadContext(name string) (string, error) {
+	data, err := os.ReadFile(ContextPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WriteContext writes content to the project's context.md.
+func WriteContext(name, content string) error {
+	dir := projectDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(ContextPath(name), []byte(content), 0o644)
+}
+
+// save persists a Project to its project.yaml.
+func save(p *Project) error {
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("marshal project: %w", err)
+	}
+	return os.WriteFile(yamlPath(p.Name), data, 0o644)
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,169 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateAndGet(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	p, err := Create("test-proj")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if p.Name != "test-proj" {
+		t.Errorf("Name = %q, want %q", p.Name, "test-proj")
+	}
+	if len(p.Repos) != 0 {
+		t.Errorf("Repos = %v, want empty", p.Repos)
+	}
+
+	// context.md should exist
+	ctxPath := ContextPath("test-proj")
+	if _, err := os.Stat(ctxPath); err != nil {
+		t.Errorf("context.md not created: %v", err)
+	}
+
+	got, err := Get("test-proj")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "test-proj" {
+		t.Errorf("Get Name = %q, want %q", got.Name, "test-proj")
+	}
+}
+
+func TestCreateDuplicate(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	if _, err := Create("dup"); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	if _, err := Create("dup"); err == nil {
+		t.Fatal("second Create should fail")
+	}
+}
+
+func TestAddRemoveRepo(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	if _, err := Create("proj"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := AddRepo("proj", "owner/backend"); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if err := AddRepo("proj", "owner/frontend"); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+
+	p, _ := Get("proj")
+	if len(p.Repos) != 2 {
+		t.Fatalf("Repos len = %d, want 2", len(p.Repos))
+	}
+
+	// duplicate add should fail
+	if err := AddRepo("proj", "owner/backend"); err == nil {
+		t.Fatal("duplicate AddRepo should fail")
+	}
+
+	if err := RemoveRepo("proj", "owner/backend"); err != nil {
+		t.Fatalf("RemoveRepo: %v", err)
+	}
+	p, _ = Get("proj")
+	if len(p.Repos) != 1 {
+		t.Fatalf("Repos len = %d after remove, want 1", len(p.Repos))
+	}
+}
+
+func TestOneProjectConstraint(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("alpha")
+	Create("beta")
+	AddRepo("alpha", "owner/shared")
+
+	if err := AddRepo("beta", "owner/shared"); err == nil {
+		t.Fatal("should reject repo already in another project")
+	}
+}
+
+func TestFindProjectByRepo(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("myproj")
+	AddRepo("myproj", "owner/api")
+
+	found, err := FindProjectByRepo("owner/api")
+	if err != nil {
+		t.Fatalf("FindProjectByRepo: %v", err)
+	}
+	if found == nil || found.Name != "myproj" {
+		t.Fatalf("expected myproj, got %v", found)
+	}
+
+	found, err = FindProjectByRepo("owner/unknown")
+	if err != nil {
+		t.Fatalf("FindProjectByRepo unknown: %v", err)
+	}
+	if found != nil {
+		t.Fatalf("expected nil for unknown repo, got %v", found)
+	}
+}
+
+func TestList(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("zebra")
+	Create("alpha")
+
+	projects, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("List len = %d, want 2", len(projects))
+	}
+	if projects[0].Name != "alpha" {
+		t.Errorf("first project = %q, want alpha", projects[0].Name)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("doomed")
+	if err := Delete("doomed"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	dir := filepath.Join(ProjectsRoot(), "doomed")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("project dir should be gone, stat err = %v", err)
+	}
+}
+
+func TestReadWriteContext(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("ctx-test")
+	if err := WriteContext("ctx-test", "# My Project\nOverview here."); err != nil {
+		t.Fatalf("WriteContext: %v", err)
+	}
+	content, err := ReadContext("ctx-test")
+	if err != nil {
+		t.Fatalf("ReadContext: %v", err)
+	}
+	if content != "# My Project\nOverview here." {
+		t.Errorf("ReadContext = %q", content)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/zhoushoujianwork/clawflow/internal/config"
 	"github.com/zhoushoujianwork/clawflow/internal/operator"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
 )
 
 // DashboardRoot is ~/.clawflow/dashboard. The SPA assets live at the root;
@@ -821,6 +822,39 @@ func collectRunEntries(root string) []RunIndexEntry {
 		return nil
 	})
 	return out
+}
+
+// ProjectView is the dashboard-facing view of one project.
+type ProjectView struct {
+	Name      string   `json:"name"`
+	Repos     []string `json:"repos"`
+	Context   string   `json:"context,omitempty"`
+	CreatedAt string   `json:"created_at"`
+	UpdatedAt string   `json:"updated_at"`
+}
+
+// WriteProjects writes data/projects.json from the on-disk project store.
+func WriteProjects() error {
+	projects, err := project.List()
+	if err != nil {
+		// No projects dir yet — write empty array.
+		if os.IsNotExist(err) {
+			return writeJSON(filepath.Join(DataDir(), "projects.json"), []ProjectView{})
+		}
+		return err
+	}
+	views := make([]ProjectView, 0, len(projects))
+	for _, p := range projects {
+		ctx, _ := project.ReadContext(p.Name)
+		views = append(views, ProjectView{
+			Name:      p.Name,
+			Repos:     p.Repos,
+			Context:   ctx,
+			CreatedAt: p.CreatedAt,
+			UpdatedAt: p.UpdatedAt,
+		})
+	}
+	return writeJSON(filepath.Join(DataDir(), "projects.json"), views)
 }
 
 func writeJSON(path string, v any) error {


### PR DESCRIPTION
Fixes #42

## What changed

Introduces a **project** concept that groups multiple repos under a named entity stored in `~/.clawflow/projects/<name>/`. Each project carries a `project.yaml` manifest and a `context.md` overview that is auto-injected into every `clawflow chat` session for member repos.

### New files
- `internal/project/project.go` — CRUD package (Create, Get, List, Delete, AddRepo, RemoveRepo, FindProjectByRepo, ReadContext, WriteContext). Enforces one-project-per-repo constraint.
- `internal/project/project_test.go` — 8 tests covering all CRUD operations and constraints.
- `cmd/clawflow/commands/project.go` — CLI parent command with 8 subcommands: create, list, show, add-repo, remove-repo, generate, chat, delete.

### Modified files
- `cmd/clawflow/commands/chat.go` — After building repo/issue context, scans projects via `FindProjectByRepo` and prepends `context.md` to the system prompt.
- `cmd/clawflow/commands/root.go` — Registers `NewProjectCmd()`.
- `cmd/clawflow/commands/web.go` — Calls `snapshot.WriteProjects()` on startup.
- `internal/snapshot/snapshot.go` — Adds `ProjectView` type and `WriteProjects()` producing `data/projects.json`.

### What was tested
- All 8 unit tests in `internal/project/` pass.
- Full `go test ./...` passes with no regressions.
- `go build ./...` clean.