### PR TITLE
fix: add agent-running to labels_excluded in all built-in skills

### DIFF
--- a/skills/classify/SKILL.md
+++ b/skills/classify/SKILL.md
@@ -15,6 +15,7 @@ operator:
       - "agent-failed"
       - "agent-mentioned"
       - "agent-replied"
+      - "agent-running"
   outcomes: ["bug", "feat", "question"]
 ---
 

--- a/skills/evaluate-bug/SKILL.md
+++ b/skills/evaluate-bug/SKILL.md
@@ -5,7 +5,7 @@ operator:
   trigger:
     target: "issue"
     labels_required: ["bug"]
-    labels_excluded: ["agent-evaluated", "agent-skipped", "agent-failed"]
+    labels_excluded: ["agent-evaluated", "agent-skipped", "agent-failed", "agent-running"]
   outcomes: ["agent-evaluated", "agent-skipped"]
 ---
 

--- a/skills/evaluate-feat/SKILL.md
+++ b/skills/evaluate-feat/SKILL.md
@@ -5,7 +5,7 @@ operator:
   trigger:
     target: "issue"
     labels_required: ["feat"]
-    labels_excluded: ["agent-evaluated", "agent-skipped", "agent-failed"]
+    labels_excluded: ["agent-evaluated", "agent-skipped", "agent-failed", "agent-running"]
   outcomes: ["agent-evaluated", "agent-skipped"]
 ---
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ operator:
   trigger:
     target: "issue"
     labels_required: ["ready-for-agent"]
-    labels_excluded: ["agent-implemented", "agent-failed"]
+    labels_excluded: ["agent-implemented", "agent-skipped", "agent-failed", "agent-running"]
   outcomes: ["agent-implemented", "agent-failed", "agent-skipped"]
 ---
 

--- a/skills/reply-comment/SKILL.md
+++ b/skills/reply-comment/SKILL.md
@@ -5,7 +5,7 @@ operator:
   trigger:
     target: "issue"
     labels_required: ["agent-mentioned"]
-    labels_excluded: ["agent-replied", "agent-failed"]
+    labels_excluded: ["agent-replied", "agent-skipped", "agent-failed", "agent-running"]
   outcomes: ["agent-replied"]
 ---
 

--- a/skills/reply-question/SKILL.md
+++ b/skills/reply-question/SKILL.md
@@ -5,7 +5,7 @@ operator:
   trigger:
     target: "issue"
     labels_required: ["question"]
-    labels_excluded: ["agent-replied", "agent-failed"]
+    labels_excluded: ["agent-replied", "agent-skipped", "agent-failed", "agent-running"]
   lock_label: "agent-running"
   outcomes: ["agent-replied", "agent-skipped"]
 ---


### PR DESCRIPTION
Fixes #59\n\nAdds `agent-running` to the `labels_excluded` frontmatter in all six built-in skills, closing the label-level concurrency guard gap.\n\n**Skills updated:**\n- `skills/evaluate-bug/SKILL.md`\n- `skills/evaluate-feat/SKILL.md`\n- `skills/implement/SKILL.md`\n- `skills/classify/SKILL.md`\n- `skills/reply-comment/SKILL.md`\n- `skills/reply-question/SKILL.md`\n\nWithout this exclusion, a second `clawflow run` (or concurrent worker) could dispatch an operator against an issue that already has `agent-running` present, bypassing the distributed lock. The in-process mutex and filesystem lockfiles only guard within a single machine; the label-level exclusion is the only cross-machine guard.\n\nAll Go tests pass.