### PR TITLE
feat: dashboard projects page - frontend UI for project management

### DIFF
--- a/internal/api/chat_spawn.go
+++ b/internal/api/chat_spawn.go
@@ -20,10 +20,16 @@ import (
 // chatSpawnRequest names the issue (or whole repo) the user wants
 // to chat about. Issue=0 means "chat at repo level"; the CLI handles
 // both shapes via clawflow chat --repo <r> [--issue <n>].
+//
+// Project-scoped spawns use the Project + Action fields instead of
+// Repo/Issue. Action is "chat" or "generate"; the spawned command is
+// `clawflow project <action> <name>`.
 type chatSpawnRequest struct {
-	Repo  string `json:"repo"`
-	Issue int    `json:"issue,omitempty"`
-	Model string `json:"model,omitempty"`
+	Repo    string `json:"repo,omitempty"`
+	Issue   int    `json:"issue,omitempty"`
+	Model   string `json:"model,omitempty"`
+	Project string `json:"project,omitempty"`
+	Action  string `json:"action,omitempty"` // "generate" or "chat" (project-scoped)
 }
 
 // HandleChatSpawn POSTs spawn a clawflow-chat session in the user's
@@ -46,8 +52,12 @@ func HandleChatSpawn(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, 400, map[string]string{"error": "invalid JSON"})
 		return
 	}
