### PR TITLE
feat: project dimension - multi-repo grouping with auto-injected context

### DIFF
--- a/cmd/clawflow/commands/chat.go
+++ b/cmd/clawflow/commands/chat.go
@@ -10,6 +10,7 @@ import (
 	"github.com/zhoushoujianwork/clawflow/internal/chat"
 	"github.com/zhoushoujianwork/clawflow/internal/claude"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 )
 
@@ -132,6 +133,17 @@ func runChat(_ context.Context, repo string, issueNum int, model string) error {
 	if err != nil {
 		return fmt.Errorf("build context: %w", err)
 	}
+
+	// Auto-inject project context: if this repo belongs to a project,
+	// prepend the project's context.md so the AI has cross-repo awareness.
+	if proj, findErr := project.FindByRepo(repo); findErr == nil {
+		if projCtx, readErr := project.ReadContext(proj.Name); readErr == nil && projCtx != "" {
+			systemCtx = fmt.Sprintf("# Project Context: %s\n\nThis repo is part of the %q project (repos: %s).\n\n%s\n\n---\n\n%s",
+				proj.Name, proj.Name, fmt.Sprintf("%v", proj.Repos), projCtx, systemCtx)
+			fmt.Fprintf(os.Stderr, "[clawflow] injected project context from %q (%d bytes)\n", proj.Name, len(projCtx))
+		}
+	}
+
 	tmpFile, err := os.CreateTemp("", "clawflow-chat-ctx-*.md")
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)

