### PR TITLE
fix: prevent infinite loop when operator self-posts via tool call

### DIFF
--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -104,6 +104,24 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 
 	outcome, body := parseOutcome(trimmed)
 
+	// Guard: if the operator produced output but no outcome marker, the model
+	// likely violated the output contract by posting the result via a VCS tool
+	// call (e.g. `gh issue comment`) instead of emitting it to stdout. In that
+	// case `trimmed` contains only a short summary line with no marker.
+	//
+	// Posting this summary as a comment would accumulate duplicate meta-comments
+	// on every run (the trigger label is still present, so the operator fires
+	// again). Instead, log a warning and skip the comment post. The lock label
+	// will still be removed by the caller, so the issue is left in a clean state
+	// for the next run (which may succeed once the prompt hardening takes effect).
+	if outcome == "" {
+		fmt.Fprintf(os.Stderr,
+			"  ⚠ operator %q stdout has no outcome marker — operator may have self-posted via a tool call; skipping comment post to prevent duplicate accumulation\n",
+			op.Name)
+		fmt.Fprintf(os.Stderr, "  ⚠ stdout was: %s\n", trimmed)
+		return trimmed, "", nil
+	}
+
 	if body != "" {
 		if err := v.PostIssueComment(opts.Repo, sub.Number, body); err != nil {
 			return body, outcome, fmt.Errorf("post result comment: %w", err)

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -106,11 +106,12 @@ func TestRun_HappyPath(t *testing.T) {
 	if v.removeLabelCals != 0 {
 		t.Errorf("RemoveLabel called %d times, want 0", v.removeLabelCals)
 	}
-	if len(v.comments) != 1 {
-		t.Fatalf("want 1 comment, got %d", len(v.comments))
-	}
-	if v.comments[0].body != "evaluation posted" {
-		t.Errorf("comment body = %q", v.comments[0].body)
+	// No outcome marker in the output → runner skips the comment post to
+	// prevent duplicate accumulation (the self-posting guard introduced in
+	// fix/issue-53). A real operator must include a marker; this test op
+	// intentionally omits one to verify the guard fires cleanly.
+	if len(v.comments) != 0 {
+		t.Fatalf("want 0 comments (no outcome marker → guard skips post), got %d", len(v.comments))
 	}
 }
 
@@ -315,7 +316,12 @@ func TestRun_OutcomeMarker_NoOutcomesSet_AcceptsAny(t *testing.T) {
 	}
 }
 
-func TestRun_OutcomeMarker_None_BackCompat(t *testing.T) {
+// TestRun_OutcomeMarker_None_NoPost verifies that when an operator produces
+// output with no outcome marker, the runner does NOT post a comment. This
+// prevents the infinite-loop / duplicate-comment accumulation that occurs when
+// a model violates the output contract by self-posting via a VCS tool call and
+// emitting only a short summary line (with no marker) to stdout.
+func TestRun_OutcomeMarker_None_NoPost(t *testing.T) {
 	op := &Operator{
 		Name:      "legacy-skill",
 		LockLabel: "lock",
@@ -334,10 +340,11 @@ func TestRun_OutcomeMarker_None_BackCompat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if len(v.comments) != 1 || v.comments[0].body != body {
-		t.Errorf("comment should be posted unchanged when no marker present; got %v", v.comments)
+	// No marker → runner skips comment post (self-posting guard).
+	if len(v.comments) != 0 {
+		t.Errorf("want 0 comments (no marker → guard skips post); got %v", v.comments)
 	}
-	// No marker → no outcome label, and no lock label is added either.
+	// No marker → no outcome label.
 	if v.addLabelCalls != 0 {
 		t.Errorf("AddLabel calls = %d, want 0", v.addLabelCalls)
 	}

--- a/skills/evaluate-bug/SKILL.md
+++ b/skills/evaluate-bug/SKILL.md
@@ -30,7 +30,15 @@ If `clawflow issue search` errors (rate limit, indexing lag), proceed with evalu
 
 ## Output contract (MUST follow)
 
-Your stdout IS the issue comment. ClawFlow posts it verbatim, then applies the outcome label declared by the marker line at the end. Four hard rules:
+Your stdout IS the issue comment. ClawFlow captures everything you print to stdout, posts it as a comment, and reads the outcome marker from it to decide which label to apply.
+
+**⛔ DO NOT call any tool that mutates VCS state.** This means: do NOT run `clawflow label`, `clawflow issue comment`, `clawflow pr`, `gh issue comment`, `gh pr`, or any other command that posts comments, adds labels, or changes PRs. If you call one of these tools, ClawFlow will NOT see your evaluation — it only reads your stdout. The outcome label will never be applied, and the operator will fire again on the next run, creating an infinite loop of duplicate comments.
+
+The correct flow is:
+- ✅ You print the full evaluation to stdout → ClawFlow posts it as a comment and applies the label.
+- ❌ You call `gh issue comment` or `clawflow issue comment` → ClawFlow sees only your summary line, finds no outcome marker, never applies the label, fires again next run.
+
+Four hard rules:
 
 1. **No tool calls that mutate VCS state.** Do NOT run `clawflow label`, `clawflow issue comment`, `clawflow pr`, `gh`, or any other command that changes labels / comments / PRs. ClawFlow owns those side-effects — your job is to produce text only.
 2. **End with exactly one outcome marker line.** The very last line of stdout must be either `<!-- clawflow:outcome=agent-evaluated -->` (confidence ≥ 7.0) or `<!-- clawflow:outcome=agent-skipped -->` (confidence < 7.0). ClawFlow strips this line before posting and uses it to decide which label to add.
@@ -38,6 +46,8 @@ Your stdout IS the issue comment. ClawFlow posts it verbatim, then applies the o
 4. **Produce a full, fresh evaluation every time.** If you see a prior evaluation comment in the thread, ignore it — the operator is triggering now because the owner removed `agent-evaluated` to request a new pass. Do not abbreviate into a "status update". Emit the complete Markdown template below.
 
 Output no preamble ("I will now evaluate…"), no code fences wrapping the whole output.
+
+**After you emit the final `<!-- clawflow:outcome=... -->` line, stop. Do NOT call any tool.**
 
 ## Score three dimensions (1-10 each)
 
@@ -82,4 +92,4 @@ Output exactly this Markdown, filling the placeholders. No code fences around th
 
 - Output **only** the Markdown comment body and the closing marker line. No "I will now evaluate…" preamble, no code fences around the whole output.
 - If the issue has too little information to score, give 1-3 on the affected dimension(s) and say *specifically what is missing*. Confidence below 7.0 → use `agent-skipped` in the marker.
-- The marker MUST be the last non-empty line of stdout. Do not run any tools after emitting the evaluation.
+- The marker MUST be the last non-empty line of stdout. **Do NOT call any tool after emitting the evaluation** — not `gh`, not `clawflow`, not anything. Your stdout is the comment; calling a tool to post it yourself will break the outcome label pipeline.

--- a/skills/evaluate-feat/SKILL.md
+++ b/skills/evaluate-feat/SKILL.md
@@ -13,7 +13,15 @@ You are a feature-request evaluator. Read the issue above and produce a structur
 
 ## Output contract (MUST follow)
 
-Your stdout IS the issue comment. ClawFlow posts it verbatim, then applies the outcome label declared by the marker line at the end. Four hard rules:
+Your stdout IS the issue comment. ClawFlow captures everything you print to stdout, posts it as a comment, and reads the outcome marker from it to decide which label to apply.
+
+**⛔ DO NOT call any tool that mutates VCS state.** This means: do NOT run `clawflow label`, `clawflow issue comment`, `clawflow pr`, `gh issue comment`, `gh pr`, or any other command that posts comments, adds labels, or changes PRs. If you call one of these tools, ClawFlow will NOT see your evaluation — it only reads your stdout. The outcome label will never be applied, and the operator will fire again on the next run, creating an infinite loop of duplicate comments.
+
+The correct flow is:
+- ✅ You print the full evaluation to stdout → ClawFlow posts it as a comment and applies the label.
+- ❌ You call `gh issue comment` or `clawflow issue comment` → ClawFlow sees only your summary line, finds no outcome marker, never applies the label, fires again next run.
+
+Four hard rules:
 
 1. **No tool calls that mutate VCS state.** Do NOT run `clawflow label`, `clawflow issue comment`, `clawflow pr`, `gh`, or any other command that changes labels / comments / PRs. ClawFlow owns those side-effects — your job is to produce text only.
 2. **End with exactly one outcome marker line.** The very last line of stdout must be either `<!-- clawflow:outcome=agent-evaluated -->` (confidence ≥ 7.0) or `<!-- clawflow:outcome=agent-skipped -->` (confidence < 7.0). ClawFlow strips this line before posting and uses it to decide which label to add.
@@ -21,6 +29,8 @@ Your stdout IS the issue comment. ClawFlow posts it verbatim, then applies the o
 4. **Produce a full, fresh evaluation every time.** If you see a prior evaluation comment in the thread, ignore it — the operator is triggering now because the owner removed `agent-evaluated` to request a new pass. Do not abbreviate into a "status update". Emit the complete Markdown template below.
 
 Output no preamble ("I will now evaluate…"), no code fences wrapping the whole output.
+
+**After you emit the final `<!-- clawflow:outcome=... -->` line, stop. Do NOT call any tool.**
 
 ## Score three dimensions (1-10 each)
 
@@ -66,4 +76,4 @@ Output exactly this Markdown, filling in the placeholders:
 - Output **only** the Markdown comment body and the closing marker line. No "I will now evaluate…" preamble, no code fences around the whole output.
 - If the feature description is too vague to evaluate, give 1-3 on Clarity and say *specifically* what's missing. Confidence below 7.0 → use `agent-skipped` in the marker.
 - Large scope is not automatic disqualification — score Scope honestly and flag it in the plan. The owner decides whether to split.
-- The marker MUST be the last non-empty line of stdout. Do not run any tools after emitting the evaluation.
+- The marker MUST be the last non-empty line of stdout. **Do NOT call any tool after emitting the evaluation** — not `gh`, not `clawflow`, not anything. Your stdout is the comment; calling a tool to post it yourself will break the outcome label pipeline.


### PR DESCRIPTION
Fixes #53

## What changed

**Runner-side guard ():**
When `claude -p` exits cleanly but stdout contains no `<!-- clawflow:outcome=... -->` marker, the runner now logs a warning and skips the comment post entirely. Previously it would post the markerless summary as a comment, find no marker, never apply the outcome label, and fire the operator again on the next run — accumulating duplicate meta-comments indefinitely.

**Prompt hardening (, ):**
- Added a prominent warning block before the rules list explaining exactly what breaks when the model calls a VCS tool instead of printing to stdout (outcome label never applied, infinite loop).
- Added a concrete negative example: calling `gh issue comment` → ClawFlow sees only the summary, no marker, fires again.
- Added a final stop instruction immediately after the marker line: "After you emit the final marker line, stop. Do NOT call any tool."

## Why two layers

The prompt fix reduces misbehavior frequency; the runner guard prevents the infinite loop and duplicate comments regardless of model behavior. Either fix alone is insufficient — the prompt can be ignored by the model, and the runner guard alone doesn't fix the root cause.

## Tests

- Renamed `TestRun_OutcomeMarker_None_BackCompat` → `TestRun_OutcomeMarker_None_NoPost` and flipped its assertion to match the new no-post contract.
- Updated `TestRun_HappyPath` to expect 0 comments when no marker is present.
- All 16 packages pass `go test ./...`.