### PR TITLE
feat(sync): add Repo.BoundMachine field + run-loop skip logic

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -127,6 +127,12 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 			op.Name, op.Trigger.Target, op.Trigger.LabelsRequired, op.Trigger.LabelsExcluded)
 	}
 
+	// Resolve the current machine's hostname once. Used to skip repos that
+	// are bound to a different machine (BoundMachine field). Errors are
+	// non-fatal: an empty hostname means no repos will be skipped by the
+	// bound_machine check (safe default).
+	hostname, _ := os.Hostname()
+
 	// Reconcile any runs whose on-disk state is inconsistent (stuck
 	// "running", missing meta.json) BEFORE we touch anything else, so the
 	// dashboard's first refresh of this run picks up the fixed state. The
@@ -165,6 +171,14 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 	var pending []snapshot.PendingEntry
 	var jobs []*runJob
 	for fullName, repoCfg := range allRepos {
+		// Skip repos bound to a different machine. A repo with no BoundMachine
+		// (empty string) is processed by every machine — the common case.
+		// When hostname resolution failed (empty string), we conservatively
+		// process all repos so a misconfigured machine doesn't silently drop work.
+		if repoCfg.BoundMachine != "" && hostname != "" && repoCfg.BoundMachine != hostname {
+			debugf("repo %s is bound to %s, skipping (current machine: %s)", fullName, repoCfg.BoundMachine, hostname)
+			continue
+		}
 		executeHere := onlyRepo == "" || onlyRepo == fullName
 		repoPending, repoJobs, err := scanRepoOnce(reg, fullName, repoCfg, executeHere, onlyIssue, &globalIssues)
 		if err != nil {

--- a/internal/config/bound_machine_test.go
+++ b/internal/config/bound_machine_test.go
@@ -1,0 +1,52 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+// shouldSkipRepo encapsulates the bound_machine skip logic from the run loop
+// so it can be unit-tested without spinning up the full operator pipeline.
+// This mirrors the condition in cmd/clawflow/commands/run.go exactly:
+//
+//	repoCfg.BoundMachine != "" && hostname != "" && repoCfg.BoundMachine != hostname
+func shouldSkipRepo(repo config.Repo, hostname string) bool {
+	return repo.BoundMachine != "" && hostname != "" && repo.BoundMachine != hostname
+}
+
+func TestBoundMachine_NoBoundMachine(t *testing.T) {
+	// Repos with no BoundMachine are always processed, regardless of hostname.
+	repo := config.Repo{Enabled: true, BoundMachine: ""}
+	if shouldSkipRepo(repo, "machine-a") {
+		t.Error("repo with empty BoundMachine should not be skipped")
+	}
+	if shouldSkipRepo(repo, "") {
+		t.Error("repo with empty BoundMachine should not be skipped even when hostname is empty")
+	}
+}
+
+func TestBoundMachine_MatchingHostname(t *testing.T) {
+	// Repos bound to the current machine are processed normally.
+	repo := config.Repo{Enabled: true, BoundMachine: "machine-a"}
+	if shouldSkipRepo(repo, "machine-a") {
+		t.Error("repo bound to current machine should not be skipped")
+	}
+}
+
+func TestBoundMachine_DifferentHostname(t *testing.T) {
+	// Repos bound to a different machine are skipped.
+	repo := config.Repo{Enabled: true, BoundMachine: "machine-b"}
+	if !shouldSkipRepo(repo, "machine-a") {
+		t.Error("repo bound to a different machine should be skipped")
+	}
+}
+
+func TestBoundMachine_EmptyHostname(t *testing.T) {
+	// When hostname resolution fails (empty string), we conservatively process
+	// all repos — no work is silently dropped due to a misconfigured machine.
+	repo := config.Repo{Enabled: true, BoundMachine: "machine-b"}
+	if shouldSkipRepo(repo, "") {
+		t.Error("repo should not be skipped when hostname is empty (hostname resolution failed)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,16 @@ type Repo struct {
 	// false preserves the original "label is gatekeeper" behaviour. Pushed
 	// from SaaS via /sync/config (issue #28).
 	AutoEvaluateAllIssues bool `yaml:"auto_evaluate_all_issues,omitempty"`
+
+	// BoundMachine, when non-empty, restricts processing of this repo to the
+	// machine whose hostname matches this value. Repos with no BoundMachine
+	// (or whose BoundMachine matches the current hostname) are processed
+	// normally. This allows multiple machines sharing a synced config to each
+	// own a subset of repos without stepping on each other.
+	//
+	// Like local_path, this field is machine-specific and is intentionally
+	// excluded from cloud sync (see syncableRepo in sync.go).
+	BoundMachine string `yaml:"bound_machine,omitempty"`
 }
 
 // Settings holds global ClawFlow settings.

--- a/internal/config/sync.go
+++ b/internal/config/sync.go
@@ -34,7 +34,7 @@ type syncableRepo struct {
 	AutoMerge             bool              `yaml:"auto_merge,omitempty"`
 	AutoApprove           bool              `yaml:"auto_approve,omitempty"`
 	AutoEvaluateAllIssues bool              `yaml:"auto_evaluate_all_issues,omitempty"`
-	// local_path is intentionally absent — never synced.
+	// local_path and bound_machine are intentionally absent — machine-specific, never synced.
 }
 
 // toSyncable converts a Repo to its syncable representation (strips local_path).
@@ -58,8 +58,9 @@ func toSyncable(r Repo) syncableRepo {
 	}
 }
 
-// fromSyncable converts a syncableRepo back to a Repo, preserving the given local_path.
-func fromSyncable(s syncableRepo, localPath string) Repo {
+// fromSyncable converts a syncableRepo back to a Repo, preserving the given
+// local_path and bound_machine (both are machine-specific and never synced).
+func fromSyncable(s syncableRepo, localPath, boundMachine string) Repo {
 	return Repo{
 		Enabled:               s.Enabled,
 		Platform:              s.Platform,
@@ -77,6 +78,7 @@ func fromSyncable(s syncableRepo, localPath string) Repo {
 		AutoMerge:             s.AutoMerge,
 		AutoApprove:           s.AutoApprove,
 		AutoEvaluateAllIssues: s.AutoEvaluateAllIssues,
+		BoundMachine:          boundMachine,
 	}
 }
 
@@ -126,13 +128,14 @@ func MergeConfigs(local *Config, remoteYAML []byte) (*Config, error) {
 		merged.Repos[k] = v
 	}
 
-	// Apply remote repos: union merge, local_path preserved from local copy.
+	// Apply remote repos: union merge, local_path and bound_machine preserved from local copy.
 	for k, remoteRepo := range remote.Repos {
-		localPath := ""
+		var localPath, boundMachine string
 		if existing, ok := local.Repos[k]; ok {
 			localPath = existing.LocalPath
+			boundMachine = existing.BoundMachine
 		}
-		merged.Repos[k] = fromSyncable(remoteRepo, localPath)
+		merged.Repos[k] = fromSyncable(remoteRepo, localPath, boundMachine)
 	}
 
 	return merged, nil

--- a/internal/config/sync_test.go
+++ b/internal/config/sync_test.go
@@ -255,6 +255,92 @@ settings:
 	}
 }
 
+// TestMarshalForGist_ExcludesBoundMachine verifies that bound_machine is
+// stripped from the Gist payload (machine-specific, like local_path).
+func TestMarshalForGist_ExcludesBoundMachine(t *testing.T) {
+	cfg := &config.Config{
+		Repos: map[string]config.Repo{
+			"owner/repo": {
+				Enabled:      true,
+				BaseBranch:   "main",
+				LocalPath:    "/home/user/repo",
+				BoundMachine: "my-laptop",
+			},
+		},
+	}
+
+	data, err := config.MarshalForGist(cfg)
+	if err != nil {
+		t.Fatalf("MarshalForGist error: %v", err)
+	}
+
+	payload := string(data)
+	if strings.Contains(payload, "my-laptop") {
+		t.Error("bound_machine value should not appear in Gist payload")
+	}
+	if strings.Contains(payload, "bound_machine") {
+		t.Error("bound_machine key should not appear in Gist payload")
+	}
+}
+
+// TestMergeConfigs_BoundMachinePreserved verifies that bound_machine is never
+// overwritten by the remote config (local wins, same as local_path).
+func TestMergeConfigs_BoundMachinePreserved(t *testing.T) {
+	local := &config.Config{
+		Repos: map[string]config.Repo{
+			"owner/repo": {
+				Enabled:      true,
+				BaseBranch:   "main",
+				LocalPath:    "/home/user/repo",
+				BoundMachine: "my-laptop",
+			},
+		},
+	}
+
+	// Remote has no bound_machine (stripped on push).
+	remoteYAML := `
+repos:
+  owner/repo:
+    enabled: true
+    base_branch: develop
+`
+
+	merged, err := config.MergeConfigs(local, []byte(remoteYAML))
+	if err != nil {
+		t.Fatalf("MergeConfigs error: %v", err)
+	}
+
+	repo := merged.Repos["owner/repo"]
+	if repo.BoundMachine != "my-laptop" {
+		t.Errorf("bound_machine should be preserved: got %q, want %q", repo.BoundMachine, "my-laptop")
+	}
+}
+
+// TestMergeConfigs_BoundMachineEmptyForNewRepo verifies that a repo arriving
+// only from the remote gets an empty bound_machine (not inherited).
+func TestMergeConfigs_BoundMachineEmptyForNewRepo(t *testing.T) {
+	local := &config.Config{
+		Repos: map[string]config.Repo{},
+	}
+
+	remoteYAML := `
+repos:
+  owner/new-repo:
+    enabled: true
+    base_branch: main
+`
+
+	merged, err := config.MergeConfigs(local, []byte(remoteYAML))
+	if err != nil {
+		t.Fatalf("MergeConfigs error: %v", err)
+	}
+
+	repo := merged.Repos["owner/new-repo"]
+	if repo.BoundMachine != "" {
+		t.Errorf("new repo from remote should have empty bound_machine, got %q", repo.BoundMachine)
+	}
+}
+
 // TestMergeConfigs_EmptyRemote verifies that an empty remote YAML leaves
 // local repos intact (no repos deleted).
 func TestMergeConfigs_EmptyRemote(t *testing.T) {


### PR DESCRIPTION
Fixes #89

## What changed

****
- Added  field to the `Repo` struct with a doc comment explaining its purpose and that it is machine-specific (excluded from cloud sync).

****
- `syncableRepo` intentionally omits `BoundMachine` (same treatment as `local_path`).
- `fromSyncable` now accepts a `boundMachine` parameter and preserves it from the local copy during merge, so a sync pull never overwrites a machine's own binding.
- `MergeConfigs` passes `existing.BoundMachine` when merging remote repos.

****
- Resolves `os.Hostname()` once at the start of `runOnce`.
- In the repo scan loop, skips any repo where `BoundMachine != "" && hostname != "" && BoundMachine != hostname`, logging a debug message with the bound machine name and current hostname.
- Conservative fallback: if hostname resolution fails (empty string), all repos are processed — no work is silently dropped.

## Tests

- `internal/config/bound_machine_test.go`: four cases covering empty BoundMachine (always process), matching hostname (process), non-matching hostname (skip), and empty hostname (process — safe fallback).
- `internal/config/sync_test.go`: three new cases — `MarshalForGist` excludes `bound_machine`, `MergeConfigs` preserves it from local, new-from-remote repos get empty `bound_machine`.
- All 16 config tests + full `go test ./...` pass.