--- a/cmd/clawflow/commands/project.go
+++ b/cmd/clawflow/commands/project.go
@@ -1,0 +1,416 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/chat"
+	"github.com/zhoushoujianwork/clawflow/internal/claude"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
+)
+
+// NewProjectCmd returns the `clawflow project` parent command with all
+// subcommands registered.
+func NewProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Manage multi-repo projects",
+		Long: `Group multiple repositories under a named project. Each project
+carries a context.md that is automatically injected into clawflow chat
+sessions for any member repo, giving the AI cross-repo awareness.`,
+	}
+	cmd.AddCommand(newProjectCreateCmd())
+	cmd.AddCommand(newProjectListCmd())
+	cmd.AddCommand(newProjectShowCmd())
+	cmd.AddCommand(newProjectAddRepoCmd())
+	cmd.AddCommand(newProjectRemoveRepoCmd())
+	cmd.AddCommand(newProjectGenerateCmd())
+	cmd.AddCommand(newProjectChatCmd())
+	cmd.AddCommand(newProjectDeleteCmd())
+	return cmd
+}
+
+func newProjectCreateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := project.Create(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("project %q created\n", p.Name)
+			fmt.Printf("  add repos with: clawflow project add-repo %s <owner/repo>\n", p.Name)
+			return nil
+		},
+	}
+}
+
+func newProjectListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List all projects",
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projects, err := project.List()
+			if err != nil {
+				return err
+			}
+			if len(projects) == 0 {
+				fmt.Println("No projects configured.")
+				fmt.Println("Create one with: clawflow project create <name>")
+				return nil
+			}
+			fmt.Printf("%-30s %-10s %s\n", "PROJECT", "REPOS", "UPDATED")
+			fmt.Println(strings.Repeat("─", 70))
+			for _, p := range projects {
+				fmt.Printf("%-30s %-10d %s\n", p.Name, len(p.Repos), p.UpdatedAt)
+			}
+			return nil
+		},
+	}
+}
+
+func newProjectShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <name>",
+		Short: "Show project details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := project.Get(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Name:       %s\n", p.Name)
+			fmt.Printf("Created:    %s\n", p.CreatedAt)
+			fmt.Printf("Updated:    %s\n", p.UpdatedAt)
+			fmt.Printf("Repos (%d):\n", len(p.Repos))
+			for _, r := range p.Repos {
+				fmt.Printf("  - %s\n", r)
+			}
+			ctx, _ := project.ReadContext(p.Name)
+			if strings.TrimSpace(ctx) != "" {
+				fmt.Println()
+				fmt.Println("--- context.md ---")
+				fmt.Println(ctx)
+			} else {
+				fmt.Println()
+				fmt.Println("context.md is empty. Generate with: clawflow project generate " + p.Name)
+			}
+			return nil
+		},
+	}
+}
+
+func newProjectAddRepoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add-repo <project> <owner/repo>",
+		Short: "Associate a repo with a project",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := project.AddRepo(args[0], args[1]); err != nil {
+				return err
+			}
+			fmt.Printf("repo %q added to project %q\n", args[1], args[0])
+			return nil
+		},
+	}
+}
+
+func newProjectRemoveRepoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove-repo <project> <owner/repo>",
+		Short: "Disassociate a repo from a project",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := project.RemoveRepo(args[0], args[1]); err != nil {
+				return err
+			}
+			fmt.Printf("repo %q removed from project %q\n", args[1], args[0])
+			return nil
+		},
+	}
+}
+
+func newProjectDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete a project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := project.Delete(args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("project %q deleted\n", args[0])
+			return nil
+		},
+	}
+}
+
+func newProjectGenerateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "generate <name>",
+		Short: "AI-generate context.md by scanning member repos",
+		Long: `For each repo in the project that has local_path configured in
+clawflow config, collects README, main config files, and top-level
+directory structure. Sends the collected info to Claude to produce
+an architecture overview, which is written to context.md.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjectGenerate(cmd.Context(), args[0])
+		},
+	}
+}
+
+func newProjectChatCmd() *cobra.Command {
+	var model string
+	cmd := &cobra.Command{
+		Use:   "chat <name>",
+		Short: "Interactive chat to review/modify context.md",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjectChat(cmd.Context(), args[0], model)
+		},
+	}
+	cmd.Flags().StringVar(&model, "model", "", "claude model to use")
+	return cmd
+}
+
+// runProjectGenerate collects repo info and asks Claude to produce context.md.
+func runProjectGenerate(_ context.Context, name string) error {
+	p, err := project.Get(name)
+	if err != nil {
+		return err
+	}
+	if len(p.Repos) == 0 {
+		return fmt.Errorf("project %q has no repos — add some first", name)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	// Collect info from each repo that has a local_path.
+	var repoSections []string
+	var skipped []string
+	for _, repoName := range p.Repos {
+		repoCfg, ok := cfg.Repos[repoName]
+		if !ok || repoCfg.LocalPath == "" {
+			skipped = append(skipped, repoName)
+			continue
+		}
+		section := collectRepoInfo(repoName, repoCfg.LocalPath)
+		repoSections = append(repoSections, section)
+	}
+
+	if len(skipped) > 0 {
+		fmt.Fprintf(os.Stderr, "[warn] skipped repos without local_path: %s\n", strings.Join(skipped, ", "))
+	}
+	if len(repoSections) == 0 {
+		return fmt.Errorf("no repos with local_path found — configure local_path for at least one repo")
+	}
+
+	prompt := fmt.Sprintf(`You are analyzing a software project called %q that consists of multiple repositories.
+Below is information collected from each repo (README, config files, directory structure).
+
+%s
+
+Based on this information, produce a concise project overview in Markdown covering:
+1. **Project Summary** — what the overall project does
+2. **Repository Roles** — each repo's responsibility (one paragraph each)
+3. **Inter-repo Dependencies** — how repos depend on or collaborate with each other
+4. **Architecture Overview** — high-level architecture diagram description
+
+Write the output as a single Markdown document. Be factual and concise.`,
+		name, strings.Join(repoSections, "\n\n---\n\n"))
+
+	// Invoke claude in --print mode to get the output.
+	creds, _ := config.LoadCredentials()
+	model := creds.EffectiveOperatorModel()
+
+	bin := claude.Resolve()
+	args := []string{"--print", "--model", model, "-p", prompt}
+
+	cmd := exec.Command(bin, args...)
+	apiKey, baseURL := "", ""
+	if creds != nil {
+		apiKey, baseURL = creds.ClaudeAPIKey, creds.ClaudeBaseURL
+	}
+	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
+
+	fmt.Fprintf(os.Stderr, "[clawflow] generating context.md for project %q (model=%s)...\n", name, model)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("claude failed: %s", string(exitErr.Stderr))
+		}
+		return fmt.Errorf("claude failed: %w", err)
+	}
+
+	if err := project.WriteContext(name, string(out)); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "✓ context.md written (%d bytes)\n", len(out))
+	return nil
+}
+
+// collectRepoInfo gathers README, config files, and directory listing
+// from a local repo path.
+func collectRepoInfo(repoName, localPath string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Repository: %s\n\n", repoName)
+	fmt.Fprintf(&b, "Path: %s\n\n", localPath)
+
+	// README
+	for _, name := range []string{"README.md", "readme.md", "README", "README.rst"} {
+		data, err := os.ReadFile(filepath.Join(localPath, name))
+		if err == nil {
+			content := string(data)
+			// Truncate very long READMEs
+			if len(content) > 4000 {
+				content = content[:4000] + "\n\n... (truncated)"
+			}
+			fmt.Fprintf(&b, "### README\n\n```\n%s\n```\n\n", content)
+			break
+		}
+	}
+
+	// Config files
+	configFiles := []string{
+		"go.mod", "package.json", "Cargo.toml", "pyproject.toml",
+		"pom.xml", "build.gradle", "Makefile", "docker-compose.yml",
+		"Dockerfile",
+	}
+	for _, cf := range configFiles {
+		data, err := os.ReadFile(filepath.Join(localPath, cf))
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		if len(content) > 2000 {
+			content = content[:2000] + "\n... (truncated)"
+		}
+		fmt.Fprintf(&b, "### %s\n\n```\n%s\n```\n\n", cf, content)
+	}
+
+	// Top-level directory listing
+	entries, err := os.ReadDir(localPath)
+	if err == nil {
+		fmt.Fprintf(&b, "### Directory structure\n\n```\n")
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			indicator := ""
+			if e.IsDir() {
+				indicator = "/"
+			}
+			fmt.Fprintf(&b, "%s%s\n", e.Name(), indicator)
+		}
+		fmt.Fprintf(&b, "```\n")
+	}
+
+	return b.String()
+}
+
+// runProjectChat launches an interactive Claude session with the current
+// context.md loaded, allowing the user to review and modify it.
+func runProjectChat(_ context.Context, name, model string) error {
+	p, err := project.Get(name)
+	if err != nil {
+		return err
+	}
+
+	currentCtx, err := project.ReadContext(name)
+	if err != nil {
+		return err
+	}
+
+	// Build system prompt
+	var sysPrompt strings.Builder
+	fmt.Fprintf(&sysPrompt, "# Project: %s\n\n", p.Name)
+	fmt.Fprintf(&sysPrompt, "Repos: %s\n\n", strings.Join(p.Repos, ", "))
+	if strings.TrimSpace(currentCtx) != "" {
+		fmt.Fprintf(&sysPrompt, "## Current context.md\n\n%s\n\n", currentCtx)
+	} else {
+		fmt.Fprint(&sysPrompt, "## Current context.md\n\n_(empty — no overview generated yet)_\n\n")
+	}
+	fmt.Fprintln(&sysPrompt, `---
+
+## Your role
+
+You are helping the user review and edit the project overview (context.md)
+for this multi-repo project. The user may ask you to:
+- Rewrite sections
+- Add missing information
+- Restructure the document
+- Generate a fresh overview
+
+When the user is satisfied with the changes, output the final version of
+context.md wrapped in a markdown code block tagged with `+"`context.md`"+`:
+
+`+"```context.md"+`
+<full content here>
+`+"```"+`
+
+The user can then copy this into their context.md, or you can write it
+directly if they confirm.`)
+
+	// Resolve model
+	if model == "" {
+		creds, _ := config.LoadCredentials()
+		model = creds.EffectiveChatModel()
+	}
+
+	sessionID := chat.NewSessionID("project:"+name, 0)
+	sessionName := fmt.Sprintf("clawflow: project %s", name)
+
+	// Write system prompt to temp file
+	tmpFile, err := os.CreateTemp("", "clawflow-project-chat-*.md")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(sysPrompt.String()); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	tmpFile.Close()
+
+	args := []string{
+		"--model", model,
+		"--name", sessionName,
+		"--session-id", sessionID,
+		"--append-system-prompt-file", tmpFile.Name(),
+	}
+
+	creds, _ := config.LoadCredentials()
+	useBare := creds != nil && creds.ClaudeAPIKey != ""
+	if useBare {
+		workdir := os.TempDir()
+		args = append(args, "--bare", "--add-dir", workdir)
+	}
+
+	bin := claude.Resolve()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = os.TempDir()
+	apiKey, baseURL := "", ""
+	if creds != nil {
+		apiKey, baseURL = creds.ClaudeAPIKey, creds.ClaudeBaseURL
+	}
+	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	fmt.Fprintf(os.Stderr, "[clawflow] project chat → %s (model=%s)\n", name, model)
+	return cmd.Run()
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -35,6 +35,7 @@ entirely in VCS labels and comments. Run 'clawflow run' once, or schedule it.`,
 	root.AddCommand(NewConfigCmd())
 	root.AddCommand(NewUpdateCmd())
 	root.AddCommand(NewInstallSkillCmd())
+	root.AddCommand(NewProjectCmd())
 	root.AddCommand(NewRespawnCmd())
 	// Helpers retained for operator use (invoked from SKILL.md bodies):
 	root.AddCommand(NewWorktreeCmd())

--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -57,6 +57,8 @@ here — run 'clawflow run' first if you want fresh data.`,
 			if cfg, err := config.Load(); err == nil {
 				_ = snapshot.WriteRepos(cfg)
 			}
+			// Refresh data/projects.json from live project definitions.
+			_ = snapshot.WriteProjects()
 
 			// Reconcile any "running" entries left over from an
 			// interrupted `clawflow run` (Ctrl-C, SIGTERM, machine

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,220 @@
+// Package project manages project definitions stored under
+// ~/.clawflow/projects/<name>/. A project groups multiple repos
+// and carries a context.md that is auto-injected into clawflow chat
+// sessions for any member repo.
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Project is the in-memory representation of project.yaml.
+type Project struct {
+	Name      string   `yaml:"name"`
+	Repos     []string `yaml:"repos"`
+	CreatedAt string   `yaml:"created_at"`
+	UpdatedAt string   `yaml:"updated_at"`
+}
+
+// projectsRoot returns ~/.clawflow/projects.
+func projectsRoot() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".clawflow", "projects")
+}
+
+// projectDir returns the directory for a named project.
+func projectDir(name string) string {
+	return filepath.Join(projectsRoot(), name)
+}
+
+// yamlPath returns the project.yaml path for a named project.
+func yamlPath(name string) string {
+	return filepath.Join(projectDir(name), "project.yaml")
+}
+
+// ContextPath returns the context.md path for a named project.
+func ContextPath(name string) string {
+	return filepath.Join(projectDir(name), "context.md")
+}
+
+// Create creates a new project with the given name. Returns an error
+// if a project with that name already exists.
+func Create(name string) (*Project, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("project name cannot be empty")
+	}
+	dir := projectDir(name)
+	if _, err := os.Stat(yamlPath(name)); err == nil {
+		return nil, fmt.Errorf("project %q already exists", name)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create project dir: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	p := &Project{
+		Name:      name,
+		Repos:     []string{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := save(p); err != nil {
+		return nil, err
+	}
+	// Create an empty context.md so the file always exists.
+	if err := os.WriteFile(ContextPath(name), []byte(""), 0o644); err != nil {
+		return nil, fmt.Errorf("create context.md: %w", err)
+	}
+	return p, nil
+}
+
+// Get loads a project by name.
+func Get(name string) (*Project, error) {
+	data, err := os.ReadFile(yamlPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("project %q not found", name)
+		}
+		return nil, err
+	}
+	var p Project
+	if err := yaml.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse project.yaml: %w", err)
+	}
+	return &p, nil
+}
+
+// List returns all projects sorted by name.
+func List() ([]*Project, error) {
+	root := projectsRoot()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var projects []*Project
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		p, err := Get(e.Name())
+		if err != nil {
+			continue // skip malformed entries
+		}
+		projects = append(projects, p)
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].Name < projects[j].Name
+	})
+	return projects, nil
+}
+
+// Delete removes a project and its directory.
+func Delete(name string) error {
+	dir := projectDir(name)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return fmt.Errorf("project %q not found", name)
+	}
+	return os.RemoveAll(dir)
+}
+
+// AddRepo associates a repo with the project. Enforces the one-project
+// constraint: if the repo already belongs to another project, an error
+// is returned.
+func AddRepo(name, repo string) error {
+	p, err := Get(name)
+	if err != nil {
+		return err
+	}
+	// Check uniqueness across all projects.
+	owner, err := FindByRepo(repo)
+	if err == nil && owner.Name != name {
+		return fmt.Errorf("repo %q already belongs to project %q", repo, owner.Name)
+	}
+	for _, r := range p.Repos {
+		if r == repo {
+			return fmt.Errorf("repo %q is already in project %q", repo, name)
+		}
+	}
+	p.Repos = append(p.Repos, repo)
+	sort.Strings(p.Repos)
+	p.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	return save(p)
+}
+
+// RemoveRepo disassociates a repo from the project.
+func RemoveRepo(name, repo string) error {
+	p, err := Get(name)
+	if err != nil {
+		return err
+	}
+	idx := -1
+	for i, r := range p.Repos {
+		if r == repo {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("repo %q is not in project %q", repo, name)
+	}
+	p.Repos = append(p.Repos[:idx], p.Repos[idx+1:]...)
+	p.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	return save(p)
+}
+
+// FindByRepo scans all projects and returns the one containing the
+// given repo. Returns an error if no project owns the repo.
+func FindByRepo(repo string) (*Project, error) {
+	projects, err := List()
+	if err != nil {
+		return nil, err
+	}
+	for _, p := range projects {
+		for _, r := range p.Repos {
+			if r == repo {
+				return p, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no project contains repo %q", repo)
+}
+
+// ReadContext reads the project's context.md. Returns "" if the file
+// does not exist (not an error — the user may not have generated it yet).
+func ReadContext(name string) (string, error) {
+	data, err := os.ReadFile(ContextPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WriteContext overwrites the project's context.md.
+func WriteContext(name, content string) error {
+	dir := projectDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(ContextPath(name), []byte(content), 0o644)
+}
+
+// save marshals the project to its project.yaml.
+func save(p *Project) error {
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("marshal project: %w", err)
+	}
+	return os.WriteFile(yamlPath(p.Name), data, 0o644)
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,192 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// withTempHome overrides HOME so tests write to a temp dir instead of
+// the real ~/.clawflow/projects. Restores the original HOME on cleanup.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	orig := os.Getenv("HOME")
+	t.Setenv("HOME", tmp)
+	t.Cleanup(func() { os.Setenv("HOME", orig) })
+	return tmp
+}
+
+func TestCreateAndGet(t *testing.T) {
+	withTempHome(t)
+
+	p, err := Create("test-proj")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if p.Name != "test-proj" {
+		t.Errorf("Name = %q, want %q", p.Name, "test-proj")
+	}
+	if len(p.Repos) != 0 {
+		t.Errorf("Repos = %v, want empty", p.Repos)
+	}
+
+	got, err := Get("test-proj")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "test-proj" {
+		t.Errorf("Get Name = %q, want %q", got.Name, "test-proj")
+	}
+
+	// context.md should exist and be empty
+	ctx, err := ReadContext("test-proj")
+	if err != nil {
+		t.Fatalf("ReadContext: %v", err)
+	}
+	if ctx != "" {
+		t.Errorf("ReadContext = %q, want empty", ctx)
+	}
+}
+
+func TestCreateDuplicate(t *testing.T) {
+	withTempHome(t)
+
+	if _, err := Create("dup"); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	if _, err := Create("dup"); err == nil {
+		t.Fatal("second Create should fail")
+	}
+}
+
+func TestList(t *testing.T) {
+	withTempHome(t)
+
+	Create("beta")
+	Create("alpha")
+
+	projects, err := List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("List len = %d, want 2", len(projects))
+	}
+	if projects[0].Name != "alpha" || projects[1].Name != "beta" {
+		t.Errorf("List order = [%s, %s], want [alpha, beta]", projects[0].Name, projects[1].Name)
+	}
+}
+
+func TestAddRemoveRepo(t *testing.T) {
+	withTempHome(t)
+
+	Create("proj")
+
+	if err := AddRepo("proj", "owner/backend"); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if err := AddRepo("proj", "owner/frontend"); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+
+	p, _ := Get("proj")
+	if len(p.Repos) != 2 {
+		t.Fatalf("Repos len = %d, want 2", len(p.Repos))
+	}
+
+	// duplicate add should fail
+	if err := AddRepo("proj", "owner/backend"); err == nil {
+		t.Fatal("duplicate AddRepo should fail")
+	}
+
+	if err := RemoveRepo("proj", "owner/backend"); err != nil {
+		t.Fatalf("RemoveRepo: %v", err)
+	}
+	p, _ = Get("proj")
+	if len(p.Repos) != 1 || p.Repos[0] != "owner/frontend" {
+		t.Errorf("after remove: Repos = %v", p.Repos)
+	}
+
+	// remove non-existent
+	if err := RemoveRepo("proj", "owner/nope"); err == nil {
+		t.Fatal("RemoveRepo non-existent should fail")
+	}
+}
+
+func TestFindByRepo(t *testing.T) {
+	withTempHome(t)
+
+	Create("proj-a")
+	AddRepo("proj-a", "owner/backend")
+	Create("proj-b")
+	AddRepo("proj-b", "owner/frontend")
+
+	found, err := FindByRepo("owner/backend")
+	if err != nil {
+		t.Fatalf("FindByRepo: %v", err)
+	}
+	if found.Name != "proj-a" {
+		t.Errorf("FindByRepo = %q, want proj-a", found.Name)
+	}
+
+	_, err = FindByRepo("owner/nope")
+	if err == nil {
+		t.Fatal("FindByRepo should fail for unknown repo")
+	}
+}
+
+func TestOneProjectConstraint(t *testing.T) {
+	withTempHome(t)
+
+	Create("proj-a")
+	AddRepo("proj-a", "owner/shared")
+	Create("proj-b")
+
+	err := AddRepo("proj-b", "owner/shared")
+	if err == nil {
+		t.Fatal("AddRepo should fail: repo already in another project")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	withTempHome(t)
+
+	Create("doomed")
+	if err := Delete("doomed"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := Get("doomed"); err == nil {
+		t.Fatal("Get after Delete should fail")
+	}
+}
+
+func TestReadWriteContext(t *testing.T) {
+	withTempHome(t)
+
+	Create("ctx-proj")
+	content := "# My Project\n\nThis is the overview."
+	if err := WriteContext("ctx-proj", content); err != nil {
+		t.Fatalf("WriteContext: %v", err)
+	}
+	got, err := ReadContext("ctx-proj")
+	if err != nil {
+		t.Fatalf("ReadContext: %v", err)
+	}
+	if got != content {
+		t.Errorf("ReadContext = %q, want %q", got, content)
+	}
+}
+
+func TestContextPathLocation(t *testing.T) {
+	withTempHome(t)
+
+	Create("loc-proj")
+	p := ContextPath("loc-proj")
+	if !filepath.IsAbs(p) {
+		t.Errorf("ContextPath should be absolute, got %q", p)
+	}
+	if filepath.Base(p) != "context.md" {
+		t.Errorf("ContextPath base = %q, want context.md", filepath.Base(p))
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/zhoushoujianwork/clawflow/internal/config"
 	"github.com/zhoushoujianwork/clawflow/internal/operator"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
 )
 
 // DashboardRoot is ~/.clawflow/dashboard. The SPA assets live at the root;
@@ -462,6 +463,40 @@ func WriteRepos(cfg *config.Config) error {
 		})
 	}
 	return writeJSON(filepath.Join(DataDir(), "repos.json"), views)
+}
+
+// ProjectView is the dashboard-facing view of one project.
+type ProjectView struct {
+	Name      string   `json:"name"`
+	Repos     []string `json:"repos"`
+	Context   string   `json:"context"`
+	CreatedAt string   `json:"created_at"`
+	UpdatedAt string   `json:"updated_at"`
+}
+
+// WriteProjects writes data/projects.json by reading all projects from
+// ~/.clawflow/projects/.
+func WriteProjects() error {
+	projects, err := project.List()
+	if err != nil {
+		// No projects dir yet — write an empty array.
+		if projects == nil {
+			return writeJSON(filepath.Join(DataDir(), "projects.json"), []ProjectView{})
+		}
+		return err
+	}
+	views := make([]ProjectView, 0, len(projects))
+	for _, p := range projects {
+		ctx, _ := project.ReadContext(p.Name)
+		views = append(views, ProjectView{
+			Name:      p.Name,
+			Repos:     p.Repos,
+			Context:   ctx,
+			CreatedAt: p.CreatedAt,
+			UpdatedAt: p.UpdatedAt,
+		})
+	}
+	return writeJSON(filepath.Join(DataDir(), "projects.json"), views)
 }
 
 // WriteOperators writes data/operators.json.


### PR DESCRIPTION
Fixes #42

## What changed

Introduces a **project** dimension that groups multiple repos under a named entity stored in `~/.clawflow/projects/<name>/`. Each project carries a `project.yaml` manifest and a `context.md` overview that is automatically injected into `clawflow chat` sessions for any member repo.

### New package: `internal/project/`
- Full CRUD: `Create`, `Get`, `List`, `Delete`, `AddRepo`, `RemoveRepo`, `FindByRepo`
- `ReadContext` / `WriteContext` for managing `context.md`
- Enforces one-project-per-repo constraint at `add-repo` time

### CLI commands (`clawflow project`)
- `create <name>` — create a project
- `list` — list all projects
- `show <name>` — show project details + context.md
- `add-repo <project> <repo>` — associate a repo (with cross-project uniqueness check)
- `remove-repo <project> <repo>` — disassociate a repo
- `generate <name>` — AI-generate context.md by scanning member repos (README, config files, dir structure)
- `chat <name>` — interactive Claude session to review/modify context.md
- `delete <name>` — delete a project

### Auto-injection into `clawflow chat`
When `clawflow chat --repo owner/backend` is invoked, `FindByRepo` locates the parent project, reads `context.md`, and prepends it to the system prompt — giving the AI cross-repo awareness without manual intervention.

### Snapshot layer
- `WriteProjects()` produces `data/projects.json` for the dashboard
- Called on `clawflow web` startup alongside `WriteRepos()`

### Tests
9 unit tests covering CRUD, uniqueness constraint, context read/write, and FindByRepo.

### Files changed (7)
- `internal/project/project.go` — new CRUD package
- `internal/project/project_test.go` — unit tests
- `cmd/clawflow/commands/project.go` — CLI subcommands + generate/chat flows
- `cmd/clawflow/commands/root.go` — register project command
- `cmd/clawflow/commands/chat.go` — auto-inject project context
- `cmd/clawflow/commands/web.go` — call WriteProjects on startup
- `internal/snapshot/snapshot.go` — WriteProjects + ProjectView type

### Not in this PR (future phases)
- Dashboard frontend routes (`/_app/projects`, `/_app/projects/$name`)
- API endpoints for project CRUD from the dashboard