### PR TITLE
fix: add labels_required_any OR semantics; fix feature label silent skip

### DIFF
--- a/internal/operator/matcher.go
+++ b/internal/operator/matcher.go
@@ -51,6 +51,18 @@ func MatchesWithReason(sub *Subject, op *Operator) (bool, string) {
 			return false, fmt.Sprintf("missing required label %q", req)
 		}
 	}
+	if len(op.Trigger.LabelsRequiredAny) > 0 {
+		found := false
+		for _, req := range op.Trigger.LabelsRequiredAny {
+			if _, ok := labelSet[req]; ok {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, fmt.Sprintf("none of the required-any labels present %v", op.Trigger.LabelsRequiredAny)
+		}
+	}
 	for _, ex := range op.Trigger.LabelsExcluded {
 		if _, ok := labelSet[ex]; ok {
 			return false, fmt.Sprintf("excluded label %q present", ex)

--- a/internal/operator/matcher_test.go
+++ b/internal/operator/matcher_test.go
@@ -90,6 +90,56 @@ func TestMatches_RequiredAndExcludedCombined(t *testing.T) {
 	}
 }
 
+func TestMatches_LabelsRequiredAny(t *testing.T) {
+	op := &Operator{Trigger: Trigger{
+		Target:            "issue",
+		LabelsRequiredAny: []string{"feat", "feature"},
+	}}
+	cases := map[string]struct {
+		labels []string
+		want   bool
+	}{
+		"first alias present":  {[]string{"feat"}, true},
+		"second alias present": {[]string{"feature"}, true},
+		"both present":         {[]string{"feat", "feature"}, true},
+		"with extras":          {[]string{"feature", "p1"}, true},
+		"neither present":      {[]string{"bug"}, false},
+		"empty":                {[]string{}, false},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := &Subject{Labels: c.labels}
+			if got := Matches(s, op); got != c.want {
+				t.Errorf("labels=%v: got %v want %v", c.labels, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMatches_RequiredAndRequiredAnyCombined(t *testing.T) {
+	// Both LabelsRequired (AND) and LabelsRequiredAny (OR) must pass.
+	op := &Operator{Trigger: Trigger{
+		Target:            "issue",
+		LabelsRequired:    []string{"ready-for-agent"},
+		LabelsRequiredAny: []string{"feat", "feature"},
+	}}
+	// Both conditions satisfied
+	if !Matches(&Subject{Labels: []string{"ready-for-agent", "feat"}}, op) {
+		t.Error("ready-for-agent + feat should match")
+	}
+	if !Matches(&Subject{Labels: []string{"ready-for-agent", "feature"}}, op) {
+		t.Error("ready-for-agent + feature should match")
+	}
+	// Missing the AND label
+	if Matches(&Subject{Labels: []string{"feat"}}, op) {
+		t.Error("feat without ready-for-agent should not match")
+	}
+	// Missing the OR label
+	if Matches(&Subject{Labels: []string{"ready-for-agent", "bug"}}, op) {
+		t.Error("ready-for-agent without feat/feature should not match")
+	}
+}
+
 func TestMatches_NoRulesAlwaysMatches(t *testing.T) {
 	op := &Operator{Trigger: Trigger{Target: "issue"}} // no required, no excluded
 	if !Matches(&Subject{Labels: []string{}}, op) {

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -41,7 +41,13 @@ type Operator struct {
 type Trigger struct {
 	Target         string
 	LabelsRequired []string
-	LabelsExcluded []string
+	// LabelsRequiredAny uses OR semantics: at least one of the listed labels
+	// must be present on the subject. Useful for alias groups like
+	// ["feat", "feature"] where either label should trigger the operator.
+	// LabelsRequired (AND) and LabelsRequiredAny (OR) are evaluated
+	// independently; both must pass when both are non-empty.
+	LabelsRequiredAny []string
+	LabelsExcluded    []string
 }
 
 // frontmatter mirrors the YAML shape inside the SKILL.md.
@@ -50,9 +56,10 @@ type frontmatter struct {
 	Description string `yaml:"description"`
 	Operator    struct {
 		Trigger struct {
-			Target         string   `yaml:"target"`
-			LabelsRequired []string `yaml:"labels_required"`
-			LabelsExcluded []string `yaml:"labels_excluded"`
+			Target            string   `yaml:"target"`
+			LabelsRequired    []string `yaml:"labels_required"`
+			LabelsRequiredAny []string `yaml:"labels_required_any"`
+			LabelsExcluded    []string `yaml:"labels_excluded"`
 		} `yaml:"trigger"`
 		LockLabel string   `yaml:"lock_label"`
 		Outcomes  []string `yaml:"outcomes"`
@@ -95,9 +102,10 @@ func Parse(data []byte, source string) (*Operator, error) {
 		Name:        fm.Name,
 		Description: fm.Description,
 		Trigger: Trigger{
-			Target:         tgt,
-			LabelsRequired: fm.Operator.Trigger.LabelsRequired,
-			LabelsExcluded: fm.Operator.Trigger.LabelsExcluded,
+			Target:            tgt,
+			LabelsRequired:    fm.Operator.Trigger.LabelsRequired,
+			LabelsRequiredAny: fm.Operator.Trigger.LabelsRequiredAny,
+			LabelsExcluded:    fm.Operator.Trigger.LabelsExcluded,
 		},
 		LockLabel: fm.Operator.LockLabel,
 		Outcomes:  fm.Operator.Outcomes,

--- a/skills/classify/SKILL.md
+++ b/skills/classify/SKILL.md
@@ -8,6 +8,7 @@ operator:
     labels_excluded:
       - "bug"
       - "feat"
+      - "feature"
       - "question"
       - "agent-evaluated"
       - "agent-skipped"

--- a/skills/evaluate-feat/SKILL.md
+++ b/skills/evaluate-feat/SKILL.md
@@ -4,7 +4,8 @@ description: "Evaluate a feat-labeled issue for clarity, scope, and architectura
 operator:
   trigger:
     target: "issue"
-    labels_required: ["feat"]
+    labels_required: []
+    labels_required_any: ["feat", "feature"]
     labels_excluded: ["agent-evaluated", "agent-skipped", "agent-failed"]
   outcomes: ["agent-evaluated", "agent-skipped"]
 ---


### PR DESCRIPTION
Fixes #62

## What changed

Added a new  trigger field with OR semantics to the operator schema. When set, at least one of the listed labels must be present on the subject — as opposed to  which requires ALL listed labels (AND semantics). Both fields are evaluated independently and both must pass when both are non-empty.

## Files changed

- **internal/operator/operator.go** — Added  to  struct and the YAML frontmatter struct; wired through in .
- **internal/operator/matcher.go** — Added OR-semantics check after the existing AND check; emits a descriptive reason string on miss for  traces.
- **internal/operator/matcher_test.go** — Two new test functions:  (6 cases) and  (4 cases).
- **skills/evaluate-feat/SKILL.md** — Switched from  to  so issues labeled either way trigger evaluation.
- **skills/classify/SKILL.md** — Added  to  so classify does not re-fire on issues already carrying the human-applied  label.

## Testing

All existing tests pass; two new test functions added covering the OR path and the combined AND+OR path. Full suite: `go test ./...` — all green.