-	if strings.TrimSpace(req.Repo) == "" {
-		writeJSON(w, 400, map[string]string{"error": "repo is required"})
+
+	// Require either a repo or a project target.
+	hasRepo := strings.TrimSpace(req.Repo) != ""
+	hasProject := strings.TrimSpace(req.Project) != ""
+	if !hasRepo && !hasProject {
+		writeJSON(w, 400, map[string]string{"error": "repo or project is required"})
 		return
 	}
 
@@ -60,12 +70,20 @@ func HandleChatSpawn(w http.ResponseWriter, r *http.Request) {
 		self = "clawflow"
 	}
 
-	// Build the shell command the terminal will run. Quoted via
-	// shell-escape so a repo name containing odd chars (it shouldn't,
-	// but defense in depth) doesn't break the script.
-	parts := []string{shellEscape(self), "chat", "--repo", shellEscape(req.Repo)}
-	if req.Issue > 0 {
-		parts = append(parts, "--issue", strconv.Itoa(req.Issue))
+	var parts []string
+	if hasProject {
+		// Project-scoped spawn: `clawflow project <action> <name>`
+		action := req.Action
+		if action != "generate" {
+			action = "chat" // default to chat
+		}
+		parts = []string{shellEscape(self), "project", action, shellEscape(req.Project)}
+	} else {
+		// Repo-scoped spawn: `clawflow chat --repo <r> [--issue <n>]`
+		parts = []string{shellEscape(self), "chat", "--repo", shellEscape(req.Repo)}
+		if req.Issue > 0 {
+			parts = append(parts, "--issue", strconv.Itoa(req.Issue))
+		}
 	}
 	if req.Model != "" {
 		parts = append(parts, "--model", shellEscape(req.Model))

--- a/web/src/lib/chatContext.tsx
+++ b/web/src/lib/chatContext.tsx
@@ -1,9 +1,11 @@
 import { createContext, useCallback, useContext, useState, type ReactNode } from 'react'
 
 interface ChatTarget {
-  repo: string
+  repo?: string
   issue?: number
   model?: string
+  project?: string
+  action?: 'generate' | 'chat'
 }
 
 // SpawnError describes a chat-spawn failure. The drawer opens

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -13,11 +13,13 @@ import { Route as AppRouteImport } from './routes/_app'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AppUsageRouteImport } from './routes/_app.usage'
 import { Route as AppSettingsRouteImport } from './routes/_app.settings'
+import { Route as AppProjectsRouteImport } from './routes/_app.projects'
 import { Route as AppOperatorsRouteImport } from './routes/_app.operators'
 import { Route as AppDashboardRouteImport } from './routes/_app.dashboard'
 import { Route as AppReposIndexRouteImport } from './routes/_app.repos.index'
 import { Route as AppReposAddRouteImport } from './routes/_app.repos.add'
 import { Route as AppReposRepoNameRouteImport } from './routes/_app.repos.$repoName'
+import { Route as AppProjectsNameRouteImport } from './routes/_app.projects.$name'
 import { Route as AppRunsSlugIssueTsRouteImport } from './routes/_app.runs.$slug.$issue.$ts'
 
 const AppRoute = AppRouteImport.update({
@@ -37,6 +39,11 @@ const AppUsageRoute = AppUsageRouteImport.update({
 const AppSettingsRoute = AppSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => AppRoute,
+} as any)
+const AppProjectsRoute = AppProjectsRouteImport.update({
+  id: '/projects',
+  path: '/projects',
   getParentRoute: () => AppRoute,
 } as any)
 const AppOperatorsRoute = AppOperatorsRouteImport.update({
@@ -64,6 +71,11 @@ const AppReposRepoNameRoute = AppReposRepoNameRouteImport.update({
   path: '/repos/$repoName',
   getParentRoute: () => AppRoute,
 } as any)
+const AppProjectsNameRoute = AppProjectsNameRouteImport.update({
+  id: '/$name',
+  path: '/$name',
+  getParentRoute: () => AppProjectsRoute,
+} as any)
 const AppRunsSlugIssueTsRoute = AppRunsSlugIssueTsRouteImport.update({
   id: '/runs/$slug/$issue/$ts',
   path: '/runs/$slug/$issue/$ts',
@@ -74,8 +86,10 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/dashboard': typeof AppDashboardRoute
   '/operators': typeof AppOperatorsRoute
+  '/projects': typeof AppProjectsRouteWithChildren
   '/settings': typeof AppSettingsRoute
   '/usage': typeof AppUsageRoute
+  '/projects/$name': typeof AppProjectsNameRoute
   '/repos/$repoName': typeof AppReposRepoNameRoute
   '/repos/add': typeof AppReposAddRoute
   '/repos/': typeof AppReposIndexRoute
@@ -85,8 +99,10 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/dashboard': typeof AppDashboardRoute
   '/operators': typeof AppOperatorsRoute
+  '/projects': typeof AppProjectsRouteWithChildren
   '/settings': typeof AppSettingsRoute
   '/usage': typeof AppUsageRoute
+  '/projects/$name': typeof AppProjectsNameRoute
   '/repos/$repoName': typeof AppReposRepoNameRoute
   '/repos/add': typeof AppReposAddRoute
   '/repos': typeof AppReposIndexRoute
@@ -98,8 +114,10 @@ export interface FileRoutesById {
   '/_app': typeof AppRouteWithChildren
   '/_app/dashboard': typeof AppDashboardRoute
   '/_app/operators': typeof AppOperatorsRoute
+  '/_app/projects': typeof AppProjectsRouteWithChildren
   '/_app/settings': typeof AppSettingsRoute
   '/_app/usage': typeof AppUsageRoute
+  '/_app/projects/$name': typeof AppProjectsNameRoute
   '/_app/repos/$repoName': typeof AppReposRepoNameRoute
   '/_app/repos/add': typeof AppReposAddRoute
   '/_app/repos/': typeof AppReposIndexRoute
@@ -111,8 +129,10 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/operators'
+    | '/projects'
     | '/settings'
     | '/usage'
+    | '/projects/$name'
     | '/repos/$repoName'
     | '/repos/add'
     | '/repos/'
@@ -122,8 +142,10 @@ export interface FileRouteTypes {
     | '/'
     | '/dashboard'
     | '/operators'
+    | '/projects'
     | '/settings'
     | '/usage'
+    | '/projects/$name'
     | '/repos/$repoName'
     | '/repos/add'
     | '/repos'
@@ -134,8 +156,10 @@ export interface FileRouteTypes {
     | '/_app'
     | '/_app/dashboard'
     | '/_app/operators'
+    | '/_app/projects'
     | '/_app/settings'
     | '/_app/usage'
+    | '/_app/projects/$name'
     | '/_app/repos/$repoName'
     | '/_app/repos/add'
     | '/_app/repos/'
@@ -177,6 +201,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppSettingsRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/projects': {
+      id: '/_app/projects'
+      path: '/projects'
+      fullPath: '/projects'
+      preLoaderRoute: typeof AppProjectsRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/_app/operators': {
       id: '/_app/operators'
       path: '/operators'
@@ -212,6 +243,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppReposRepoNameRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/projects/$name': {
+      id: '/_app/projects/$name'
+      path: '/$name'
+      fullPath: '/projects/$name'
+      preLoaderRoute: typeof AppProjectsNameRouteImport
+      parentRoute: typeof AppProjectsRoute
+    }
     '/_app/runs/$slug/$issue/$ts': {
       id: '/_app/runs/$slug/$issue/$ts'
       path: '/runs/$slug/$issue/$ts'
@@ -222,9 +260,22 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface AppProjectsRouteChildren {
+  AppProjectsNameRoute: typeof AppProjectsNameRoute
+}
+
+const AppProjectsRouteChildren: AppProjectsRouteChildren = {
+  AppProjectsNameRoute: AppProjectsNameRoute,
+}
+
+const AppProjectsRouteWithChildren = AppProjectsRoute._addFileChildren(
+  AppProjectsRouteChildren,
+)
+
 interface AppRouteChildren {
   AppDashboardRoute: typeof AppDashboardRoute
   AppOperatorsRoute: typeof AppOperatorsRoute
+  AppProjectsRoute: typeof AppProjectsRouteWithChildren
   AppSettingsRoute: typeof AppSettingsRoute
   AppUsageRoute: typeof AppUsageRoute
   AppReposRepoNameRoute: typeof AppReposRepoNameRoute
@@ -236,6 +287,7 @@ interface AppRouteChildren {
 const AppRouteChildren: AppRouteChildren = {
   AppDashboardRoute: AppDashboardRoute,
   AppOperatorsRoute: AppOperatorsRoute,
+  AppProjectsRoute: AppProjectsRouteWithChildren,
   AppSettingsRoute: AppSettingsRoute,
   AppUsageRoute: AppUsageRoute,
   AppReposRepoNameRoute: AppReposRepoNameRoute,

--- a/web/src/routes/_app.projects.$name.tsx
+++ b/web/src/routes/_app.projects.$name.tsx
@@ -1,0 +1,165 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { ChevronLeft, FolderKanban, MessageSquare, Sparkles, X } from 'lucide-react'
+import { cn } from '../lib/utils'
+import { useChatDrawer } from '../lib/chatContext'
+import { Markdown } from '../components/Markdown'
+
+interface Project {
+  name: string
+  repos: string[]
+  created_at?: string
+  context_md?: string
+}
+
+export const Route = createFileRoute('/_app/projects/$name')({
+  component: ProjectDetail,
+})
+
+function ProjectDetail() {
+  const { name } = Route.useParams()
+  const chatDrawer = useChatDrawer()
+
+  const [project, setProject] = useState<Project | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/data/projects.json', { cache: 'no-store' })
+      .then(r => (r.ok ? r.json() : []))
+      .catch(() => [])
+      .then(data => {
+        const list: Project[] = Array.isArray(data) ? data : []
+        const match = list.find(p => p.name === name) || null
+        setProject(match)
+        setLoading(false)
+      })
+  }, [name])
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6">
+      <Link
+        to="/projects"
+        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mb-4"
+      >
+        <ChevronLeft className="w-3.5 h-3.5" /> Projects
+      </Link>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground py-8">Loading…</p>
+      ) : !project ? (
+        <div className="bg-card border border-border rounded-xl p-6 text-sm text-muted-foreground">
+          Project <code className="font-mono text-foreground">{name}</code> not found. Run{' '}
+          <code className="px-1 py-0.5 bg-secondary rounded font-mono">
+            clawflow project create {name}
+          </code>{' '}
+          to create it.
+        </div>
+      ) : (
+        <>
+          {/* Header */}
+          <div className="mb-6">
+            <h1 className="text-2xl font-bold text-foreground font-mono flex items-center gap-2">
+              <FolderKanban className="w-5 h-5 text-muted-foreground" />
+              {project.name}
+            </h1>
+            <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+              <span className="tabular-nums">
+                {project.repos?.length ?? 0} {(project.repos?.length ?? 0) === 1 ? 'repo' : 'repos'}
+              </span>
+              {project.created_at && (
+                <>
+                  <span>·</span>
+                  <span>created {new Date(project.created_at).toLocaleDateString()}</span>
+                </>
+              )}
+            </div>
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex gap-2 mb-6">
+            <button
+              type="button"
+              onClick={() => chatDrawer.open({ project: project.name, action: 'chat' })}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors',
+                'border-border text-foreground hover:bg-secondary/50',
+              )}
+            >
+              <MessageSquare className="w-3.5 h-3.5" />
+              Chat
+            </button>
+            <button
+              type="button"
+              onClick={() => chatDrawer.open({ project: project.name, action: 'generate' })}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors',
+                'border-border text-foreground hover:bg-secondary/50',
+              )}
+            >
+              <Sparkles className="w-3.5 h-3.5" />
+              AI Generate
+            </button>
+          </div>
+
+          {/* Context.md */}
+          <section className="mb-6">
+            <h2 className="text-sm font-semibold text-foreground mb-2">Context</h2>
+            {project.context_md ? (
+              <div className="bg-card border border-border rounded-xl p-4">
+                <Markdown>{project.context_md}</Markdown>
+              </div>
+            ) : (
+              <div className="bg-card border border-border rounded-xl p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  No <code className="px-1 py-0.5 bg-secondary rounded text-xs font-mono">context.md</code> yet.
+                  Click <strong>AI Generate</strong> to create one, or add it manually.
+                </p>
+              </div>
+            )}
+          </section>
+
+          {/* Member repos */}
+          <section>
+            <h2 className="text-sm font-semibold text-foreground mb-2">
+              Member repos{' '}
+              <span className="font-normal text-muted-foreground">
+                ({project.repos?.length ?? 0})
+              </span>
+            </h2>
+            {!project.repos || project.repos.length === 0 ? (
+              <div className="bg-card border border-border rounded-xl p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  No repos in this project. Use{' '}
+                  <code className="px-1 py-0.5 bg-secondary rounded text-xs font-mono">
+                    clawflow project add-repo {project.name} &lt;owner/repo&gt;
+                  </code>{' '}
+                  to add one.
+                </p>
+              </div>
+            ) : (
+              <div className="bg-card border border-border rounded-xl overflow-hidden divide-y divide-border">
+                {project.repos.map(repo => (
+                  <div
+                    key={repo}
+                    className="flex items-center justify-between px-4 py-2 hover:bg-secondary/20"
+                  >
+                    <Link
+                      to="/repos/$repoName"
+                      params={{ repoName: encodeURIComponent(repo) }}
+                      className="font-mono text-sm text-foreground hover:underline"
+                    >
+                      {repo}
+                    </Link>
+                    <span className="text-muted-foreground">
+                      <X className="w-3.5 h-3.5 opacity-0" aria-hidden="true" />
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/routes/_app.projects.tsx
+++ b/web/src/routes/_app.projects.tsx
@@ -1,0 +1,113 @@
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { FolderKanban, ChevronRight } from 'lucide-react'
+
+interface Project {
+  name: string
+  repos: string[]
+  created_at?: string
+  context_md?: string
+}
+
+export const Route = createFileRoute('/_app/projects')({
+  component: ProjectList,
+})
+
+function timeAgo(iso: string): string {
+  if (!iso) return '—'
+  const t = new Date(iso).getTime()
+  if (!isFinite(t)) return '—'
+  const diff = Math.floor((Date.now() - t) / 1000)
+  if (diff < 0) return 'just now'
+  if (diff < 60) return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}min ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+function ProjectList() {
+  const [projects, setProjects] = useState<Project[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('/data/projects.json', { cache: 'no-store' })
+      .then(r => (r.ok ? r.json() : []))
+      .catch(() => [])
+      .then(data => {
+        setProjects(Array.isArray(data) ? data : [])
+        setLoading(false)
+      })
+  }, [])
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6">
+      <div className="mb-5">
+        <h1 className="text-2xl font-bold text-foreground">Projects</h1>
+        <p className="text-xs text-muted-foreground mt-1">
+          Cross-repo project groups. Use{' '}
+          <code className="px-1 py-0.5 bg-secondary rounded text-[10px]">clawflow project create &lt;name&gt;</code>{' '}
+          to add a new project.
+        </p>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground text-center py-8">Loading…</p>
+      ) : projects.length === 0 ? (
+        <div className="bg-card border border-border rounded-xl p-8 text-center">
+          <FolderKanban className="w-8 h-8 text-muted-foreground/40 mx-auto mb-3" />
+          <p className="text-sm text-muted-foreground">
+            No projects yet. Run{' '}
+            <code className="px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">
+              clawflow project create &lt;name&gt;
+            </code>{' '}
+            to get started.
+          </p>
+        </div>
+      ) : (
+        <div className="bg-card border border-border rounded-xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-secondary/30 text-xs uppercase text-muted-foreground">
+              <tr>
+                <th className="text-left px-4 py-2 font-semibold">Project</th>
+                <th className="text-left px-4 py-2 font-semibold">Repos</th>
+                <th className="text-left px-4 py-2 font-semibold">Created</th>
+                <th className="w-8" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {projects.map(p => (
+                <tr key={p.name} className="hover:bg-secondary/20">
+                  <td className="px-4 py-2">
+                    <Link
+                      to="/projects/$name"
+                      params={{ name: p.name }}
+                      className="inline-flex items-center gap-2 font-mono text-foreground hover:underline"
+                    >
+                      <FolderKanban className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                      {p.name}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground tabular-nums">
+                    {p.repos?.length ?? 0} {(p.repos?.length ?? 0) === 1 ? 'repo' : 'repos'}
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground text-xs tabular-nums">
+                    {p.created_at ? timeAgo(p.created_at) : '—'}
+                  </td>
+                  <td className="px-4 py-2">
+                    <Link
+                      to="/projects/$name"
+                      params={{ name: p.name }}
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      <ChevronRight className="w-4 h-4" />
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/routes/_app.tsx
+++ b/web/src/routes/_app.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Outlet, Link } from '@tanstack/react-router'
-import { BookOpen, Receipt } from 'lucide-react'
+import { BookOpen, Receipt, FolderKanban } from 'lucide-react'
 import { useTheme } from '../lib/useTheme'
 import { ChatProvider } from '../lib/chatContext'
 import { ChatDrawer } from '../components/ChatDrawer'
@@ -54,6 +54,15 @@ function AppLayout() {
                 activeProps={{ style: { color: 'hsl(var(--brand))', background: 'hsl(var(--brand) / 0.08)' } }}
               >
                 Repos
+              </Link>
+              <Link
+                to="/projects"
+                className="text-sm font-medium px-2.5 py-1 rounded-sm transition-colors inline-flex items-center gap-1"
+                style={{ color: 'hsl(var(--text-low))' }}
+                activeProps={{ style: { color: 'hsl(var(--brand))', background: 'hsl(var(--brand) / 0.08)' } }}
+              >
+                <FolderKanban className="w-3.5 h-3.5" />
+                Projects
               </Link>
               <Link
                 to="/operators"


### PR DESCRIPTION
Fixes #46

## What changed

Adds a frontend projects section to the ClawFlow dashboard:

- **`/_app/projects`** — List page fetching `/data/projects.json`, showing all projects with name, member repo count, and creation date. Gracefully handles missing/empty data.
- **`/_app/projects/$name`** — Detail page with project metadata, rendered `context.md` content (via existing Markdown component), Chat and AI Generate buttons that spawn terminal sessions, and a member repos list linking to repo detail pages.
- **Nav link** — "Projects" with FolderKanban icon added to the header navigation between Repos and Operators.
- **`chatContext.tsx`** — Extended `ChatTarget` type to support `project` and `action` fields for project-scoped chat/generate spawns.
- **`chat_spawn.go`** — Extended the spawn endpoint to accept a `project` field and map `action` to `clawflow project generate <name>` or `clawflow project chat <name>`.

## Files changed

- `web/src/routes/_app.projects.tsx` (new)
- `web/src/routes/_app.projects.$name.tsx` (new)
- `web/src/routes/_app.tsx` (nav link)
- `web/src/lib/chatContext.tsx` (ChatTarget extension)
- `web/src/routeTree.gen.ts` (route registration)
- `internal/api/chat_spawn.go` (project spawn support)

## Testing

- Go: `go build ./...` clean, `go test ./...` all pass
- Frontend: `vite build` + `tsc --noEmit` both clean

## Notes

- Repo add/remove management is read-only for now (displays CLI commands). A mutation API doesn't exist yet — this can be a follow-up.
- The `/data/projects.json` endpoint is expected to be produced by the backend (`snapshot.WriteProjects`). The frontend gracefully falls back to an empty state if the file doesn't exist.