### PR TITLE
feat: add configurable default IDE setting

### DIFF
--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -60,6 +60,7 @@ type settingsView struct {
 		GitlabCloneDir      string   `json:"gitlab_clone_dir,omitempty"`
 		GitLabURL           string   `json:"gitlab_url,omitempty"`
 		Terminal            string   `json:"terminal,omitempty"`
+		DefaultIDE          string   `json:"default_ide,omitempty"`
 	} `json:"global"`
 }
 
@@ -105,6 +106,7 @@ func HandleGetSettings(w http.ResponseWriter, r *http.Request) {
 		v.Global.GitLabURL = cfg.Settings.GitLabHosts[0]
 	}
 	v.Global.Terminal = cfg.Settings.Terminal
+	v.Global.DefaultIDE = cfg.Settings.DefaultIDE
 
 	writeJSON(w, 200, v)
 }
@@ -246,6 +248,7 @@ type globalUpdate struct {
 	GitlabCloneDir      *string `json:"gitlab_clone_dir,omitempty"`
 	GitLabURL           *string `json:"gitlab_url,omitempty"`
 	Terminal            *string `json:"terminal,omitempty"`
+	DefaultIDE          *string `json:"default_ide,omitempty"`
 }
 
 // HandleUpdateGlobalSettings handles POST /api/settings/global.
