### PR TITLE
test: add unit tests for shellEscape, appleScriptQuote, detectVSCodeAppName

### DIFF
--- a/internal/api/chat_spawn_test.go
+++ b/internal/api/chat_spawn_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"testing"
+)
+
+// TestShellEscape verifies that shellEscape produces correct POSIX
+// single-quoted strings for a range of inputs, including the '"'"'
+// dance for embedded single quotes.
+func TestShellEscape(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "''",
+		},
+		{
+			name:  "plain word",
+			input: "hello",
+			want:  "'hello'",
+		},
+		{
+			name:  "string with spaces",
+			input: "hello world",
+			want:  "'hello world'",
+		},
+		{
+			name:  "single quote in string",
+			input: "it's",
+			want:  "'it'\"'\"'s'",
+		},
+		{
+			name:  "repo name with single quote",
+			input: "owner/it's-a-repo",
+			want:  "'owner/it'\"'\"'s-a-repo'",
+		},
+		{
+			name:  "double quote in string",
+			input: `a"b`,
+			want:  `'a"b'`,
+		},
+		{
+			name:  "backtick in string",
+			input: "a`b",
+			want:  "'a`b'",
+		},
+		{
+			name:  "dollar sign",
+			input: "$HOME",
+			want:  "'$HOME'",
+		},
+		{
+			name:  "newline in string",
+			input: "line\nbreak",
+			want:  "'line\nbreak'",
+		},
+		{
+			name:  "multiple single quotes",
+			input: "it's a 'test'",
+			want:  "'it'\"'\"'s a '\"'\"'test'\"'\"''",
+		},
+		{
+			name:  "path with spaces",
+			input: "/usr/local/bin/my app",
+			want:  "'/usr/local/bin/my app'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shellEscape(tc.input)
+			if got != tc.want {
+				t.Errorf("shellEscape(%q)\n  got  %q\n  want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAppleScriptQuote verifies that appleScriptQuote produces correct
+// AppleScript double-quoted string literals, escaping backslashes and
+// double quotes.
+func TestAppleScriptQuote(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  `""`,
+		},
+		{
+			name:  "plain word",
+			input: "hello",
+			want:  `"hello"`,
+		},
+		{
+			name:  "string with spaces",
+			input: "hello world",
+			want:  `"hello world"`,
+		},
+		{
+			name:  "embedded double quote",
+			input: `say "hi"`,
+			want:  `"say \"hi\""`,
+		},
+		{
+			name:  "backslash",
+			input: `path\to`,
+			want:  `"path\\to"`,
+		},
+		{
+			name:  "backslash and double quote",
+			input: `a\"b`,
+			want:  `"a\\\"b"`,
+		},
+		{
+			name:  "newline — documented current behavior (literal newline, not escaped)",
+			input: "line\nbreak",
+			want:  "\"line\nbreak\"",
+		},
+		{
+			name:  "single quote — no escaping needed in AppleScript double-quoted strings",
+			input: "it's",
+			want:  `"it's"`,
+		},
+		{
+			name:  "app name with spaces",
+			input: "Visual Studio Code",
+			want:  `"Visual Studio Code"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := appleScriptQuote(tc.input)
+			if got != tc.want {
+				t.Errorf("appleScriptQuote(%q)\n  got  %q\n  want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDetectVSCodeAppName verifies the app-name detection heuristic
+// that maps a resolved binary path to the correct application name.
+func TestDetectVSCodeAppName(t *testing.T) {
+	tests := []struct {
+		name    string
+		codeBin string
+		want    string
+	}{
+		{
+			name:    "standard VS Code path",
+			codeBin: "/usr/local/bin/code",
+			want:    "Visual Studio Code",
+		},
+		{
+			name:    "Cursor path",
+			codeBin: "/Applications/Cursor.app/Contents/MacOS/cursor",
+			want:    "Cursor",
+		},
+		{
+			name:    "Qoder path",
+			codeBin: "/Applications/Qoder.app/Contents/MacOS/qoder",
+			want:    "Qoder",
+		},
+		{
+			name:    "VSCodium path",
+			codeBin: "/Applications/VSCodium.app/Contents/MacOS/vscodium",
+			want:    "VSCodium",
+		},
+		{
+			name:    "VS Code Insiders path",
+			codeBin: "/Applications/Visual Studio Code - Insiders.app/Contents/MacOS/code",
+			want:    "Visual Studio Code - Insiders",
+		},
+		{
+			name:    "unknown binary falls back to VS Code",
+			codeBin: "/usr/local/bin/myeditor",
+			want:    "Visual Studio Code",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectVSCodeAppName(tc.codeBin)
+			if got != tc.want {
+				t.Errorf("detectVSCodeAppName(%q)\n  got  %q\n  want %q", tc.codeBin, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #78

## What changed

Added `internal/api/chat_spawn_test.go` with 26 table-driven test cases covering the three pure functions in `chat_spawn.go` that had zero coverage:

- **`TestShellEscape`** (11 cases) — empty string, plain word, spaces, single quote (the `'"'"'` dance), repo name with single quote, double quote, backtick, `$` sign, newline, multiple single quotes, path with spaces.
- **`TestAppleScriptQuote`** (9 cases) — empty string, plain word, spaces, embedded double quote, backslash, backslash+quote combo, newline (documents current literal-newline behavior), single quote (no escaping needed), app name with spaces.
- **`TestDetectVSCodeAppName`** (6 cases) — standard VS Code, Cursor, Qoder, VSCodium, VS Code Insiders, unknown binary fallback.

## Notes

- `appleScriptQuote` does not escape newlines — the newline test documents this as current behavior rather than asserting it's correct. If a multi-line command is ever passed through this path, a follow-up fix would be needed.
- The platform-specific launcher functions (`openInTerminalMac`, `openInTerminalLinux`, etc.) require OS-level mocking and are out of scope for this PR per the issue.