### PR TITLE
feat: project chat with context.md write-back

### DIFF
--- a/cmd/clawflow/commands/project.go
+++ b/cmd/clawflow/commands/project.go
@@ -1,0 +1,365 @@
+package commands
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/chat"
+	"github.com/zhoushoujianwork/clawflow/internal/claude"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+func NewProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Manage project-level context documents",
+		Long: `Manage project-level context.md documents stored in ~/.clawflow/projects/<name>/.
+These documents capture a project's purpose, architecture, conventions, and
+current state. Use 'project chat' to refine them interactively with Claude.`,
+	}
+	cmd.AddCommand(newProjectInitCmd())
+	cmd.AddCommand(newProjectListCmd())
+	cmd.AddCommand(newProjectChatCmd())
+	cmd.AddCommand(newProjectShowCmd())
+	return cmd
+}
+
+func newProjectInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init <name>",
+		Short: "Initialize a new project with a starter context.md",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			existing, err := chat.LoadProjectContext(name)
+			if err != nil {
+				return err
+			}
+			if existing != "" {
+				return fmt.Errorf("project %q already has a context.md; use 'clawflow project chat %s' to edit it", name, name)
+			}
+			starter := fmt.Sprintf("# %s\n\n## Overview\n\n_Describe the project here._\n\n## Architecture\n\n## Conventions\n\n## Current State\n", name)
+			if err := chat.SaveProjectContext(name, starter); err != nil {
+				return err
+			}
+			path, _ := chat.ProjectContextPath(name)
+			fmt.Fprintf(os.Stderr, "Created %s\n", path)
+			fmt.Fprintf(os.Stderr, "Edit it directly or run: clawflow project chat %s\n", name)
+			return nil
+		},
+	}
+}
+
+func newProjectListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "list",
+		Short:   "List all projects with a context.md",
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			names, err := chat.ListProjects()
+			if err != nil {
+				return err
+			}
+			if len(names) == 0 {
+				fmt.Println("No projects found.")
+				fmt.Println("Create one with: clawflow project init <name>")
+				return nil
+			}
+			for _, n := range names {
+				fmt.Println(n)
+			}
+			return nil
+		},
+	}
+}
+
+func newProjectShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <name>",
+		Short: "Print the current context.md for a project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			content, err := chat.LoadProjectContext(args[0])
+			if err != nil {
+				return err
+			}
+			if content == "" {
+				return fmt.Errorf("project %q has no context.md; run 'clawflow project init %s' first", args[0], args[0])
+			}
+			fmt.Print(content)
+			return nil
+		},
+	}
+}
+
+func newProjectChatCmd() *cobra.Command {
+	var model string
+	cmd := &cobra.Command{
+		Use:   "chat <name>",
+		Short: "Interactive Claude session to refine a project's context.md",
+		Long: `Start an interactive Claude session with the project's context.md loaded
+as system context. When the session ends, if Claude produced an updated
+context.md (in a fenced code block tagged "context.md"), you'll be shown
+a preview and asked whether to save it back.
+
+Example:
+  clawflow project chat my-project`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjectChat(cmd.Context(), args[0], model)
+		},
+	}
+	cmd.Flags().StringVar(&model, "model", "", "claude model to use (default: settings chat model)")
+	return cmd
+}
+
+func runProjectChat(_ context.Context, name, model string) error {
+	// Load existing context.md (may be empty for a new project).
+	originalCtx, err := chat.LoadProjectContext(name)
+	if err != nil {
+		return err
+	}
+	if originalCtx == "" {
+		fmt.Fprintf(os.Stderr, "[clawflow] project %q has no context.md yet — starting with an empty document.\n", name)
+		fmt.Fprintf(os.Stderr, "[clawflow] Tip: run 'clawflow project init %s' first for a starter template.\n", name)
+	}
+
+	// Resolve model
+	if model == "" {
+		creds, _ := config.LoadCredentials()
+		model = creds.EffectiveChatModel()
+	}
+
+	// Build system prompt
+	systemCtx := chat.BuildProjectChatContext(name, originalCtx)
+	tmpFile, err := os.CreateTemp("", "clawflow-project-ctx-*.md")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(systemCtx); err != nil {
+		tmpFile.Close()
+		return err
+	}
+	tmpFile.Close()
+
+	// Session setup — fresh session each time, same pattern as chat.go
+	sessionID := chat.NewSessionID("project/"+name, 0)
+	sessionName := fmt.Sprintf("clawflow: project/%s", name)
+
+	// Working directory: use a temp dir since project chat is not repo-bound
+	workdir := os.TempDir()
+
+	args := []string{
+		"--model", model,
+		"--name", sessionName,
+		"--output-format", "stream-json",
+		"--session-id", sessionID,
+		"--append-system-prompt-file", tmpFile.Name(),
+	}
+
+	// When the user has an API key configured, use --bare mode (same logic as chat.go)
+	preCreds, _ := config.LoadCredentials()
+	useBare := preCreds != nil && preCreds.ClaudeAPIKey != ""
+	if useBare {
+		args = append(args, "--bare", "--add-dir", workdir)
+	}
+
+	bin := claude.Resolve()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = workdir
+
+	creds, _ := config.LoadCredentials()
+	apiKey, baseURL := "", ""
+	if creds != nil {
+		apiKey, baseURL = creds.ClaudeAPIKey, creds.ClaudeBaseURL
+	}
+	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
+
+	// Print provenance banner (same pattern as chat.go)
+	keyHint := "(none — falling back to OAuth/keychain)"
+	if apiKey != "" {
+		if n := len(apiKey); n >= 4 {
+			keyHint = "…" + apiKey[n-4:]
+		} else {
+			keyHint = "(set, <4 chars)"
+		}
+	}
+	urlHint := baseURL
+	if urlHint == "" {
+		urlHint = "(default — api.anthropic.com)"
+	}
+	bareNote := ""
+	if useBare {
+		bareNote = " --bare (forced, API key takes priority over claude.ai login)"
+	}
+	fmt.Fprintf(os.Stderr, "[clawflow] project chat → model=%s key=%s base_url=%s%s\n", model, keyHint, urlHint, bareNote)
+
+	// Connect stdin directly so the user can interact.
+	cmd.Stdin = os.Stdin
+
+	// Capture stdout (stream-json) while also displaying it to the user via
+	// stderr. stream-json lines are machine-readable, so we parse them and
+	// echo a human-friendly rendering to stderr for the interactive experience.
+	var capturedOutput bytes.Buffer
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start claude: %w", err)
+	}
+
+	// Read stream-json from stdout, display assistant text to stderr, and
+	// capture everything for post-session extraction.
+	streamDone := make(chan error, 1)
+	go func() {
+		streamDone <- streamAndCapture(stdoutPipe, os.Stderr, &capturedOutput)
+	}()
+
+	// Wait for the stream reader to finish before waiting on the process,
+	// so we don't miss any output.
+	if err := <-streamDone; err != nil {
+		debugf("stream reader error: %v", err)
+	}
+
+	runErr := cmd.Wait()
+
+	// Even if claude exited non-zero (e.g. user Ctrl-C), we still try to
+	// extract and offer write-back from whatever output was captured.
+	if runErr != nil {
+		debugf("claude exited with: %v", runErr)
+	}
+
+	// Extract the last context.md block from the captured stream-json output.
+	captured := capturedOutput.String()
+	newCtx := chat.ExtractLastContextMD(captured)
+
+	if newCtx == "" {
+		fmt.Fprintln(os.Stderr, "\n[clawflow] No updated context.md found in the session output.")
+		fmt.Fprintln(os.Stderr, "[clawflow] Tip: ask Claude to output the final document in a ```context.md code block.")
+		return runErr
+	}
+
+	// Ensure the extracted content ends with a newline
+	if !strings.HasSuffix(newCtx, "\n") {
+		newCtx += "\n"
+	}
+
+	// Show preview
+	fmt.Fprintln(os.Stderr, "\n[clawflow] ─── Updated context.md preview ───")
+	fmt.Fprintln(os.Stderr, newCtx)
+	fmt.Fprintln(os.Stderr, "[clawflow] ─── End preview ───")
+
+	if originalCtx == newCtx {
+		fmt.Fprintln(os.Stderr, "[clawflow] No changes detected — context.md is unchanged.")
+		return runErr
+	}
+
+	// Prompt for confirmation
+	fmt.Fprint(os.Stderr, "[clawflow] Save updated context.md? [y/N] ")
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	if answer == "y" || answer == "yes" {
+		if err := chat.SaveProjectContext(name, newCtx); err != nil {
+			return fmt.Errorf("write context.md: %w", err)
+		}
+		path, _ := chat.ProjectContextPath(name)
+		fmt.Fprintf(os.Stderr, "[clawflow] Saved → %s\n", path)
+	} else {
+		fmt.Fprintln(os.Stderr, "[clawflow] Discarded — context.md unchanged.")
+	}
+
+	return runErr
+}
+
+// streamAndCapture reads stream-json lines from r, writes them to captured,
+// and renders a human-friendly version of assistant text to display.
+func streamAndCapture(r io.Reader, display io.Writer, captured *bytes.Buffer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		// Always capture the raw line
+		captured.Write(line)
+		captured.WriteByte('\n')
+
+		// Try to extract displayable text for the user
+		displayStreamLine(line, display)
+	}
+	return scanner.Err()
+}
+
+// displayStreamLine parses a single stream-json line and writes any
+// assistant text content to w for the user to see.
+func displayStreamLine(line []byte, w io.Writer) {
+	// Quick pre-check to avoid parsing non-text events
+	if !bytes.Contains(line, []byte(`"text"`)) && !bytes.Contains(line, []byte(`"assistant"`)) {
+		return
+	}
+
+	var evt struct {
+		Type         string `json:"type"`
+		Role         string `json:"role,omitempty"`
+		Content      string `json:"content,omitempty"`
+		ContentBlock *struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content_block,omitempty"`
+		Delta *struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"delta,omitempty"`
+		Message *struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"message,omitempty"`
+	}
+
+	if err := json.Unmarshal(line, &evt); err != nil {
+		return
+	}
+
+	// content_block_delta with text — the most common streaming event
+	if evt.Delta != nil && evt.Delta.Type == "text_delta" {
+		fmt.Fprint(w, evt.Delta.Text)
+		return
+	}
+
+	// Full content_block
+	if evt.ContentBlock != nil && evt.ContentBlock.Type == "text" {
+		fmt.Fprint(w, evt.ContentBlock.Text)
+		return
+	}
+
+	// Inline assistant content
+	if evt.Role == "assistant" && evt.Content != "" {
+		fmt.Fprint(w, evt.Content)
+		return
+	}
+
+	// Message wrapper
+	if evt.Message != nil && evt.Message.Role == "assistant" {
+		for _, cb := range evt.Message.Content {
+			if cb.Type == "text" {
+				fmt.Fprint(w, cb.Text)
+			}
+		}
+	}
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -35,6 +35,7 @@ entirely in VCS labels and comments. Run 'clawflow run' once, or schedule it.`,
 	root.AddCommand(NewConfigCmd())
 	root.AddCommand(NewUpdateCmd())
 	root.AddCommand(NewInstallSkillCmd())
+	root.AddCommand(NewProjectCmd())
 	root.AddCommand(NewRespawnCmd())
 	// Helpers retained for operator use (invoked from SKILL.md bodies):
 	root.AddCommand(NewWorktreeCmd())

--- a/internal/chat/project.go
+++ b/internal/chat/project.go
@@ -1,0 +1,243 @@
+package chat
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ProjectDir returns ~/.clawflow/projects/<name>.
+func ProjectDir(name string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".clawflow", "projects", name), nil
+}
+
+// ProjectContextPath returns ~/.clawflow/projects/<name>/context.md.
+func ProjectContextPath(name string) (string, error) {
+	dir, err := ProjectDir(name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "context.md"), nil
+}
+
+// LoadProjectContext reads context.md for the named project.
+// Returns ("", nil) if the file does not exist yet.
+func LoadProjectContext(name string) (string, error) {
+	p, err := ProjectContextPath(name)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(p)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// SaveProjectContext writes content to context.md, creating the directory
+// if needed.
+func SaveProjectContext(name, content string) error {
+	p, err := ProjectContextPath(name)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(content), 0o644)
+}
+
+// ListProjects returns the names of all projects that have a context.md.
+func ListProjects() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	base := filepath.Join(home, ".clawflow", "projects")
+	entries, err := os.ReadDir(base)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		ctxPath := filepath.Join(base, e.Name(), "context.md")
+		if _, err := os.Stat(ctxPath); err == nil {
+			names = append(names, e.Name())
+		}
+	}
+	return names, nil
+}
+
+// BuildProjectChatContext assembles the system prompt for project-level chat.
+// It instructs Claude to work with the context.md document and output the
+// final version when the user is satisfied.
+func BuildProjectChatContext(name, contextMD string) string {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, "# Project Chat Context")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "Project: %s\n", name)
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Current context.md")
+	fmt.Fprintln(&b)
+	if strings.TrimSpace(contextMD) == "" {
+		fmt.Fprintln(&b, "_(empty — this is a new project)_")
+	} else {
+		fmt.Fprintln(&b, contextMD)
+	}
+
+	fmt.Fprintln(&b, "---")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, `## Your role
+
+You are a project context assistant. You help the user refine and maintain
+the project's context.md — a living document that captures the project's
+purpose, architecture, conventions, and current state.
+
+## Important: outputting the final document
+
+When the conversation reaches a natural conclusion, or when the user asks
+you to finalize, output the complete updated context.md inside a fenced
+code block with the `+"`"+`context.md`+"`"+` info string, like this:
+
+`+"```"+`context.md
+# Project Name
+... full document content ...
+`+"```"+`
+
+This is how the tool captures your changes for write-back. Always output
+the COMPLETE document, not a partial diff. If the user hasn't asked for
+changes, you don't need to output it.
+
+## Hard constraints
+
+- Do NOT run git commands that mutate the working tree.
+- Do NOT edit, create, or delete files. This is a planning session.
+- Focus on the context.md document — its structure, accuracy, and
+  completeness.`)
+
+	return b.String()
+}
+
+// streamJSONMessage is the minimal projection of a claude --output-format
+// stream-json assistant message event. We only care about extracting text
+// content from assistant messages.
+type streamJSONMessage struct {
+	Type    string `json:"type"`
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+	// For content_block events
+	ContentBlock *contentBlock `json:"content_block,omitempty"`
+	// For message events with content array
+	Message *messagePayload `json:"message,omitempty"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type messagePayload struct {
+	Role    string         `json:"role"`
+	Content []contentBlock `json:"content"`
+}
+
+// ExtractLastContextMD scans a stream-json output (one JSON object per line)
+// and returns the content of the last fenced code block tagged "context.md"
+// found in assistant messages. Returns "" if none found.
+func ExtractLastContextMD(output string) string {
+	// Collect all assistant text from the stream-json output.
+	// Claude's stream-json format emits various event types; we look for
+	// assistant message text in multiple possible shapes.
+	var allText strings.Builder
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var msg streamJSONMessage
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			continue
+		}
+
+		// assistant message with inline content string
+		if msg.Role == "assistant" && msg.Content != "" {
+			allText.WriteString(msg.Content)
+			continue
+		}
+		// content_block with text
+		if msg.ContentBlock != nil && msg.ContentBlock.Type == "text" {
+			allText.WriteString(msg.ContentBlock.Text)
+			continue
+		}
+		// message wrapper with content array
+		if msg.Message != nil && msg.Message.Role == "assistant" {
+			for _, cb := range msg.Message.Content {
+				if cb.Type == "text" {
+					allText.WriteString(cb.Text)
+				}
+			}
+			continue
+		}
+	}
+
+	return extractFencedBlock(allText.String(), "context.md")
+}
+
+// extractFencedBlock finds the last fenced code block with the given info
+// string in text. Returns the content between the fences, or "" if not found.
+func extractFencedBlock(text, infoString string) string {
+	var last string
+	lines := strings.Split(text, "\n")
+	inBlock := false
+	var blockLines []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inBlock {
+			// Look for opening fence: ```context.md or ``` context.md
+			if (strings.HasPrefix(trimmed, "```"+infoString) || strings.HasPrefix(trimmed, "~~~ "+infoString)) &&
+				len(trimmed) <= len("```"+infoString)+1 { // allow trailing whitespace
+				inBlock = true
+				blockLines = nil
+				continue
+			}
+			// Also match with a space: "``` context.md"
+			if strings.HasPrefix(trimmed, "``` "+infoString) {
+				inBlock = true
+				blockLines = nil
+				continue
+			}
+		} else {
+			// Look for closing fence
+			if trimmed == "```" || trimmed == "~~~" {
+				inBlock = false
+				last = strings.Join(blockLines, "\n")
+				continue
+			}
+			blockLines = append(blockLines, line)
+		}
+	}
+
+	return last
+}

