### PR TITLE
feat: web dashboard support for deployment.md (display + AI generate)

### DIFF
--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -201,6 +201,8 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/project/remove-repo", api.HandleProjectRemoveRepo)
 			mux.HandleFunc("/api/project/generate-context", api.HandleProjectGenerateContext)
 			mux.HandleFunc("/api/project/generate-context/status", api.HandleProjectGenerateContextStatus)
+			mux.HandleFunc("/api/project/generate-deployment", api.HandleProjectGenerateDeployment)
+			mux.HandleFunc("/api/project/generate-deployment/status", api.HandleProjectGenerateDeploymentStatus)
 			mux.HandleFunc("/api/project/automation", api.HandleProjectAutomation)
 			mux.HandleFunc("/api/project/get", api.HandleProjectGet)
 			mux.HandleFunc("/api/project/health-check/run", api.HandleProjectHealthCheckRun)

--- a/internal/api/project.go
+++ b/internal/api/project.go
@@ -295,6 +295,151 @@ func HandleProjectGenerateContextStatus(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, 200, persisted)
 }
 
+// --- generate-deployment ---
+
+// generateDeploymentJobStorePath is the on-disk JSON for the most recent
+// completed generate-deployment run, stored alongside deployment.md.
+func generateDeploymentJobStorePath(projectName string) string {
+	return filepath.Join(project.ProjectDir(projectName), "generate-deployment.json")
+}
+
+var (
+	generateDeploymentJobsMu sync.Mutex
+	generateDeploymentJobs   = map[string]*generateJob{}
+)
+
+// HandleProjectGenerateDeployment kicks off deployment.md generation for a
+// project and returns immediately. Mirrors HandleProjectGenerateContext —
+// same async job pattern, same polling contract, same 202/409 semantics.
+// The AI prompt is built by projectgen.GenerateDeployment.
+func HandleProjectGenerateDeployment(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req projectGenerateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	name := strings.TrimSpace(req.Project)
+	if name == "" {
+		writeJSON(w, 400, map[string]string{"error": "project is required"})
+		return
+	}
+
+	generateDeploymentJobsMu.Lock()
+	if existing, ok := generateDeploymentJobs[name]; ok && existing.Status == "running" {
+		generateDeploymentJobsMu.Unlock()
+		writeJSON(w, 409, map[string]any{
+			"error": "generation already running for this project",
+			"job":   existing,
+		})
+		return
+	}
+	job := &generateJob{Status: "running", StartedAt: time.Now()}
+	generateDeploymentJobs[name] = job
+	generateDeploymentJobsMu.Unlock()
+
+	model := req.Model
+	go func() {
+		_, err := projectgen.GenerateDeployment(name, model)
+		generateDeploymentJobsMu.Lock()
+		job.EndedAt = time.Now()
+		if err != nil {
+			job.Status = "error"
+			job.Error = err.Error()
+		} else {
+			job.Status = "done"
+			_ = snapshot.WriteProjects()
+		}
+		snapshotJob := *job
+		generateDeploymentJobsMu.Unlock()
+		if err := saveDeploymentJob(name, &snapshotJob); err != nil {
+			fmt.Fprintf(os.Stderr, "[generate-deployment] %s: persist failed: %v\n", name, err)
+		}
+	}()
+
+	writeJSON(w, 202, map[string]any{
+		"status": "accepted",
+		"job":    job,
+	})
+}
+
+// HandleProjectGenerateDeploymentStatus reports the current job state
+// for `?project=X`. Returns 404 when no job has been recorded — the
+// frontend treats 404 as "idle".
+func HandleProjectGenerateDeploymentStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	name := strings.TrimSpace(r.URL.Query().Get("project"))
+	if name == "" {
+		writeJSON(w, 400, map[string]string{"error": "project is required"})
+		return
+	}
+	generateDeploymentJobsMu.Lock()
+	job, ok := generateDeploymentJobs[name]
+	generateDeploymentJobsMu.Unlock()
+	if ok {
+		writeJSON(w, 200, job)
+		return
+	}
+	persisted, err := loadDeploymentJob(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[generate-deployment] %s: load persisted failed: %v\n", name, err)
+		writeJSON(w, 404, map[string]string{"status": "idle"})
+		return
+	}
+	if persisted == nil {
+		writeJSON(w, 404, map[string]string{"status": "idle"})
+		return
+	}
+	generateDeploymentJobsMu.Lock()
+	if _, raced := generateDeploymentJobs[name]; !raced {
+		generateDeploymentJobs[name] = persisted
+	}
+	generateDeploymentJobsMu.Unlock()
+	writeJSON(w, 200, persisted)
+}
+
+func saveDeploymentJob(projectName string, job *generateJob) error {
+	path := generateDeploymentJobStorePath(projectName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(job, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+func loadDeploymentJob(projectName string) (*generateJob, error) {
+	path := generateDeploymentJobStorePath(projectName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var job generateJob
+	if err := json.Unmarshal(data, &job); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return &job, nil
+}
+
 // HandleProjectGet returns the LIVE view of a single project by
 // reading project.yaml + context.md + testing.md fresh from disk.
 //
@@ -327,11 +472,13 @@ func HandleProjectGet(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, _ := project.ReadContext(name)
 	testing, _ := project.ReadTesting(name)
+	deployment, _ := project.ReadDeployment(name)
 	view := snapshot.ProjectView{
-		Name:    p.Name,
-		Repos:   p.Repos,
-		Context: ctx,
-		Testing: testing,
+		Name:       p.Name,
+		Repos:      p.Repos,
+		Context:    ctx,
+		Testing:    testing,
+		Deployment: deployment,
 		Automation: snapshot.ProjectAutomationView{
 			Enabled:         p.Automation.Enabled,
 			CooldownMinutes: p.Automation.CooldownMinutes,

--- a/internal/projectgen/generate.go
+++ b/internal/projectgen/generate.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/zhoushoujianwork/clawflow/internal/claude"
@@ -82,7 +83,166 @@ func Generate(name, model, instructions string) (string, error) {
 	return content, nil
 }
 
-// sanitizeOutput cleans up `claude -p` output that disobeyed the
+// GenerateDeployment scans the project's member repos for CI workflow files
+// and existing context.md, builds a prompt, runs `claude -p`, writes the
+// result to deployment.md, and returns the content that was written.
+// `model` may be empty to use the default chat model from credentials.
+func GenerateDeployment(name, model string) (string, error) {
+	p, err := project.Get(name)
+	if err != nil {
+		return "", err
+	}
+	if len(p.Repos) == 0 {
+		return "", fmt.Errorf("project %q has no repos — add one first", name)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return "", fmt.Errorf("load config: %w", err)
+	}
+
+	prompt, scanned := buildDeploymentPrompt(name, p.Repos, cfg)
+	if scanned == 0 {
+		return "", fmt.Errorf("no repos with local_path configured — set local_path in config for at least one member repo")
+	}
+
+	if model == "" {
+		creds, _ := config.LoadCredentials()
+		model = creds.EffectiveChatModel()
+	}
+
+	bin := claude.Resolve()
+	args := []string{
+		"--model", model,
+		"--print",
+		"-p", prompt,
+	}
+	cmd := exec.Command(bin, args...)
+	creds, _ := config.LoadCredentials()
+	apiKey, baseURL := "", ""
+	if creds != nil {
+		apiKey, baseURL = creds.ClaudeAPIKey, creds.ClaudeBaseURL
+	}
+	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
+	cmd.Stderr = os.Stderr
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("claude generate failed: %w", err)
+	}
+
+	content := sanitizeOutput(string(output))
+	if content == "" {
+		return "", fmt.Errorf("claude returned empty output")
+	}
+
+	if err := project.WriteDeployment(name, content); err != nil {
+		return "", err
+	}
+	return content, nil
+}
+
+// buildDeploymentPrompt constructs the prompt for deployment.md generation.
+// It scans each repo's .github/workflows/ directory for CI configs and
+// includes the existing context.md for deployment-related context.
+func buildDeploymentPrompt(name string, repos []string, cfg *config.Config) (string, int) {
+	var parts []string
+	parts = append(parts, fmt.Sprintf("# Project: %s\n\n", name))
+	parts = append(parts, fmt.Sprintf("This project contains %d repositories:\n", len(repos)))
+
+	scanned := 0
+	for _, repoName := range repos {
+		repoCfg, ok := cfg.Repos[repoName]
+		localPath := ""
+		if ok {
+			localPath = repoCfg.LocalPath
+		}
+		if localPath == "" {
+			parts = append(parts, fmt.Sprintf("\n## %s\n(no local_path configured — skipped)\n", repoName))
+			continue
+		}
+
+		parts = append(parts, fmt.Sprintf("\n## %s\nLocal path: %s\n", repoName, localPath))
+
+		// Scan CI workflow files for deployment clues (release jobs, deploy
+		// steps, Docker/k8s references, cron schedules, etc.)
+		workflowDir := filepath.Join(localPath, ".github", "workflows")
+		if entries, err := os.ReadDir(workflowDir); err == nil {
+			for _, e := range entries {
+				if e.IsDir() || (!strings.HasSuffix(e.Name(), ".yml") && !strings.HasSuffix(e.Name(), ".yaml")) {
+					continue
+				}
+				data, err := os.ReadFile(filepath.Join(workflowDir, e.Name()))
+				if err != nil {
+					continue
+				}
+				content := string(data)
+				if len(content) > 2000 {
+					content = content[:2000] + "\n... (truncated)"
+				}
+				parts = append(parts, fmt.Sprintf("\n### CI: .github/workflows/%s\n```yaml\n%s\n```\n", e.Name(), content))
+			}
+		}
+
+		// Also check for docker-compose, Dockerfile, k8s manifests at root
+		for _, deployFile := range []string{"docker-compose.yml", "docker-compose.yaml", "Dockerfile"} {
+			data, err := os.ReadFile(filepath.Join(localPath, deployFile))
+			if err != nil {
+				continue
+			}
+			content := string(data)
+			if len(content) > 1500 {
+				content = content[:1500] + "\n... (truncated)"
+			}
+			parts = append(parts, fmt.Sprintf("\n### %s\n```\n%s\n```\n", deployFile, content))
+		}
+
+		scanned++
+	}
+
+	// Include existing context.md for deployment-related references
+	existing, _ := project.ReadContext(name)
+	if strings.TrimSpace(existing) != "" {
+		parts = append(parts, "\n---\n\n## Existing context.md (for deployment context)\n\n```\n")
+		if len(existing) > 3000 {
+			existing = existing[:3000] + "\n... (truncated)"
+		}
+		parts = append(parts, existing)
+		if !strings.HasSuffix(existing, "\n") {
+			parts = append(parts, "\n")
+		}
+		parts = append(parts, "```\n")
+	}
+
+	parts = append(parts, "\n---\n\n"+
+		"Based on the repository information above, produce a deployment.md document in Markdown.\n"+
+		"This document will be used by an AI project manager to inspect runtime health, retrieve logs,\n"+
+		"and assess the live system. Include the following sections:\n\n"+
+		"# Deployment\n\n"+
+		"## 环境\n"+
+		"| 名称 | 类型 | 地址 |\n"+
+		"|------|------|------|\n"+
+		"(fill in from CI/CD config if available, otherwise leave as placeholders)\n\n"+
+		"## 部署方式\n"+
+		"Describe the deployment method inferred from CI workflows (e.g. GitHub Actions release, Docker, k8s, systemd, cron).\n"+
+		"If unclear, provide a template the user should fill in.\n\n"+
+		"## 日志获取\n"+
+		"### 方式: (infer from deployment type — docker logs / kubectl logs / journalctl / SSH)\n"+
+		"- command: `<fill in>`\n\n"+
+		"## 健康指标关注点\n"+
+		"- List key metrics or endpoints to check (infer from the codebase if possible)\n\n"+
+		"OUTPUT FORMAT — strict:\n"+
+		"- Output ONLY the Markdown document body.\n"+
+		"- Do NOT prepend any preamble like \"Here is the document:\" or \"I have generated...\".\n"+
+		"- Do NOT wrap the document in a ``` fence.\n"+
+		"- Start your response with \"# Deployment\" and end with the last section of the document.\n"+
+		"- Use placeholder text like \"<待配置>\" for values the user must fill in.",
+	)
+
+	return strings.Join(parts, ""), scanned
+}
+
+
 // "Markdown only, no preamble" instruction. Two common failure modes:
 //
 //  1. Preamble like "Here is the updated context.md:" before the doc

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1025,6 +1025,7 @@ type ProjectView struct {
 	Repos      []string              `json:"repos"`
 	Context    string                `json:"context_md,omitempty"`
 	Testing    string                `json:"testing_md,omitempty"`
+	Deployment string                `json:"deployment_md,omitempty"`
 	Automation ProjectAutomationView `json:"automation"`
 	CreatedAt  string                `json:"created_at"`
 	UpdatedAt  string                `json:"updated_at"`
@@ -1053,11 +1054,13 @@ func WriteProjects() error {
 	for _, p := range projects {
 		ctx, _ := project.ReadContext(p.Name)
 		testing, _ := project.ReadTesting(p.Name)
+		deployment, _ := project.ReadDeployment(p.Name)
 		views = append(views, ProjectView{
-			Name:    p.Name,
-			Repos:   p.Repos,
-			Context: ctx,
-			Testing: testing,
+			Name:       p.Name,
+			Repos:      p.Repos,
+			Context:    ctx,
+			Testing:    testing,
+			Deployment: deployment,
 			Automation: ProjectAutomationView{
 				Enabled:         p.Automation.Enabled,
 				CooldownMinutes: p.Automation.CooldownMinutes,

--- a/web/src/routes/_app.projects.$name.tsx
+++ b/web/src/routes/_app.projects.$name.tsx
@@ -26,6 +26,7 @@ interface Project {
   created_at?: string
   context_md?: string
   testing_md?: string
+  deployment_md?: string
   automation?: ProjectAutomation
 }
 
@@ -135,6 +136,12 @@ function ProjectDetail() {
   // their own "no content yet" panel and ignore this state.
   const [contextOpen, setContextOpen] = useState(false)
   const [testingOpen, setTestingOpen] = useState(false)
+  const [deploymentOpen, setDeploymentOpen] = useState(false)
+
+  // Generate deployment state — mirrors the context generation pattern.
+  const [generatingDeployment, setGeneratingDeployment] = useState(false)
+  const [generateDeploymentError, setGenerateDeploymentError] = useState<string | null>(null)
+  const deploymentPollTimerRef = useRef<number | null>(null)
 
   // Cross-repo backlog state — same data sources the per-repo page
   // reads, just filtered to project.repos here. The shared IssueList
@@ -208,7 +215,17 @@ function ProjectDetail() {
         }
       })
       .catch(() => { /* idle */ })
-    return () => { stopPolling() }
+    // Same resume-on-navigate check for deployment generation.
+    fetch(`/api/project/generate-deployment/status?project=${encodeURIComponent(name)}`, { cache: 'no-store' })
+      .then(r => r.json().catch(() => ({})).then(d => ({ status: r.status, body: d })))
+      .then(({ status, body }) => {
+        if (status === 200 && body.status === 'running') {
+          setGeneratingDeployment(true)
+          startDeploymentPolling()
+        }
+      })
+      .catch(() => { /* idle */ })
+    return () => { stopPolling(); stopDeploymentPolling() }
   }, [name])
 
   function fetchAvailableRepos() {
@@ -348,6 +365,66 @@ function ProjectDetail() {
     if (pollTimerRef.current !== null) {
       window.clearInterval(pollTimerRef.current)
       pollTimerRef.current = null
+    }
+  }
+
+  function startDeploymentPolling() {
+    if (deploymentPollTimerRef.current !== null) return
+    const tick = async () => {
+      try {
+        const r = await fetch(`/api/project/generate-deployment/status?project=${encodeURIComponent(name)}`, { cache: 'no-store' })
+        const d = await r.json().catch(() => ({}))
+        if (r.status === 404 || d.status === 'idle') {
+          stopDeploymentPolling()
+          setGeneratingDeployment(false)
+          return
+        }
+        if (d.status === 'running') return
+        if (d.status === 'done') {
+          stopDeploymentPolling()
+          setGeneratingDeployment(false)
+          fetchProject()
+          return
+        }
+        if (d.status === 'error') {
+          stopDeploymentPolling()
+          setGeneratingDeployment(false)
+          setGenerateDeploymentError(d.error || 'generation failed')
+          return
+        }
+      } catch {
+        // network blip — keep polling
+      }
+    }
+    void tick()
+    deploymentPollTimerRef.current = window.setInterval(tick, 2000)
+  }
+
+  function stopDeploymentPolling() {
+    if (deploymentPollTimerRef.current !== null) {
+      window.clearInterval(deploymentPollTimerRef.current)
+      deploymentPollTimerRef.current = null
+    }
+  }
+
+  async function handleGenerateDeployment() {
+    setGenerateDeploymentError(null)
+    setGeneratingDeployment(true)
+    try {
+      const r = await fetch('/api/project/generate-deployment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project: name }),
+      })
+      const d = await r.json().catch(() => ({}))
+      if (r.status === 202 || r.status === 409) {
+        startDeploymentPolling()
+        return
+      }
+      throw new Error(d.error || `HTTP ${r.status}`)
+    } catch (e) {
+      setGeneratingDeployment(false)
+      setGenerateDeploymentError(e instanceof Error ? e.message : 'Unknown error')
     }
   }
 
@@ -768,6 +845,91 @@ function ProjectDetail() {
                   <p className="text-xs text-muted-foreground">
                     This is a runbook (startup steps), not a list of test cases.
                   </p>
+                </div>
+              </>
+            )}
+          </section>
+
+          {/* Deployment.md — collapsible. Same pattern as Context and
+              Testing above. Has an AI Generate button in the empty state
+              (mirrors context.md's Initialize button) because deployment
+              config can be inferred from CI workflows and context.md. */}
+          <section className="mb-6">
+            {generateDeploymentError && (
+              <div className="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2 dark:bg-red-950/30 dark:border-red-900">
+                {generateDeploymentError}
+              </div>
+            )}
+            {project.deployment_md ? (
+              <div className="bg-card border border-border rounded-xl overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setDeploymentOpen(o => !o)}
+                  className="w-full flex items-center gap-2 px-4 py-3 hover:bg-secondary/30 transition-colors text-left"
+                  aria-expanded={deploymentOpen}
+                >
+                  {deploymentOpen ? <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" /> : <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0" />}
+                  <span className="text-sm font-semibold text-foreground">Deployment</span>
+                  <span className="text-xs text-muted-foreground tabular-nums shrink-0">
+                    {(project.deployment_md.length / 1024).toFixed(1)}kb
+                  </span>
+                  {!deploymentOpen && (
+                    <span className="text-xs text-muted-foreground truncate">
+                      · {previewMD(project.deployment_md)}
+                    </span>
+                  )}
+                  <span className="ml-auto text-xs text-muted-foreground inline-flex items-center gap-1 shrink-0">
+                    <MessageSquare className="w-3 h-3" />
+                    Edit via chat
+                  </span>
+                </button>
+                {deploymentOpen && (
+                  <div className="px-4 pb-4 pt-0 border-t border-border">
+                    <Markdown>{project.deployment_md}</Markdown>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center justify-between mb-2">
+                  <h2 className="text-sm font-semibold text-foreground">Deployment</h2>
+                  <span className="text-xs text-muted-foreground">
+                    Runtime environment, log retrieval, health indicators
+                  </span>
+                </div>
+                <div className="bg-card border border-border rounded-xl p-6 text-center space-y-3">
+                  <p className="text-sm text-muted-foreground">
+                    No <code className="px-1 py-0.5 bg-secondary rounded text-xs font-mono">deployment.md</code> yet.
+                    Describe how to inspect the runtime (logs, metrics, SSH/kubectl) so the PM can assess live health.
+                  </p>
+                  <div className="flex items-center justify-center gap-2 flex-wrap">
+                    <button
+                      type="button"
+                      onClick={handleGenerateDeployment}
+                      disabled={generatingDeployment || !project.repos?.length}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
+                        'bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed',
+                      )}
+                    >
+                      {generatingDeployment ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Sparkles className="w-3.5 h-3.5" />}
+                      {generatingDeployment ? 'Generating…' : 'Generate deployment.md'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => chatDrawer.open({ project: project.name, action: 'chat' })}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors border border-border text-muted-foreground hover:text-foreground hover:bg-secondary/50"
+                    >
+                      <MessageSquare className="w-3.5 h-3.5" />
+                      Draft via chat
+                    </button>
+                  </div>
+                  {!project.repos?.length && (
+                    <p className="text-xs text-muted-foreground">Add at least one repo first.</p>
+                  )}
+                  {generatingDeployment && (
+                    <p className="text-xs text-muted-foreground">{GENERATE_HINT}</p>
+                  )}
                 </div>
               </>
             )}


### PR DESCRIPTION
Fixes #66

## What changed

**Snapshot layer** (internal/snapshot/snapshot.go)
- Added Deployment field (deployment_md) to ProjectView
- WriteProjects() now calls project.ReadDeployment() to populate the field

**API layer** (internal/api/project.go)
- HandleProjectGet now reads and returns deployment_md in the live project response
- Added HandleProjectGenerateDeployment — async POST endpoint that kicks off projectgen.GenerateDeployment in a background goroutine (202/409 semantics, same as generate-context)
- Added HandleProjectGenerateDeploymentStatus — GET polling endpoint; persists job state to generate-deployment.json for cross-restart visibility

**Projectgen** (internal/projectgen/generate.go)
- Added GenerateDeployment(name, model string) — scans .github/workflows/, docker-compose.yml, Dockerfile, and existing context.md to build a structured prompt, calls claude -p, and writes the result to deployment.md

**Router** (cmd/clawflow/commands/web.go)
- Registered /api/project/generate-deployment and /api/project/generate-deployment/status

**Web frontend** (web/src/routes/_app.projects.$name.tsx)
- Added deployment_md to the Project interface
- Added deploymentOpen, generatingDeployment, generateDeploymentError, deploymentPollTimerRef state
- Added startDeploymentPolling, stopDeploymentPolling, handleGenerateDeployment functions
- useEffect now resumes an in-flight deployment generation job on page navigate-back, and cleans up both poll timers on unmount
- Collapsible Deployment card rendered between testing.md and member repos — matches the context/testing pattern exactly; empty state shows a Generate deployment.md button (AI) and a Draft via chat button

## Testing
- go test ./internal/snapshot/... ./internal/api/... ./internal/project/... — all pass
- Build: go build ./... — clean