### PR TITLE
feat(sync): clawflow login Gist discovery/creation flow

### DIFF
--- a/cmd/clawflow/commands/login.go
+++ b/cmd/clawflow/commands/login.go
@@ -1,0 +1,174 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/vcs/github"
+)
+
+// NewLoginCmd returns the `clawflow login` command.
+//
+// Flow:
+//  1. Accept a GitHub token (arg or --token flag).
+//  2. Validate it against GET /user.
+//  3. Search the user's Gists for description="clawflow-config".
+//     - Found  → store Gist ID, pull config from Gist.
+//     - Not found → create a new private Gist, store its ID, push current config.
+//  4. Persist the token + Gist ID in credentials.yaml.
+func NewLoginCmd() *cobra.Command {
+	var tokenFlag string
+
+	cmd := &cobra.Command{
+		Use:   "login [gh-token]",
+		Short: "Authenticate and set up config Gist sync",
+		Long: `Saves your GitHub token and discovers (or creates) your private
+clawflow-config Gist for multi-machine config sync.
+
+Required token scopes: repo (full), read:org, gist
+
+On first login on a new machine the config is pulled from the existing Gist
+automatically. On first login ever a new private Gist is created.`,
+		Args:    cobra.MaximumNArgs(1),
+		Example: "  clawflow login ghp_xxxxxxxxxxxx\n  clawflow login --token ghp_xxxxxxxxxxxx",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			token := tokenFlag
+			if token == "" && len(args) > 0 {
+				token = args[0]
+			}
+			if token == "" {
+				// Fall back to already-stored token so `clawflow login` (no
+				// args) can re-run the Gist discovery without re-entering the
+				// token.
+				creds, _ := config.LoadCredentials()
+				if creds != nil {
+					token = creds.GHToken
+				}
+			}
+			if token == "" {
+				return fmt.Errorf("no token provided — pass it as an argument or use --token")
+			}
+
+			gh := github.New(token, "")
+
+			// 1. Validate token.
+			login, err := gh.GetAuthenticatedUser()
+			if err != nil {
+				return fmt.Errorf("token validation failed: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Authenticated as %s\n", login)
+
+			// 2. Load existing credentials (to preserve other fields).
+			creds, err := config.LoadCredentials()
+			if err != nil {
+				return fmt.Errorf("cannot load credentials: %w", err)
+			}
+			if creds == nil {
+				creds = &config.Credentials{}
+			}
+			creds.GHToken = token
+
+			// 3. Discover or create the sync Gist.
+			gistID, err := discoverOrCreateGist(gh, creds)
+			if err != nil {
+				return err
+			}
+			creds.GistID = gistID
+
+			// 4. Persist credentials.
+			if err := config.SaveCredentials(creds); err != nil {
+				return fmt.Errorf("cannot save credentials: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "Credentials saved to %s\n", config.CredentialsPath())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tokenFlag, "token", "", "GitHub personal access token")
+	return cmd
+}
+
+// discoverOrCreateGist finds the clawflow-config Gist or creates one.
+// It returns the Gist ID and handles the pull/push of config content.
+func discoverOrCreateGist(gh *github.Client, creds *config.Credentials) (string, error) {
+	// If we already have a stored Gist ID, verify it still exists.
+	if creds.GistID != "" {
+		gist, err := gh.GetGist(creds.GistID)
+		if err == nil && gist != nil {
+			fmt.Fprintf(os.Stderr, "Using existing config Gist (id: %s)\n", gist.ID)
+			return gist.ID, nil
+		}
+		// Gist gone (deleted externally) — fall through to search.
+		fmt.Fprintf(os.Stderr, "Stored Gist ID %s no longer accessible, searching...\n", creds.GistID)
+	}
+
+	// Search for an existing Gist with the canonical description.
+	gist, err := gh.FindGistByDescription(config.GistDescription)
+	if err != nil {
+		// Gist scope missing is a common mistake — surface a clear message.
+		if strings.Contains(err.Error(), "missing the 'gist' scope") {
+			return "", fmt.Errorf("%w\n\nAdd the 'gist' scope to your token at https://github.com/settings/tokens", err)
+		}
+		return "", fmt.Errorf("cannot search gists: %w", err)
+	}
+
+	if gist != nil {
+		// Found an existing Gist — pull config from it.
+		fmt.Fprintf(os.Stderr, "Found existing config Gist (id: %s), pulling...\n", gist.ID)
+		if err := pullConfigFromGist(gh, gist.ID); err != nil {
+			// Non-fatal: warn but don't abort login.
+			fmt.Fprintf(os.Stderr, "Warning: could not pull config from Gist: %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "Config pulled from Gist → %s\n", config.ConfigPath())
+		}
+		return gist.ID, nil
+	}
+
+	// No existing Gist — create one and push current local config.
+	fmt.Fprintf(os.Stderr, "No config Gist found, creating new private Gist...\n")
+	content, err := buildGistContent()
+	if err != nil {
+		// If there's no local config yet, seed with an empty placeholder.
+		content = "# clawflow config — managed by clawflow login\nrepos: {}\n"
+	}
+	newGist, err := gh.CreateGist(config.GistDescription, map[string]string{
+		config.GistConfigFilename: content,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "missing the 'gist' scope") {
+			return "", fmt.Errorf("%w\n\nAdd the 'gist' scope to your token at https://github.com/settings/tokens", err)
+		}
+		return "", fmt.Errorf("cannot create config Gist: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Created new config Gist (id: %s)\n", newGist.ID)
+	return newGist.ID, nil
+}
+
+// pullConfigFromGist fetches the Gist content and merges it into the local config.
+func pullConfigFromGist(gh *github.Client, gistID string) error {
+	gist, err := gh.GetGist(gistID)
+	if err != nil {
+		return err
+	}
+	f, ok := gist.Files[config.GistConfigFilename]
+	if !ok {
+		return fmt.Errorf("gist %s has no %s file", gistID, config.GistConfigFilename)
+	}
+	return config.ApplyGistConfig([]byte(f.Content))
+}
+
+// buildGistContent serialises the current local config for upload.
+func buildGistContent() (string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return "", err
+	}
+	b, err := config.MarshalForGist(cfg)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -24,6 +24,7 @@ entirely in VCS labels and comments. Run 'clawflow run' once, or schedule it.`,
 	// runs stay quiet enough to schedule via cron.
 	root.PersistentFlags().BoolVar(&Debug, "debug", false, "Print debug trace to stderr (matcher decisions, scan counts)")
 
+	root.AddCommand(NewLoginCmd())
 	root.AddCommand(NewRunCmd())
 	root.AddCommand(NewWebCmd())
 	root.AddCommand(NewChatCmd())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,11 @@ type Credentials struct {
 	GHToken     string `yaml:"gh_token,omitempty"`
 	GitLabToken string `yaml:"gitlab_token,omitempty"`
 
+	// GistID is the ID of the user's private "clawflow-config" GitHub Gist,
+	// discovered or created by `clawflow login`. Persisted here so subsequent
+	// sync operations skip the search step. Never synced to the Gist itself.
+	GistID string `yaml:"gist_id,omitempty"`
+
 	// ClaudeAPIKey, when set, overrides whatever auth the user's
 	// system claude would use (OAuth keychain, ~/.claude.json) by
 	// passing ANTHROPIC_API_KEY to every claude subprocess clawflow

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GistConfigFilename is the filename used inside the clawflow-config Gist.
+const GistConfigFilename = "config.yaml"
+
+// GistDescription is the Gist description used to identify the sync Gist.
+const GistDescription = "clawflow-config"
+
+// MarshalForGist serialises the config into YAML bytes suitable for storing
+// in the sync Gist. Credentials are intentionally excluded — only repos and
+// settings are synced.
+func MarshalForGist(cfg *Config) ([]byte, error) {
+	// Build a sanitised copy that omits credentials.
+	type gistConfig struct {
+		Repos    map[string]Repo `yaml:"repos,omitempty"`
+		Settings Settings        `yaml:"settings,omitempty"`
+	}
+	safe := gistConfig{
+		Repos:    cfg.Repos,
+		Settings: cfg.Settings,
+	}
+	return yaml.Marshal(safe)
+}
+
+// ApplyGistConfig merges the YAML content pulled from the sync Gist into the
+// local config file. The merge strategy is a union of repos: remote repos are
+// added or overwritten, but repos that exist only locally are preserved. This
+// lets machine B gain machine A's repos without losing its own.
+func ApplyGistConfig(content []byte) error {
+	type gistConfig struct {
+		Repos    map[string]Repo `yaml:"repos,omitempty"`
+		Settings Settings        `yaml:"settings,omitempty"`
+	}
+	var remote gistConfig
+	if err := yaml.Unmarshal(content, &remote); err != nil {
+		return fmt.Errorf("cannot parse gist config: %w", err)
+	}
+
+	// Load (or initialise) the local config.
+	local, err := Load()
+	if errors.Is(err, os.ErrNotExist) || (err != nil && local == nil) {
+		local = &Config{Repos: make(map[string]Repo)}
+	} else if err != nil {
+		return fmt.Errorf("cannot load local config: %w", err)
+	}
+	if local.Repos == nil {
+		local.Repos = make(map[string]Repo)
+	}
+
+	// Merge: remote repos overwrite local entries with the same key.
+	for k, v := range remote.Repos {
+		local.Repos[k] = v
+	}
+
+	// Merge settings only when the local file has none yet (first pull).
+	// We don't overwrite settings on subsequent pulls to avoid clobbering
+	// machine-specific preferences (terminal, IDE, billing day, etc.).
+	// Settings contains a []string field so direct struct comparison is not
+	// allowed; we use the numeric fields as a proxy for "zero / unset".
+	if local.Settings.PollInterval == 0 && local.Settings.ConfidenceThreshold == 0 &&
+		local.Settings.AgentTimeout == 0 && local.Settings.MaxConcurrentAgents == 0 {
+		local.Settings = remote.Settings
+	}
+
+	return local.Save()
+}

--- a/internal/vcs/github/gist.go
+++ b/internal/vcs/github/gist.go
@@ -1,0 +1,145 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// GistFile represents a single file inside a GitHub Gist.
+type GistFile struct {
+	Filename string `json:"filename"`
+	Content  string `json:"content"`
+}
+
+// Gist is a minimal representation of a GitHub Gist.
+type Gist struct {
+	ID          string              `json:"id"`
+	Description string              `json:"description"`
+	Public      bool                `json:"public"`
+	Files       map[string]GistFile `json:"files"`
+}
+
+// ListGists returns all Gists owned by the authenticated user.
+func (c *Client) ListGists() ([]Gist, error) {
+	data, status, err := c.do("GET", "/gists?per_page=100", nil)
+	if err != nil {
+		return nil, err
+	}
+	if status == 403 || status == 404 {
+		return nil, fmt.Errorf("cannot list gists: HTTP %d — token may be missing the 'gist' scope", status)
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("github list gists: HTTP %d: %s", status, data)
+	}
+	var gists []Gist
+	if err := json.Unmarshal(data, &gists); err != nil {
+		return nil, err
+	}
+	return gists, nil
+}
+
+// FindGistByDescription returns the first Gist whose description matches, or nil if none found.
+func (c *Client) FindGistByDescription(description string) (*Gist, error) {
+	gists, err := c.ListGists()
+	if err != nil {
+		return nil, err
+	}
+	for i := range gists {
+		if gists[i].Description == description {
+			return &gists[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// GetGist fetches a single Gist by ID, including full file contents.
+func (c *Client) GetGist(id string) (*Gist, error) {
+	data, status, err := c.do("GET", "/gists/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status == 404 {
+		return nil, fmt.Errorf("gist %q not found", id)
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("github get gist: HTTP %d: %s", status, data)
+	}
+	var g Gist
+	if err := json.Unmarshal(data, &g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+// CreateGist creates a new private Gist with the given description and files.
+// files maps filename → content.
+func (c *Client) CreateGist(description string, files map[string]string) (*Gist, error) {
+	apiFiles := make(map[string]map[string]string, len(files))
+	for name, content := range files {
+		apiFiles[name] = map[string]string{"content": content}
+	}
+	body := map[string]any{
+		"description": description,
+		"public":      false,
+		"files":       apiFiles,
+	}
+	data, status, err := c.do("POST", "/gists", body)
+	if err != nil {
+		return nil, err
+	}
+	if status == 403 || status == 404 {
+		return nil, fmt.Errorf("cannot create gist: HTTP %d — token may be missing the 'gist' scope", status)
+	}
+	if status != 201 {
+		return nil, fmt.Errorf("github create gist: HTTP %d: %s", status, data)
+	}
+	var g Gist
+	if err := json.Unmarshal(data, &g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+// UpdateGist updates the files in an existing Gist.
+// files maps filename → content.
+func (c *Client) UpdateGist(id string, files map[string]string) (*Gist, error) {
+	apiFiles := make(map[string]map[string]string, len(files))
+	for name, content := range files {
+		apiFiles[name] = map[string]string{"content": content}
+	}
+	body := map[string]any{"files": apiFiles}
+	data, status, err := c.do("PATCH", "/gists/"+id, body)
+	if err != nil {
+		return nil, err
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("github update gist: HTTP %d: %s", status, data)
+	}
+	var g Gist
+	if err := json.Unmarshal(data, &g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+// GetAuthenticatedUser returns the login name of the authenticated user.
+// It calls GET /user and is used to validate a token during login.
+func (c *Client) GetAuthenticatedUser() (string, error) {
+	data, status, err := c.do("GET", "/user", nil)
+	if err != nil {
+		return "", err
+	}
+	if status == 401 {
+		return "", fmt.Errorf("invalid or expired token (HTTP 401)")
+	}
+	if status != 200 {
+		return "", fmt.Errorf("github get user: HTTP %d: %s", status, data)
+	}
+	var raw struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return "", err
+	}
+	return raw.Login, nil
+}


### PR DESCRIPTION
Fixes #91

## What changed

### New command: `clawflow login [token]`
Validates the GitHub token (GET /user), then runs the Gist discovery/creation flow:
- **Found** existing `clawflow-config` Gist → stores its ID in `credentials.yaml`, pulls config (union-merge of repos into local `config.yaml`)
- **Not found** → creates a new private Gist, pushes current local config, stores the ID
- **Subsequent logins** → skips search if a valid stored Gist ID is already present

Token is accepted as a positional arg, `--token` flag, or re-uses the already-stored token when called with no args.

### New file: `internal/vcs/github/gist.go`
Gist API methods on the existing `*Client`: `ListGists`, `FindGistByDescription`, `GetGist`, `CreateGist`, `UpdateGist`, `GetAuthenticatedUser`. Follows the same `do()` helper pattern as the rest of the client.

### New file: `internal/config/sync.go`
- `GistDescription` / `GistConfigFilename` constants
- `MarshalForGist` — serialises config to YAML, credentials are excluded (only repos + settings sync)
- `ApplyGistConfig` — union-merge: remote repos overwrite matching local keys, local-only repos are preserved; settings are only applied on first pull (zero-value check)

### Extended `Credentials`
Added `GistID` field (yaml: gist_id) — persisted in `credentials.yaml` so subsequent syncs skip the Gist search.

### Registered in `root.go`
`clawflow login` is now a top-level command.

## Merge strategy note
Config pull uses a union merge: repos from the Gist overwrite local entries with the same key, but repos that exist only locally are kept. Settings are only pulled on first login (when all numeric settings fields are zero). This lets machine B gain machine A's repos without losing its own local-only configuration.

## Token scope note
The Gist API requires the `gist` OAuth scope. If the token lacks it, the command prints a clear error with a link to the token settings page.

## Testing
- `go build ./...` clean
- `go test ./...` all pass (15 packages)