### PR TITLE
fix: use atomic temp-then-rename in writeJSON to prevent partial writes

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1171,5 +1171,21 @@ func writeJSON(path string, v any) error {
 	if err != nil {
 		return fmt.Errorf("marshal %s: %w", path, err)
 	}
-	return os.WriteFile(path, data, 0o644)
+	// Write to a temp file in the same directory, then rename atomically.
+	// os.Rename on the same filesystem is atomic on POSIX — the target
+	// either has the old content or the new content, never a partial write.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op if rename succeeded
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	return os.Rename(tmpName, path)
 }


### PR DESCRIPTION
Fixes #71

## What changed

Replaced the  call in  () with an atomic write-to-temp-then-rename pattern.

 truncates the target file before writing new content. A process kill, OOM, or power loss between truncate and the final write leaves a partial/empty JSON file — permanently corrupting the sole persistence layer for the dashboard.

The new pattern:
1. Marshals JSON to  (unchanged)
2. Creates a temp file in the same directory via 
3. Writes the full content to the temp file
4. Closes the temp file (flushes kernel buffers)
5. Renames the temp file to the target path — atomic on POSIX same-filesystem

A  cleans up the temp file if any step before rename fails. All 14+ snapshot files written through  are protected automatically with no API changes.

## Testing

-  — clean
- ok  	github.com/zhoushoujianwork/clawflow/internal/snapshot	0.424s — 24/24 tests pass