--- a/internal/chat/project_test.go
+++ b/internal/chat/project_test.go
@@ -1,0 +1,219 @@
+package chat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractFencedBlock(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple block",
+			input: "Some text\n```context.md\n# My Project\n\nOverview here.\n```\nMore text",
+			want:  "# My Project\n\nOverview here.",
+		},
+		{
+			name:  "multiple blocks returns last",
+			input: "```context.md\n# V1\n```\nSome discussion\n```context.md\n# V2 Final\n\nUpdated.\n```\n",
+			want:  "# V2 Final\n\nUpdated.",
+		},
+		{
+			name:  "no block",
+			input: "Just some regular text\nwith no code blocks",
+			want:  "",
+		},
+		{
+			name:  "wrong info string",
+			input: "```markdown\n# Not context.md\n```",
+			want:  "",
+		},
+		{
+			name:  "block with space before info string",
+			input: "``` context.md\n# Spaced\n```",
+			want:  "# Spaced",
+		},
+		{
+			name:  "empty block",
+			input: "```context.md\n```",
+			want:  "",
+		},
+		{
+			name:  "multiline content",
+			input: "```context.md\n# Project\n\n## Overview\n\nThis is a project.\n\n## Architecture\n\nMicroservices.\n```",
+			want:  "# Project\n\n## Overview\n\nThis is a project.\n\n## Architecture\n\nMicroservices.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractFencedBlock(tt.input, "context.md")
+			if got != tt.want {
+				t.Errorf("extractFencedBlock() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractLastContextMD(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream string
+		want   string
+	}{
+		{
+			name: "content_block with text",
+			stream: `{"type":"content_block_start","content_block":{"type":"text","text":"Here is the updated document:\n\n` + "```context.md\\n# Updated\\n```" + `"}}
+`,
+			want: "# Updated",
+		},
+		{
+			name: "message with content array",
+			stream: `{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"` + "```context.md\\n# From Array\\n```" + `"}]}}
+`,
+			want: "# From Array",
+		},
+		{
+			name: "assistant role with inline content",
+			stream: `{"role":"assistant","content":"` + "```context.md\\n# Inline\\n```" + `"}
+`,
+			want: "# Inline",
+		},
+		{
+			name:   "no context.md block in output",
+			stream: `{"type":"content_block_start","content_block":{"type":"text","text":"Just a regular response."}}` + "\n",
+			want:   "",
+		},
+		{
+			name:   "empty stream",
+			stream: "",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractLastContextMD(tt.stream)
+			if got != tt.want {
+				t.Errorf("ExtractLastContextMD() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectContextRoundTrip(t *testing.T) {
+	// Use a temp dir as home to avoid touching the real ~/.clawflow
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	name := "test-project"
+
+	// Initially empty
+	content, err := LoadProjectContext(name)
+	if err != nil {
+		t.Fatalf("LoadProjectContext: %v", err)
+	}
+	if content != "" {
+		t.Fatalf("expected empty content, got %q", content)
+	}
+
+	// Save
+	doc := "# Test Project\n\nHello world.\n"
+	if err := SaveProjectContext(name, doc); err != nil {
+		t.Fatalf("SaveProjectContext: %v", err)
+	}
+
+	// Load back
+	got, err := LoadProjectContext(name)
+	if err != nil {
+		t.Fatalf("LoadProjectContext after save: %v", err)
+	}
+	if got != doc {
+		t.Errorf("round-trip mismatch: got %q, want %q", got, doc)
+	}
+
+	// Verify file path
+	p, _ := ProjectContextPath(name)
+	wantPath := filepath.Join(tmpHome, ".clawflow", "projects", name, "context.md")
+	if p != wantPath {
+		t.Errorf("ProjectContextPath = %q, want %q", p, wantPath)
+	}
+}
+
+func TestListProjects(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// No projects yet
+	names, err := ListProjects()
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("expected 0 projects, got %d", len(names))
+	}
+
+	// Create two projects
+	for _, n := range []string{"alpha", "beta"} {
+		if err := SaveProjectContext(n, "# "+n+"\n"); err != nil {
+			t.Fatalf("SaveProjectContext(%s): %v", n, err)
+		}
+	}
+
+	// Create a dir without context.md — should not appear
+	emptyDir := filepath.Join(tmpHome, ".clawflow", "projects", "empty")
+	os.MkdirAll(emptyDir, 0o755)
+
+	names, err = ListProjects()
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 projects, got %d: %v", len(names), names)
+	}
+
+	// Check both are present (order may vary by filesystem)
+	found := map[string]bool{}
+	for _, n := range names {
+		found[n] = true
+	}
+	if !found["alpha"] || !found["beta"] {
+		t.Errorf("expected alpha and beta, got %v", names)
+	}
+}
+
+func TestBuildProjectChatContext(t *testing.T) {
+	ctx := BuildProjectChatContext("my-proj", "# My Project\n\nSome content.\n")
+
+	// Should contain the project name
+	if got := ctx; !contains(got, "Project: my-proj") {
+		t.Error("missing project name in context")
+	}
+
+	// Should contain the original content
+	if !contains(ctx, "# My Project") {
+		t.Error("missing original context.md content")
+	}
+
+	// Should contain the instruction about outputting context.md
+	if !contains(ctx, "```context.md") {
+		t.Error("missing instruction about context.md code block")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Fixes #45

## What changed

Adds the `clawflow project` command group with four subcommands:

- **`project init <name>`** — creates `~/.clawflow/projects/<name>/context.md` with a starter template
- **`project list`** — lists all projects that have a context.md
- **`project show <name>`** — prints the current context.md
- **`project chat <name>`** — launches an interactive Claude session with context.md as system context, then captures the final version and offers to write it back

## How write-back works

1. The chat session runs with `--output-format stream-json` so stdout can be captured programmatically while assistant text is streamed to stderr for the user to read
2. The system prompt instructs Claude to output the final context.md in a fenced code block tagged `context.md`
3. After the session ends, the captured stream-json is parsed to extract the last such block
4. A preview is shown and the user is prompted: `Save updated context.md? [y/N]`
5. On confirmation, the file is written to `~/.clawflow/projects/<name>/context.md`

## Files changed

- `internal/chat/project.go` — project directory helpers, context builder, stream-json extraction
- `internal/chat/project_test.go` — 12 tests covering extraction, round-trip, listing, and context building
- `cmd/clawflow/commands/project.go` — project command group and `runProjectChat()`
- `cmd/clawflow/commands/root.go` — register the new command

## Testing

All existing tests pass. New tests cover the extraction/parsing logic, file round-trip, project listing, and context building.