### PR TITLE
feat: add deployment.md project config for runtime health observability

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -81,6 +81,16 @@ func TestingPath(name string) string {
 	return filepath.Join(ProjectDir(name), "testing.md")
 }
 
+// DeploymentPath returns the deployment.md path for a named project.
+//
+// deployment.md is a natural-language SOP describing the runtime
+// environment and how to retrieve logs (SSH, local file, systemd,
+// etc.). It is consumed by PM-mode operators when diagnosing runtime
+// health — not parsed as structured data.
+func DeploymentPath(name string) string {
+	return filepath.Join(ProjectDir(name), "deployment.md")
+}
+
 // Create creates a new project with the given name.
 func Create(name string) (*Project, error) {
 	if strings.TrimSpace(name) == "" {
@@ -103,15 +113,19 @@ func Create(name string) (*Project, error) {
 	if err := save(p); err != nil {
 		return nil, err
 	}
-	// Create empty context.md and testing.md so both files always
-	// exist. context.md is the project overview; testing.md is the
-	// local-environment SOP. Both get auto-injected into operator
-	// prompts via the project header.
+	// Create empty context.md, testing.md, and deployment.md so all
+	// three files always exist. context.md is the project overview;
+	// testing.md is the local-environment SOP; deployment.md describes
+	// the runtime environment and log retrieval methods. All three get
+	// auto-injected into operator prompts via the project header.
 	if err := os.WriteFile(ContextPath(name), []byte(""), 0o644); err != nil {
 		return nil, fmt.Errorf("create context.md: %w", err)
 	}
 	if err := os.WriteFile(TestingPath(name), []byte(""), 0o644); err != nil {
 		return nil, fmt.Errorf("create testing.md: %w", err)
+	}
+	if err := os.WriteFile(DeploymentPath(name), []byte(""), 0o644); err != nil {
+		return nil, fmt.Errorf("create deployment.md: %w", err)
 	}
 	return p, nil
 }
@@ -275,6 +289,28 @@ func WriteTesting(name, content string) error {
 	return os.WriteFile(TestingPath(name), []byte(content), 0o644)
 }
 
+// ReadDeployment reads the project's deployment.md. Returns "" if the
+// file doesn't exist.
+func ReadDeployment(name string) (string, error) {
+	data, err := os.ReadFile(DeploymentPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WriteDeployment writes content to the project's deployment.md.
+func WriteDeployment(name, content string) error {
+	dir := ProjectDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(DeploymentPath(name), []byte(content), 0o644)
+}
+
 // SetAutomation flips the automation toggle and/or cooldown for a
 // project. Pass cooldownMinutes < 0 to leave the existing value in
 // place (use case: enable/disable without retyping the cooldown).
@@ -344,7 +380,7 @@ func ListAutomationEnabled() ([]*Project, error) {
 // HeaderForRepo returns a project-context header to prepend to any
 // prompt for an operation rooted at `repo`. Empty string if the repo
 // isn't a member of any project, or if the project has no
-// non-trivial context.md / testing.md to share.
+// non-trivial context.md / testing.md / deployment.md to share.
 //
 // The header carries everything an AI consumer (operator, chat) needs
 // to act with project-wide awareness:
@@ -354,11 +390,13 @@ func ListAutomationEnabled() ([]*Project, error) {
 //   - the project's context.md (architecture / conventions / state)
 //   - the project's testing.md (local env SOP — start order, services,
 //     hardware hookups; consulted before doing local verification)
+//   - the project's deployment.md (runtime environment and log
+//     retrieval methods; consulted by PM operators for health checks)
 //
-// Both context and testing sections are emitted only when non-empty,
-// so a project with neither doc won't generate a noisy "_(empty)_"
-// header. The returned string ends with `\n---\n\n` so a caller can
-// concatenate it directly in front of an existing system prompt.
+// All three sections are emitted only when non-empty, so a project
+// with no docs won't generate a noisy "_(empty)_" header. The
+// returned string ends with `\n---\n\n` so a caller can concatenate
+// it directly in front of an existing system prompt.
 func HeaderForRepo(repo string) string {
 	p, err := FindProjectByRepo(repo)
 	if err != nil || p == nil {
@@ -366,7 +404,8 @@ func HeaderForRepo(repo string) string {
 	}
 	ctx, _ := ReadContext(p.Name)
 	testing, _ := ReadTesting(p.Name)
-	if strings.TrimSpace(ctx) == "" && strings.TrimSpace(testing) == "" {
+	deployment, _ := ReadDeployment(p.Name)
+	if strings.TrimSpace(ctx) == "" && strings.TrimSpace(testing) == "" && strings.TrimSpace(deployment) == "" {
 		return ""
 	}
 
@@ -383,6 +422,12 @@ func HeaderForRepo(repo string) string {
 		fmt.Fprintf(&b, "order, services, hardware/serial hookups. Consult this before\n")
 		fmt.Fprintf(&b, "running local verification of code changes._\n\n")
 		fmt.Fprintf(&b, "%s\n\n", testing)
+	}
+	if strings.TrimSpace(deployment) != "" {
+		fmt.Fprintf(&b, "## Deployment environment (deployment.md)\n\n")
+		fmt.Fprintf(&b, "_Runtime environment details and log retrieval methods.\n")
+		fmt.Fprintf(&b, "Consult this when diagnosing runtime health or fetching logs._\n\n")
+		fmt.Fprintf(&b, "%s\n\n", deployment)
 	}
 	b.WriteString("---\n\n")
 	return b.String()

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -165,5 +166,96 @@ func TestReadWriteContext(t *testing.T) {
 	}
 	if content != "# My Project\nOverview here." {
 		t.Errorf("ReadContext = %q", content)
+	}
+}
+
+func TestCreateCreatesDeploymentMd(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	if _, err := Create("deploy-test"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := os.Stat(DeploymentPath("deploy-test")); err != nil {
+		t.Errorf("deployment.md not created: %v", err)
+	}
+}
+
+func TestReadWriteDeployment(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("dep-rw")
+	content, err := ReadDeployment("dep-rw")
+	if err != nil {
+		t.Fatalf("ReadDeployment on empty file: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected empty, got %q", content)
+	}
+
+	want := "# Deployment\n\n## Environments\n\nproduction: VPS"
+	if err := WriteDeployment("dep-rw", want); err != nil {
+		t.Fatalf("WriteDeployment: %v", err)
+	}
+	got, err := ReadDeployment("dep-rw")
+	if err != nil {
+		t.Fatalf("ReadDeployment: %v", err)
+	}
+	if got != want {
+		t.Errorf("ReadDeployment = %q, want %q", got, want)
+	}
+}
+
+func TestReadDeploymentMissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	// No project created — file doesn't exist; should return "" not error.
+	content, err := ReadDeployment("nonexistent")
+	if err != nil {
+		t.Fatalf("ReadDeployment on missing file: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected empty string, got %q", content)
+	}
+}
+
+func TestHeaderForRepoWithDeployment(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("hdr-proj")
+	AddRepo("hdr-proj", "owner/repo")
+
+	// Only deployment.md populated — header should still be emitted.
+	WriteDeployment("hdr-proj", "# Deployment\n\nproduction: VPS")
+	header := HeaderForRepo("owner/repo")
+	if header == "" {
+		t.Fatal("expected non-empty header when deployment.md is set")
+	}
+	if !strings.Contains(header, "## Deployment environment (deployment.md)") {
+		t.Errorf("header missing deployment section:\n%s", header)
+	}
+	if !strings.Contains(header, "production: VPS") {
+		t.Errorf("header missing deployment content:\n%s", header)
+	}
+}
+
+func TestHeaderForRepoDeploymentAbsent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("hdr-no-deploy")
+	AddRepo("hdr-no-deploy", "owner/repo2")
+
+	// Only context.md populated; deployment.md empty → no deployment section.
+	WriteContext("hdr-no-deploy", "# Overview")
+	header := HeaderForRepo("owner/repo2")
+	if strings.Contains(header, "deployment") {
+		t.Errorf("header should not contain deployment section when deployment.md is empty:\n%s", header)
+	}
+	if !strings.Contains(header, "## Project overview (context.md)") {
+		t.Errorf("header missing context section:\n%s", header)
 	}
 }

--- a/project-skills/pm-health-check/SKILL.md
+++ b/project-skills/pm-health-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm-health-check
-description: "Project-level PM operator that audits each repo's CLAUDE.md and the project's context.md / testing.md against a 12-dimension rubric, then proposes concrete updates the user can apply with one click."
+description: "Project-level PM operator that audits each repo's CLAUDE.md and the project's context.md / testing.md / deployment.md against a 12-dimension rubric, then proposes concrete updates the user can apply with one click."
 project_operator:
   trigger: manual
   outcomes: ["healthy", "changes-proposed"]
@@ -15,6 +15,7 @@ You do **not** run any tools. You produce text only. The runner owns all VCS sid
 - **Project name**
 - **Project context.md** — current full content (may be empty)
 - **Project testing.md** — current full content (may be empty)
+- **Project deployment.md** — current full content (may be empty)
 - For **each repo** in the project:
   - Repo identifier (e.g. `owner/name`)
   - Repo local path (so you can reason about layout if relevant)
@@ -54,6 +55,11 @@ For `testing.md` (local SOP), check whether it covers:
 - Required env vars / credentials
 - How to run an end-to-end smoke test that touches multiple repos
 
+For `deployment.md` (runtime environment SOP), check whether it covers:
+- Named environments (production, staging, etc.) with type and address
+- At least one log retrieval method (SSH, local file, systemd, or equivalent)
+- Key health indicators to watch (error rates, timeouts, rate limits, etc.)
+
 ## Decide what to update
 
 For each **repo CLAUDE.md**:
@@ -63,6 +69,7 @@ For each **repo CLAUDE.md**:
 For the **project-level files**:
 - If aggregating repos reveals facts that should be in `context.md` but aren't (e.g., a new repo, a renamed component, a documented collaboration pattern in a repo's CLAUDE.md that isn't reflected at the project level) → propose an updated `context.md`.
 - If a repo's testing section reveals SOP changes (new service, new prerequisite) → propose an updated `testing.md`.
+- If deployment topology or log retrieval methods are known but `deployment.md` is empty or missing key environments → propose an updated `deployment.md`.
 - Otherwise leave them alone.
 
 ### Update style
@@ -83,6 +90,7 @@ Your stdout is parsed by the runner. Structure:
 - `<repo-id>` — …
 - Project context.md — <one sentence>
 - Project testing.md — <one sentence>
+- Project deployment.md — <one sentence>
 
 ## Proposed changes
 
@@ -96,6 +104,10 @@ Your stdout is parsed by the runner. Structure:
 
 <!-- clawflow:propose target=project path=testing.md action=update -->
 <full proposed testing.md content>
+<!-- clawflow:propose-end -->
+
+<!-- clawflow:propose target=project path=deployment.md action=update -->
+<full proposed deployment.md content>
 <!-- clawflow:propose-end -->
 
 <!-- clawflow:project-outcome=changes-proposed -->


### PR DESCRIPTION
Fixes #55

## What changed

**`internal/project/project.go`**
- Added `DeploymentPath(name)` — returns `~/.clawflow/projects/<name>/deployment.md`
- Added `ReadDeployment(name)` — reads deployment.md, returns "" if absent (mirrors `ReadTesting`)
- Added `WriteDeployment(name, content)` — writes deployment.md (mirrors `WriteTesting`)
- Updated `Create()` — now touches an empty `deployment.md` alongside context.md and testing.md
- Updated `HeaderForRepo()` — injects a `## Deployment environment (deployment.md)` section when the file is non-empty; the empty-check now covers all three docs

**`internal/project/project_test.go`**
- `TestCreateCreatesDeploymentMd` — verifies deployment.md is created on project init
- `TestReadWriteDeployment` — round-trip read/write including empty-file baseline
- `TestReadDeploymentMissingFile` — confirms missing file returns "" not an error
- `TestHeaderForRepoWithDeployment` — header emitted and contains deployment section when file is populated
- `TestHeaderForRepoDeploymentAbsent` — deployment section absent when file is empty

**`project-skills/pm-health-check/SKILL.md`**
- Added deployment.md to the Inputs list
- Added a Deployment project-level dimension (environments, log retrieval, health indicators)
- Added deployment.md to the health summary output format
- Added a `clawflow:propose target=project path=deployment.md` block to the output contract

## Testing

All 13 tests in `internal/project` pass; full `go test ./...` is green.