@@ -303,6 +306,9 @@ func HandleUpdateGlobalSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Terminal != nil {
 		cfg.Settings.Terminal = strings.TrimSpace(*req.Terminal)
+	}
+	if req.DefaultIDE != nil {
+		cfg.Settings.DefaultIDE = strings.TrimSpace(*req.DefaultIDE)
 	}
 	if err := cfg.Save(); err != nil {
 		writeErr(w, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,15 @@ type Settings struct {
 	//   custom path — any executable; invoked as `<path> -e <cmdLine>`
 	Terminal string `yaml:"terminal,omitempty"`
 
+	// DefaultIDE selects which IDE the dashboard's "Open in IDE" button
+	// uses. Supported values:
+	//   ""         / "vscode"          — VS Code (vscode://file/<path>)
+	//   "cursor"                       — Cursor (cursor://file/<path>)
+	//   "qoder"                        — Qoder (qoder://file/<path>)
+	//   "vscode-insiders"              — VS Code Insiders
+	// Empty/unset defaults to "vscode" for backward compatibility.
+	DefaultIDE string `yaml:"default_ide,omitempty"`
+
 	// BillingCycleDay is the day of month (1-28) when a billing period
 	// starts. Usage is aggregated into monthly periods aligned to this
 	// day. 0 or unset defaults to 1 (calendar month).
@@ -105,6 +114,23 @@ func (s *Settings) ResolveGitlabCloneDir() string {
 	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, "gitlab")
+}
+
+// ResolveIDEScheme returns the URI scheme prefix for the configured IDE.
+// The returned string is the full prefix up to and including "://file/",
+// ready to be concatenated with an absolute local path.
+// Unknown values fall back to the vscode scheme.
+func (s *Settings) ResolveIDEScheme() string {
+	switch s.DefaultIDE {
+	case "cursor":
+		return "cursor://file/"
+	case "qoder":
+		return "qoder://file/"
+	case "vscode-insiders":
+		return "vscode-insiders://file/"
+	default: // "", "vscode", or any unrecognised value
+		return "vscode://file/"
+	}
 }
 
 func expandHome(path string) string {

--- a/web/src/routes/_app.repos.index.tsx
+++ b/web/src/routes/_app.repos.index.tsx
@@ -50,6 +50,7 @@ function RepoList() {
 
   const [repos, setRepos] = useState<Repo[]>([])
   const [runs, setRuns] = useState<RunEntry[]>([])
+  const [ideScheme, setIdeScheme] = useState('vscode://file/')
   const [loading, setLoading] = useState(true)
   const [didApplyDefault, setDidApplyDefault] = useState(false)
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -63,9 +64,22 @@ function RepoList() {
       fetch('/data/runs.json', { cache: 'no-store' })
         .then(r => (r.ok ? r.json() : []))
         .catch(() => []),
-    ]).then(([rp, rn]) => {
+      fetch('/api/settings', { cache: 'no-store' })
+        .then(r => (r.ok ? r.json() : null))
+        .catch(() => null),
+    ]).then(([rp, rn, settings]) => {
       setRepos(Array.isArray(rp) ? rp : [])
       setRuns(Array.isArray(rn) ? rn : [])
+      if (settings?.global?.default_ide) {
+        const ide = settings.global.default_ide as string
+        const schemeMap: Record<string, string> = {
+          vscode: 'vscode://file/',
+          cursor: 'cursor://file/',
+          qoder: 'qoder://file/',
+          'vscode-insiders': 'vscode-insiders://file/',
+        }
+        setIdeScheme(schemeMap[ide] ?? 'vscode://file/')
+      }
       setLoading(false)
     })
   }, [])
@@ -309,8 +323,8 @@ function RepoList() {
                       </a>
                       {r.local_path && (
                         <a
-                          href={`qoder://file/${r.local_path}?windowId=_blank`}
-                          title={`Open in VS Code: ${r.local_path}`}
+                          href={`${ideScheme}${r.local_path}?windowId=_blank`}
+                          title={`Open in IDE: ${r.local_path}`}
                           className="inline-flex items-center text-muted-foreground hover:text-foreground shrink-0"
                         >
                           <FolderOpen className="w-3.5 h-3.5" />

--- a/web/src/routes/_app.settings.tsx
+++ b/web/src/routes/_app.settings.tsx
@@ -26,6 +26,7 @@ interface SettingsView {
     gitlab_clone_dir?: string
     gitlab_url?: string
     terminal?: string
+    default_ide?: string
   }
 }
 
@@ -496,6 +497,7 @@ function GlobalSection({
   const [glDir, setGlDir] = useState(view.gitlab_clone_dir ?? '')
   const [gitlabURL, setGitlabURL] = useState(view.gitlab_url ?? '')
   const [terminal, setTerminal] = useState(view.terminal ?? '')
+  const [defaultIDE, setDefaultIDE] = useState(view.default_ide ?? '')
   const [busy, setBusy] = useState(false)
   const [saveMsg, setSaveMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
@@ -510,6 +512,7 @@ function GlobalSection({
     setGlDir(view.gitlab_clone_dir ?? '')
     setGitlabURL(view.gitlab_url ?? '')
     setTerminal(view.terminal ?? '')
+    setDefaultIDE(view.default_ide ?? '')
   }, [view])
 
   const dirty =
@@ -521,7 +524,8 @@ function GlobalSection({
     ghDir !== (view.github_clone_dir ?? '') ||
     glDir !== (view.gitlab_clone_dir ?? '') ||
     gitlabURL !== (view.gitlab_url ?? '') ||
-    terminal !== (view.terminal ?? '')
+    terminal !== (view.terminal ?? '') ||
+    defaultIDE !== (view.default_ide ?? '')
 
   const save = () => {
     setBusy(true); setSaveMsg(null)
@@ -538,6 +542,7 @@ function GlobalSection({
         gitlab_clone_dir: glDir,
         gitlab_url: gitlabURL,
         terminal: terminal,
+        default_ide: defaultIDE,
       }),
     })
       .then(async r => {
@@ -598,6 +603,19 @@ function GlobalSection({
           <option value="">System default (Terminal.app / xterm)</option>
           <option value="vscode">VS Code (supports image paste)</option>
           <option value="iterm">iTerm2 (macOS)</option>
+        </select>
+      </Row>
+      <Row label="Default IDE" hint="IDE used by the 'Open in IDE' button on the repos list.">
+        <select
+          value={defaultIDE}
+          onChange={e => setDefaultIDE(e.target.value)}
+          className="flex-1 text-sm px-2 py-1 border border-border rounded bg-background"
+        >
+          <option value="">VS Code (default)</option>
+          <option value="vscode">VS Code</option>
+          <option value="cursor">Cursor</option>
+          <option value="qoder">Qoder</option>
+          <option value="vscode-insiders">VS Code Insiders</option>
         </select>
       </Row>
 


### PR DESCRIPTION
Fixes #80

## What changed

Added a `default_ide` setting so users can choose which IDE the repos list 'Open in IDE' button uses, instead of the previously hardcoded `qoder://` scheme.

### Supported IDEs

| IDE | URI Scheme |
|-----|-----------|
| VS Code (default) | `vscode://file/<path>?windowId=_blank` |
| Cursor | `cursor://file/<path>?windowId=_blank` |
| Qoder | `qoder://file/<path>?windowId=_blank` |
| VS Code Insiders | `vscode-insiders://file/<path>?windowId=_blank` |

### Files changed

- **`internal/config/config.go`** — Added `DefaultIDE string` field to `Settings` struct and `ResolveIDEScheme()` method that maps the value to the correct URI prefix. Empty/unset defaults to `vscode://` for backward compatibility.
- **`internal/api/settings.go`** — Exposed `default_ide` in `settingsView.Global`, added it to `globalUpdate` struct, and persisted it in `HandleUpdateGlobalSettings`.
- **`web/src/routes/_app.settings.tsx`** — Added `default_ide` to the `SettingsView` interface and a dropdown selector in `GlobalSection`, wired into the existing save flow.
- **`web/src/routes/_app.repos.index.tsx`** — Fetches `/api/settings` alongside repos/runs data, resolves the IDE scheme from `settings.global.default_ide`, and uses it to build the 'Open in IDE' href dynamically.

### Testing

- `go test ./...` — all pass
- `npm run build` — clean build, no TypeScript errors