### PR TITLE
ci: add test workflow for pushes to main and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Unit tests
+        run: go test -v -race ./...
+
+      - name: CLI smoke tests
+        run: |
+          go build -o clawflow ./cmd/clawflow/
+          ./clawflow --help
+          ./clawflow version
+          ./clawflow run --help
+          ./clawflow operators list
+          # Hard fail if any embedded SKILL.md has bad frontmatter.
+          ./clawflow operators validate
+          ./clawflow repo --help
+          ./clawflow issue --help
+          ./clawflow label --help
+          ./clawflow pr --help
+          ./clawflow config --help
+          ./clawflow status --help
+          ./clawflow worktree --help
+          ./clawflow pr-check --help
+          ./clawflow update --help
+          ./clawflow web --help

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,6 @@ go test ./internal/operator/...
 - 使用标准 `testing` 包，不引入外部测试框架
 - 算子集成测试：在测试仓库上运行 `clawflow run`，验证 label 和 comment 结果
 
-> TODO: CI 中的测试流程——确认 GitHub Actions 是否在 release 之外也跑 `go test`
-
 ---
 
 ## 代码规范


### PR DESCRIPTION
Fixes #52

## What changed

- Added  — triggers on  and 
- Mirrors the test job from  (unit tests + CLI smoke tests), using  to track the Go version declared in the module
- Removed the resolved TODO from 

No changes to .