### PR TITLE
fix: recover outcome marker from intermediate assistant turns

### DIFF
--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -128,6 +128,14 @@ type streamEnvelope struct {
 // tool_use (e.g. the model emits its answer, then calls one more tool to
 // touch labels and ends). Without the fallback, a trailing tool call
 // silently wipes out the operator's output.
+//
+// Multi-turn outcome recovery: when a long session emits the outcome marker
+// in an intermediate assistant turn and then produces a short wrap-up in the
+// final turn, the "result" event (or lastAssistantText fallback) contains no
+// marker. In that case we return lastAssistantTextWithMarker — the last
+// assistant turn that contained a valid outcome marker — so the runner can
+// still parse the outcome and fire post-automation. A warning is printed to
+// stderr so the prompt can be improved upstream.
 func parseClaudeStream(r io.Reader, events io.Writer) (string, error) {
 	sc := bufio.NewScanner(r)
 	// Claude stream-json lines can carry full assistant messages; bump the
@@ -135,7 +143,8 @@ func parseClaudeStream(r io.Reader, events io.Writer) (string, error) {
 	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 
 	var finalResult string
-	var lastAssistantText string // last assistant turn that emitted any text
+	var lastAssistantText string            // last assistant turn that emitted any text
+	var lastAssistantTextWithMarker string  // last assistant turn that contained an outcome marker
 	printedAnyDelta := false
 
 	for sc.Scan() {
@@ -179,6 +188,14 @@ func parseClaudeStream(r io.Reader, events io.Writer) (string, error) {
 			}
 			if turn != "" {
 				lastAssistantText = turn
+				// Track the last turn that contains an outcome marker
+				// separately. This lets us recover when the marker appears
+				// in an intermediate turn and the final turn is a short
+				// wrap-up with no marker (see multi-turn outcome recovery
+				// comment above).
+				if outcomeRE.MatchString(turn) {
+					lastAssistantTextWithMarker = turn
+				}
 			}
 		case env.Type == "stream_event" &&
 			env.Event.Type == "content_block_delta" &&
@@ -207,6 +224,15 @@ func parseClaudeStream(r io.Reader, events io.Writer) (string, error) {
 	}
 	if finalResult == "" {
 		finalResult = lastAssistantText
+	}
+	// If the resolved result has no outcome marker but an earlier assistant
+	// turn did, fall back to that turn. This handles the multi-turn case
+	// where the model emits the full structured output (including the marker)
+	// in turn N and then produces a brief wrap-up in turn N+1.
+	if !outcomeRE.MatchString(finalResult) && lastAssistantTextWithMarker != "" {
+		fmt.Fprintf(os.Stderr,
+			"  ⚠ outcome marker found in intermediate assistant turn but not in final result — using intermediate turn (consider tightening the operator prompt)\n")
+		finalResult = lastAssistantTextWithMarker
 	}
 	return finalResult, nil
 }

--- a/internal/operator/claude_test.go
+++ b/internal/operator/claude_test.go
@@ -1,0 +1,160 @@
+package operator
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// buildAssistantEvent returns a stream-json line for an "assistant" event
+// carrying a single text content block.
+func buildAssistantEvent(text string) string {
+	type contentBlock struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type message struct {
+		Content []contentBlock `json:"content"`
+	}
+	type event struct {
+		Type    string  `json:"type"`
+		Message message `json:"message"`
+	}
+	e := event{
+		Type: "assistant",
+		Message: message{
+			Content: []contentBlock{{Type: "text", Text: text}},
+		},
+	}
+	b, _ := json.Marshal(e)
+	return string(b)
+}
+
+// buildResultEvent returns a stream-json line for a "result" event.
+func buildResultEvent(result string) string {
+	type event struct {
+		Type   string `json:"type"`
+		Result string `json:"result"`
+	}
+	b, _ := json.Marshal(event{Type: "result", Result: result})
+	return string(b)
+}
+
+// TestParseClaudeStream_MarkerInFinalTurn is the happy path: marker is in the
+// final result, no fallback needed.
+func TestParseClaudeStream_MarkerInFinalTurn(t *testing.T) {
+	body := "## Eval\n\nRepro: 8/10\n\n<!-- clawflow:outcome=agent-evaluated -->\n"
+	stream := strings.Join([]string{
+		buildAssistantEvent(body),
+		buildResultEvent(body),
+	}, "\n") + "\n"
+
+	got, err := parseClaudeStream(strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != body {
+		t.Errorf("got %q, want %q", got, body)
+	}
+	// Outcome must be parseable from the returned text.
+	label, _ := parseOutcome(got)
+	if label != "agent-evaluated" {
+		t.Errorf("parseOutcome label = %q, want %q", label, "agent-evaluated")
+	}
+}
+
+// TestParseClaudeStream_MarkerInIntermediateTurn is the bug scenario from
+// issue #75: the outcome marker appears in an intermediate assistant turn;
+// the final "result" event carries only a short wrap-up with no marker.
+// parseClaudeStream must return the intermediate turn so the runner can
+// extract the outcome label.
+func TestParseClaudeStream_MarkerInIntermediateTurn(t *testing.T) {
+	fullEval := "## Eval\n\nRepro: 8/10\n\n<!-- clawflow:outcome=agent-evaluated -->\n"
+	wrapUp := "All done — the evaluation was completed successfully earlier."
+
+	stream := strings.Join([]string{
+		buildAssistantEvent(fullEval), // turn N: full output with marker
+		buildAssistantEvent(wrapUp),   // turn N+1: short wrap-up, no marker
+		buildResultEvent(wrapUp),      // result event mirrors the final turn
+	}, "\n") + "\n"
+
+	got, err := parseClaudeStream(strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The returned text must contain the outcome marker so the runner can act.
+	label, _ := parseOutcome(got)
+	if label != "agent-evaluated" {
+		t.Errorf("parseOutcome label = %q, want %q — intermediate turn marker was not recovered", label, "agent-evaluated")
+	}
+}
+
+// TestParseClaudeStream_MarkerInIntermediateTurn_EmptyResult covers the
+// variant where the "result" event is empty (pure tool_use final turn) and
+// the marker lives in an earlier assistant turn.
+func TestParseClaudeStream_MarkerInIntermediateTurn_EmptyResult(t *testing.T) {
+	fullEval := "## Eval\n\nRepro: 9/10\n\n<!-- clawflow:outcome=agent-evaluated -->\n"
+
+	stream := strings.Join([]string{
+		buildAssistantEvent(fullEval), // turn N: full output with marker
+		buildResultEvent(""),          // empty result (trailing tool_use)
+	}, "\n") + "\n"
+
+	got, err := parseClaudeStream(strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	label, _ := parseOutcome(got)
+	if label != "agent-evaluated" {
+		t.Errorf("parseOutcome label = %q, want %q — intermediate turn marker was not recovered", label, "agent-evaluated")
+	}
+}
+
+// TestParseClaudeStream_NoMarkerAnywhere verifies that when no turn contains
+// a marker, the function still returns the final result text unchanged (no
+// regression on the existing no-marker path).
+func TestParseClaudeStream_NoMarkerAnywhere(t *testing.T) {
+	wrapUp := "All done."
+	stream := strings.Join([]string{
+		buildAssistantEvent("Some intermediate text."),
+		buildAssistantEvent(wrapUp),
+		buildResultEvent(wrapUp),
+	}, "\n") + "\n"
+
+	got, err := parseClaudeStream(strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != wrapUp {
+		t.Errorf("got %q, want %q", got, wrapUp)
+	}
+	label, _ := parseOutcome(got)
+	if label != "" {
+		t.Errorf("expected no label, got %q", label)
+	}
+}
+
+// TestParseClaudeStream_MultipleMarkerTurns_LastWins verifies that when
+// multiple intermediate turns contain markers, the last one wins (consistent
+// with parseOutcome's "last wins" contract).
+func TestParseClaudeStream_MultipleMarkerTurns_LastWins(t *testing.T) {
+	turn1 := "Draft\n<!-- clawflow:outcome=agent-skipped -->\n"
+	turn2 := "Final eval\n<!-- clawflow:outcome=agent-evaluated -->\n"
+	wrapUp := "Summary."
+
+	stream := strings.Join([]string{
+		buildAssistantEvent(turn1),
+		buildAssistantEvent(turn2),
+		buildAssistantEvent(wrapUp),
+		buildResultEvent(wrapUp),
+	}, "\n") + "\n"
+
+	got, err := parseClaudeStream(strings.NewReader(stream), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	label, _ := parseOutcome(got)
+	if label != "agent-evaluated" {
+		t.Errorf("last marker turn should win; got label %q", label)
+	}
+}


### PR DESCRIPTION
Fixes #75

## What changed

In `parseClaudeStream` (`internal/operator/claude.go`), added a second tracking variable `lastAssistantTextWithMarker` alongside the existing `lastAssistantText`. After the stream is fully consumed and the final result is resolved, if that result contains no outcome marker but an earlier assistant turn did, the function substitutes the intermediate turn and emits a stderr warning.

The fast path (marker in the final turn / result event) is completely unchanged — zero overhead for the common case.

## Why here, not in runner.go

The issue suggested a post-hoc `scanEventsForOutcome` fallback that re-reads `events.jsonl` after `RunClaude` returns. The in-stream approach is cleaner: no file I/O after the fact, no need to thread the events file path into `RunOptions`, and the fix lives entirely within the layer that already owns stream parsing.

## Tests added (`internal/operator/claude_test.go`)

- `TestParseClaudeStream_MarkerInFinalTurn` — happy path, no regression
- `TestParseClaudeStream_MarkerInIntermediateTurn` — exact bug scenario from #75
- `TestParseClaudeStream_MarkerInIntermediateTurn_EmptyResult` — variant with empty result event (trailing tool_use)
- `TestParseClaudeStream_NoMarkerAnywhere` — no marker in any turn, returns final result unchanged
- `TestParseClaudeStream_MultipleMarkerTurns_LastWins` — last marker-bearing turn wins, consistent with `parseOutcome`

All existing tests pass (`go test ./...`).