### PR TITLE
feat: extend PM prompt with deployment log inspection and issue filing budget

### DIFF
--- a/internal/chat/project_pm.go
+++ b/internal/chat/project_pm.go
@@ -74,7 +74,7 @@ type PMPRRow struct {
 // is mid-flight on it), and PM must not duplicate its own prior
 // comments/label-changes (idempotence is the PM's responsibility,
 // enforced via prompt — cooldown gives it room to mean something).
-func BuildProjectPMContext(name, contextMD string, repos []PMRepoDigest) string {
+func BuildProjectPMContext(name, contextMD, deploymentMD string, repos []PMRepoDigest) string {
 	var b strings.Builder
 
 	fmt.Fprintln(&b, "# Project Manager Auto-Wake")
@@ -95,6 +95,40 @@ func BuildProjectPMContext(name, contextMD string, repos []PMRepoDigest) string 
 	} else {
 		fmt.Fprintln(&b, contextMD)
 	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Deployment & runtime health")
+	fmt.Fprintln(&b)
+	if strings.TrimSpace(deploymentMD) == "" {
+		fmt.Fprintln(&b, "_(deployment.md not found — skip log inspection and proceed with issue-tracker-only triage.)_")
+	} else {
+		fmt.Fprintln(&b, deploymentMD)
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "### Log inspection instructions")
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "Before triaging the backlog, fetch recent runtime logs using the")
+		fmt.Fprintln(&b, "commands described above. Use Bash to execute them. Analyze for:")
+		fmt.Fprintln(&b, "- Repeated errors (same pattern 3+ times)")
+		fmt.Fprintln(&b, "- Operator failures (`agent-failed` triggers)")
+		fmt.Fprintln(&b, "- Rate limit or timeout patterns")
+		fmt.Fprintln(&b, "- Unexpected panics or crashes")
+		fmt.Fprintln(&b)
+		fmt.Fprintln(&b, "If SSH/remote access fails, note it and proceed with issue-tracker-only")
+		fmt.Fprintln(&b, "triage. Do NOT retry indefinitely on unreachable hosts.")
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, "## Issue filing budget")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Each wake you may file **AT MOST 2 new issues**. Prioritize by:")
+	fmt.Fprintln(&b, "1. Production-breaking errors (from deployment logs)")
+	fmt.Fprintln(&b, "2. Recurring failures (same error pattern 3+ times)")
+	fmt.Fprintln(&b, "3. Performance degradation")
+	fmt.Fprintln(&b, "4. Missing coverage / stale backlog items")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "If you see more than 2 problems, file the top 2 and note the rest in a")
+	fmt.Fprintln(&b, "single \"backlog observation\" comment on the most relevant existing issue.")
+	fmt.Fprintln(&b, "They will be picked up next wake.")
 	fmt.Fprintln(&b)
 
 	fmt.Fprintln(&b, "## Snapshot at wake time")
