### PR TITLE
fix: fall back to owner-repo path when flat clone name collides

### DIFF
--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -80,8 +80,25 @@ func EnsureLocalClone(cfg *config.Config, ownerRepo string, repoCfg config.Repo,
 			saveLocalPath(cfg, ownerRepo, candidate)
 			return candidate, nil
 		}
-		// Directory exists but is not the expected repo — don't clobber it.
-		return "", fmt.Errorf("directory %s exists but is not a clone of %s", candidate, ownerRepo)
+		// Name collision: the flat path is occupied by a different repo.
+		// Try a disambiguated path: <cloneBase>/<owner>-<repo>
+		// e.g. ~/github/daboluocc-bbclaw instead of ~/github/bbclaw
+		fallback := filepath.Join(cloneBase, strings.ReplaceAll(ownerRepo, "/", "-"))
+		if _, err := os.Stat(fallback); err == nil {
+			// Fallback path already exists — check if it's already the right clone.
+			if matchesRepo(fallback, ownerRepo, repoCfg) {
+				saveLocalPath(cfg, ownerRepo, fallback)
+				return fallback, nil
+			}
+			// Both flat and disambiguated paths are occupied by other repos.
+			return "", fmt.Errorf("directory %s exists but is not a clone of %s (also tried %s)", candidate, ownerRepo, fallback)
+		}
+		fmt.Fprintf(progress, "path %s is occupied by another repo, cloning %s to %s instead ...\n", candidate, ownerRepo, fallback)
+		if err := cloneRepo(ownerRepo, fallback, repoCfg, progress, token); err != nil {
+			return "", fmt.Errorf("auto-clone failed: %w", err)
+		}
+		saveLocalPath(cfg, ownerRepo, fallback)
+		return fallback, nil
 	}
 
 	fmt.Fprintf(progress, "local clone not found, cloning %s to %s ...\n", ownerRepo, candidate)
@@ -239,6 +256,8 @@ func normalizeRemoteURL(rawURL string) string {
 
 // DetectLocalClone checks if a local clone already exists for the given
 // ownerRepo at the expected path (based on platform clone dir settings).
+// Checks both the flat path (<cloneBase>/<repo>) and the disambiguated path
+// (<cloneBase>/<owner>-<repo>) that EnsureLocalClone falls back to on collision.
 // Returns the local path if found and verified, empty string otherwise.
 func DetectLocalClone(cfg *config.Config, ownerRepo string, repoCfg config.Repo) string {
 	cloneBase := cfg.Settings.ResolveGithubCloneDir()
@@ -250,12 +269,20 @@ func DetectLocalClone(cfg *config.Config, ownerRepo string, repoCfg config.Repo)
 	subPath := parts[len(parts)-1]
 	candidate := filepath.Join(cloneBase, subPath)
 
-	if _, err := os.Stat(candidate); err != nil {
-		return ""
+	if _, err := os.Stat(candidate); err == nil {
+		if matchesRepo(candidate, ownerRepo, repoCfg) {
+			return candidate
+		}
 	}
-	if matchesRepo(candidate, ownerRepo, repoCfg) {
-		return candidate
+
+	// Also check the disambiguated fallback path used when the flat name collides.
+	fallback := filepath.Join(cloneBase, strings.ReplaceAll(ownerRepo, "/", "-"))
+	if _, err := os.Stat(fallback); err == nil {
+		if matchesRepo(fallback, ownerRepo, repoCfg) {
+			return fallback
+		}
 	}
+
 	return ""
 }
 


### PR DESCRIPTION
Fixes #82

## What changed

When adding a repo whose trailing name (e.g. `bbclaw`) already exists at the flat clone path (`~/github/bbclaw`) but belongs to a *different* repository, `EnsureLocalClone` previously returned a hard error and rolled back the config entry entirely.

### New behaviour in `internal/clone/clone.go`

1. Flat path occupied by another repo → try the disambiguated path `<cloneBase>/<owner>-<repo>` (e.g. `~/github/daboluocc-bbclaw`).
2. Disambiguated path already exists and matches → reuse it (no clone needed).
3. Disambiguated path doesn't exist → clone there, save path to config.
4. Both paths occupied by foreign repos → return a clear error listing both paths tried.

`DetectLocalClone` is updated in parallel to probe the same fallback path, so the "already cloned" detection in `HandleListRemoteRepos` and `HandleAddRemoteRepo` stays consistent.

## Testing

All existing tests pass (`go test ./...`). No test files exist for the `clone` package; the change is a localised path-resolution fallback with no external side-effects beyond the new clone destination.