@@ -141,7 +175,12 @@ func BuildProjectPMContext(name, contextMD string, repos []PMRepoDigest) string 
 
 	fmt.Fprintln(&b, `## Your job
 
-Triage the backlog so it stays actionable. Common moves:
+Triage the backlog so it stays actionable. If deployment.md was
+provided above, start by inspecting runtime logs (see "Log inspection
+instructions") — production errors take priority over static backlog
+work. Then proceed with the moves below.
+
+Common moves:
 
 **File new issues** when work is concrete, valuable, and not tracked:
 - You grep the codebase and find a class of bug or missing coverage.

--- a/internal/chat/project_test.go
+++ b/internal/chat/project_test.go
@@ -133,6 +133,62 @@ func TestBuildProjectChatContext(t *testing.T) {
 	}
 }
 
+func TestBuildProjectPMContext_WithDeployment(t *testing.T) {
+	repos := []PMRepoDigest{
+		{Name: "owner/api", OpenIssues: []PMIssueRow{{Number: 1, Title: "crash on startup", Labels: []string{"bug"}}}},
+	}
+	deploymentMD := "## Logs\n\n```bash\nssh prod 'journalctl -u myapp -n 200'\n```"
+
+	prompt := BuildProjectPMContext("my-proj", "# Context\n\nSome overview.", deploymentMD, repos)
+
+	// deployment section present
+	if !containsStr(prompt, "Deployment & runtime health") {
+		t.Error("missing 'Deployment & runtime health' section")
+	}
+	if !containsStr(prompt, "journalctl") {
+		t.Error("missing deployment.md content in prompt")
+	}
+	if !containsStr(prompt, "Log inspection instructions") {
+		t.Error("missing 'Log inspection instructions' subsection")
+	}
+	if !containsStr(prompt, "Repeated errors") {
+		t.Error("missing log analysis guidance")
+	}
+	// filing budget present
+	if !containsStr(prompt, "AT MOST 2 new issues") {
+		t.Error("missing issue filing budget cap")
+	}
+	if !containsStr(prompt, "Production-breaking errors") {
+		t.Error("missing filing budget prioritization")
+	}
+	// log-driven triage instruction in "Your job"
+	if !containsStr(prompt, "start by inspecting runtime logs") {
+		t.Error("missing log-first triage instruction in 'Your job'")
+	}
+	// project name attribution
+	if !containsStr(prompt, "my-proj") {
+		t.Error("missing project name")
+	}
+}
+
+func TestBuildProjectPMContext_NoDeployment(t *testing.T) {
+	repos := []PMRepoDigest{}
+
+	prompt := BuildProjectPMContext("empty-proj", "", "", repos)
+
+	// deployment section still present but with fallback message
+	if !containsStr(prompt, "Deployment & runtime health") {
+		t.Error("missing 'Deployment & runtime health' section even when empty")
+	}
+	if !containsStr(prompt, "deployment.md not found") {
+		t.Error("missing fallback message when deployment.md is absent")
+	}
+	// filing budget always present
+	if !containsStr(prompt, "AT MOST 2 new issues") {
+		t.Error("missing issue filing budget even without deployment.md")
+	}
+}
+
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -81,6 +81,16 @@ func TestingPath(name string) string {
 	return filepath.Join(ProjectDir(name), "testing.md")
 }
 
+// DeploymentPath returns the deployment.md path for a named project.
+//
+// deployment.md describes how to inspect the project's runtime health:
+// log retrieval commands (SSH, kubectl, docker logs, etc.), key metrics
+// endpoints, and any other commands the PM should run to assess the
+// live system before triaging the backlog.
+func DeploymentPath(name string) string {
+	return filepath.Join(ProjectDir(name), "deployment.md")
+}
+
 // Create creates a new project with the given name.
 func Create(name string) (*Project, error) {
 	if strings.TrimSpace(name) == "" {
@@ -273,6 +283,31 @@ func WriteTesting(name, content string) error {
 		return err
 	}
 	return os.WriteFile(TestingPath(name), []byte(content), 0o644)
+}
+
+// ReadDeployment reads the project's deployment.md. Returns "" if the
+// file doesn't exist (not an error — the user may not have created it yet).
+//
+// deployment.md contains commands the PM uses to inspect runtime health:
+// log retrieval, metrics endpoints, SSH/kubectl invocations, etc.
+func ReadDeployment(name string) (string, error) {
+	data, err := os.ReadFile(DeploymentPath(name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return string(data), nil
+}
+
+// WriteDeployment writes content to the project's deployment.md.
+func WriteDeployment(name, content string) error {
+	dir := ProjectDir(name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(DeploymentPath(name), []byte(content), 0o644)
 }
 
 // SetAutomation flips the automation toggle and/or cooldown for a

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -151,6 +151,35 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestReadWriteDeployment(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("deploy-test")
+
+	// deployment.md does not exist yet — should return "" without error
+	content, err := ReadDeployment("deploy-test")
+	if err != nil {
+		t.Fatalf("ReadDeployment on missing file: %v", err)
+	}
+	if content != "" {
+		t.Errorf("ReadDeployment on missing file = %q, want empty", content)
+	}
+
+	// write and read back
+	body := "## Logs\n\nssh prod 'journalctl -u app -n 200'\n"
+	if err := WriteDeployment("deploy-test", body); err != nil {
+		t.Fatalf("WriteDeployment: %v", err)
+	}
+	got, err := ReadDeployment("deploy-test")
+	if err != nil {
+		t.Fatalf("ReadDeployment after write: %v", err)
+	}
+	if got != body {
+		t.Errorf("ReadDeployment = %q, want %q", got, body)
+	}
+}
+
 func TestReadWriteContext(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)

--- a/internal/projectpm/schedule.go
+++ b/internal/projectpm/schedule.go
@@ -136,8 +136,9 @@ func wake(ctx context.Context, p *project.Project, cfg *config.Config, creds *co
 
 	digests := buildDigests(p, cfg, creds)
 	contextMD, _ := project.ReadContext(p.Name)
+	deploymentMD, _ := project.ReadDeployment(p.Name)
 
-	prompt := chat.BuildProjectPMContext(p.Name, contextMD, digests)
+	prompt := chat.BuildProjectPMContext(p.Name, contextMD, deploymentMD, digests)
 	model := creds.EffectiveOperatorModel()
 	workdir := project.ProjectDir(p.Name)
 


### PR DESCRIPTION
Fixes #56

## What changed

**`internal/project/project.go`**
- Added `DeploymentPath()` — returns `~/.clawflow/projects/<name>/deployment.md`
- Added `ReadDeployment()` — reads deployment.md, returns "" if absent (not an error)
- Added `WriteDeployment()` — writes deployment.md

**`internal/chat/project_pm.go`**
- `BuildProjectPMContext` now accepts a `deploymentMD string` parameter
- Injects a new **"Deployment & runtime health"** section: when non-empty it renders the deployment.md content plus log inspection instructions (what patterns to look for, graceful degradation on SSH failure); when empty it shows a fallback note and skips to issue-tracker-only triage
- Injects a new **"Issue filing budget"** section: caps new issues at 2 per wake with a prioritized list and a "note the rest as a backlog observation" escape hatch
- Updates **"Your job"** to direct the PM to inspect runtime logs first when deployment.md is present

**`internal/projectpm/schedule.go`**
- `wake()` now calls `project.ReadDeployment(p.Name)` and passes the result to `BuildProjectPMContext`

## Tests
- `TestBuildProjectPMContext_WithDeployment` — verifies all new sections appear when deploymentMD is non-empty
- `TestBuildProjectPMContext_NoDeployment` — verifies fallback message and budget section appear when deploymentMD is empty
- `TestReadWriteDeployment` — verifies round-trip and missing-file behaviour

## Notes
- The 2-issue cap is enforced via prompt, not code. If strict mechanical enforcement is needed later, a post-execution count check in schedule.go can be added.
- deployment.md commands run with the same OS privileges as the ClawFlow process — worth documenting for users who author that file.