### PR TITLE
feat(sync): add /api/sync and /api/login HTTP endpoints

### DIFF
--- a/cmd/clawflow/commands/login.go
+++ b/cmd/clawflow/commands/login.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
+	clawsync "github.com/zhoushoujianwork/clawflow/internal/sync"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs/github"
 )
 
@@ -149,26 +150,14 @@ func discoverOrCreateGist(gh *github.Client, creds *config.Credentials) (string,
 
 // pullConfigFromGist fetches the Gist content and merges it into the local config.
 func pullConfigFromGist(gh *github.Client, gistID string) error {
-	gist, err := gh.GetGist(gistID)
+	content, err := clawsync.FetchGistContent(gh, gistID)
 	if err != nil {
 		return err
 	}
-	f, ok := gist.Files[config.GistConfigFilename]
-	if !ok {
-		return fmt.Errorf("gist %s has no %s file", gistID, config.GistConfigFilename)
-	}
-	return config.ApplyGistConfig([]byte(f.Content))
+	return config.ApplyGistConfig(content)
 }
 
 // buildGistContent serialises the current local config for upload.
 func buildGistContent() (string, error) {
-	cfg, err := config.Load()
-	if err != nil {
-		return "", err
-	}
-	b, err := config.MarshalForGist(cfg)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
+	return clawsync.BuildGistContent()
 }

--- a/cmd/clawflow/commands/sync.go
+++ b/cmd/clawflow/commands/sync.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
-	"github.com/zhoushoujianwork/clawflow/internal/vcs/github"
+	clawsync "github.com/zhoushoujianwork/clawflow/internal/sync"
 )
 
 // NewSyncCmd returns the `clawflow sync` command tree.
@@ -54,23 +54,23 @@ local_path fields) and uploads it to your private clawflow-config Gist.
 If no Gist exists yet, one is created automatically. The Gist ID is stored
 in credentials.yaml so subsequent pushes update the same Gist.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gh, gistID, err := syncClient()
+			gh, gistID, err := clawsync.Client()
 			if err != nil {
 				return err
 			}
 
-			content, err := buildGistContent()
+			content, err := clawsync.BuildGistContent()
 			if err != nil {
 				return fmt.Errorf("cannot build config payload: %w", err)
 			}
 
-			gistID, err = pushToGist(gh, gistID, content)
+			gistID, err = clawsync.PushToGist(gh, gistID, content)
 			if err != nil {
 				return err
 			}
 
 			// Persist the Gist ID if it was just created.
-			if err := saveGistID(gistID); err != nil {
+			if err := clawsync.SaveGistID(gistID); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: could not persist Gist ID: %v\n", err)
 			}
 
@@ -92,7 +92,7 @@ func newSyncPullCmd() *cobra.Command {
   repos       → union merge (local_path preserved from local copy)
   credentials → never touched`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gh, gistID, err := syncClient()
+			gh, gistID, err := clawsync.Client()
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func newSyncPullCmd() *cobra.Command {
 				return fmt.Errorf("no Gist ID found — run 'clawflow sync push' first or 'clawflow login' to set up sync")
 			}
 
-			remoteYAML, err := fetchGistContent(gh, gistID)
+			remoteYAML, err := clawsync.FetchGistContent(gh, gistID)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ func newSyncPullCmd() *cobra.Command {
 // runSyncInteractive is the bare `clawflow sync` handler: shows a diff and
 // asks for confirmation before applying the pull.
 func runSyncInteractive(cmd *cobra.Command, args []string) error {
-	gh, gistID, err := syncClient()
+	gh, gistID, err := clawsync.Client()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func runSyncInteractive(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no Gist ID found — run 'clawflow sync push' first or 'clawflow login' to set up sync")
 	}
 
-	remoteYAML, err := fetchGistContent(gh, gistID)
+	remoteYAML, err := clawsync.FetchGistContent(gh, gistID)
 	if err != nil {
 		return err
 	}
@@ -162,84 +162,6 @@ func runSyncInteractive(cmd *cobra.Command, args []string) error {
 
 	fmt.Fprintf(os.Stderr, "Config merged from Gist %s → %s\n", gistID, config.ConfigPath())
 	return nil
-}
-
-// syncClient loads credentials and returns a GitHub client plus the stored Gist ID.
-func syncClient() (*github.Client, string, error) {
-	creds, err := config.LoadCredentials()
-	if err != nil {
-		return nil, "", fmt.Errorf("cannot load credentials: %w", err)
-	}
-	if creds == nil || creds.GHToken == "" {
-		return nil, "", fmt.Errorf("no GitHub token found — run 'clawflow login <token>' first")
-	}
-	gh := github.New(creds.GHToken, "")
-	return gh, creds.GistID, nil
-}
-
-// fetchGistContent retrieves the config.yaml content from the given Gist.
-func fetchGistContent(gh *github.Client, gistID string) ([]byte, error) {
-	gist, err := gh.GetGist(gistID)
-	if err != nil {
-		return nil, fmt.Errorf("cannot fetch Gist %s: %w", gistID, err)
-	}
-	f, ok := gist.Files[config.GistConfigFilename]
-	if !ok {
-		return nil, fmt.Errorf("Gist %s has no %s file", gistID, config.GistConfigFilename)
-	}
-	return []byte(f.Content), nil
-}
-
-// pushToGist uploads content to an existing Gist or creates a new one.
-// Returns the Gist ID (which may be new if none existed).
-func pushToGist(gh *github.Client, gistID, content string) (string, error) {
-	files := map[string]string{config.GistConfigFilename: content}
-
-	if gistID != "" {
-		// Try to update the existing Gist.
-		_, err := gh.UpdateGist(gistID, files)
-		if err == nil {
-			return gistID, nil
-		}
-		// Gist may have been deleted — fall through to create.
-		fmt.Fprintf(os.Stderr, "Stored Gist %s not accessible (%v), creating new one...\n", gistID, err)
-	}
-
-	// Search for an existing Gist with the canonical description before creating.
-	existing, err := gh.FindGistByDescription(config.GistDescription)
-	if err != nil {
-		return "", fmt.Errorf("cannot search Gists: %w", err)
-	}
-	if existing != nil {
-		_, err := gh.UpdateGist(existing.ID, files)
-		if err != nil {
-			return "", fmt.Errorf("cannot update Gist: %w", err)
-		}
-		return existing.ID, nil
-	}
-
-	// Create a brand-new private Gist.
-	newGist, err := gh.CreateGist(config.GistDescription, files)
-	if err != nil {
-		return "", fmt.Errorf("cannot create Gist: %w", err)
-	}
-	return newGist.ID, nil
-}
-
-// saveGistID persists the Gist ID into credentials.yaml.
-func saveGistID(gistID string) error {
-	creds, err := config.LoadCredentials()
-	if err != nil {
-		return err
-	}
-	if creds == nil {
-		creds = &config.Credentials{}
-	}
-	if creds.GistID == gistID {
-		return nil // already stored
-	}
-	creds.GistID = gistID
-	return config.SaveCredentials(creds)
 }
 
 // confirmPrompt prints prompt and returns true if the user types "y" or "yes".

--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -209,6 +209,10 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/project/health-check/status", api.HandleProjectHealthCheckStatus)
 			mux.HandleFunc("/api/project/health-check/apply", api.HandleProjectHealthCheckApply)
 			mux.HandleFunc("/api/project/pm-runs", api.HandleProjectPMRuns)
+			mux.HandleFunc("/api/sync/status", api.HandleSyncStatus)
+			mux.HandleFunc("/api/sync/push", api.HandleSyncPush)
+			mux.HandleFunc("/api/sync/pull", api.HandleSyncPull)
+			mux.HandleFunc("/api/login", api.HandleLogin)
 			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 				// SPA fallback: if the requested path maps to a real
 				// asset inside the embedded bundle (assets/, favicon.svg,

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1,0 +1,272 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	clawsync "github.com/zhoushoujianwork/clawflow/internal/sync"
+	"github.com/zhoushoujianwork/clawflow/internal/vcs/github"
+)
+
+// syncStatusResponse is returned by GET /api/sync/status.
+// Credentials and local_path are intentionally absent.
+type syncStatusResponse struct {
+	GistID      string `json:"gist_id"`
+	GHTokenSet  bool   `json:"gh_token_set"`
+	LastSyncedAt string `json:"last_synced_at,omitempty"`
+}
+
+// HandleSyncStatus handles GET /api/sync/status.
+// Returns the current sync state: whether a token is configured, the stored
+// Gist ID, and the last-synced timestamp (if recorded).
+func HandleSyncStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	resp := syncStatusResponse{}
+	if creds != nil {
+		resp.GHTokenSet = creds.GHToken != ""
+		resp.GistID = creds.GistID
+		resp.LastSyncedAt = creds.LastSyncedAt
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// syncPushResponse is returned by POST /api/sync/push.
+type syncPushResponse struct {
+	Status string `json:"status"`
+	GistID string `json:"gist_id,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// HandleSyncPush handles POST /api/sync/push.
+// Serialises the local config and uploads it to the clawflow-config Gist,
+// creating one if it doesn't exist yet.
+func HandleSyncPush(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check token first — fail fast before touching the config file.
+	gh, gistID, err := clawsync.Client()
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, syncPushResponse{Error: err.Error()})
+		return
+	}
+
+	content, err := clawsync.BuildGistContent()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, syncPushResponse{Error: "cannot build config payload: " + err.Error()})
+		return
+	}
+
+	newGistID, err := clawsync.PushToGist(gh, gistID, content)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, syncPushResponse{Error: err.Error()})
+		return
+	}
+
+	if err := clawsync.SaveGistID(newGistID); err != nil {
+		// Non-fatal: the push succeeded; warn via the response but don't fail.
+		writeJSON(w, http.StatusOK, syncPushResponse{
+			Status: "ok",
+			GistID: newGistID,
+			Error:  "push succeeded but could not persist Gist ID: " + err.Error(),
+		})
+		return
+	}
+
+	// Record the sync timestamp.
+	_ = recordLastSynced()
+
+	writeJSON(w, http.StatusOK, syncPushResponse{Status: "ok", GistID: newGistID})
+}
+
+// syncPullResponse is returned by POST /api/sync/pull.
+type syncPullResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// HandleSyncPull handles POST /api/sync/pull.
+// Fetches the clawflow-config Gist and merges it into the local config using
+// the field-level merge strategy (settings: cloud wins; repos: union merge).
+func HandleSyncPull(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	gh, gistID, err := clawsync.Client()
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, syncPullResponse{Error: err.Error()})
+		return
+	}
+	if gistID == "" {
+		writeJSON(w, http.StatusBadRequest, syncPullResponse{
+			Error: "no Gist ID found — run sync push first or use /api/login to set up sync",
+		})
+		return
+	}
+
+	remoteYAML, err := clawsync.FetchGistContent(gh, gistID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, syncPullResponse{Error: err.Error()})
+		return
+	}
+
+	if err := config.ApplyGistConfig(remoteYAML); err != nil {
+		writeJSON(w, http.StatusInternalServerError, syncPullResponse{Error: "merge failed: " + err.Error()})
+		return
+	}
+
+	// Record the sync timestamp.
+	_ = recordLastSynced()
+
+	writeJSON(w, http.StatusOK, syncPullResponse{Status: "ok"})
+}
+
+// loginRequest is the body accepted by POST /api/login.
+type loginRequest struct {
+	Token string `json:"token"`
+}
+
+// loginResponse is returned by POST /api/login.
+type loginResponse struct {
+	Status string `json:"status"`
+	Login  string `json:"login,omitempty"`
+	GistID string `json:"gist_id,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// HandleLogin handles POST /api/login.
+// Accepts {"token": "ghp_xxx"}, validates it via GET /user, discovers or
+// creates the clawflow-config Gist, and persists the token + Gist ID.
+// The token is never echoed back in the response.
+func HandleLogin(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, loginResponse{Error: "invalid JSON"})
+		return
+	}
+	token := strings.TrimSpace(req.Token)
+	if token == "" {
+		writeJSON(w, http.StatusBadRequest, loginResponse{Error: "token is required"})
+		return
+	}
+
+	gh := github.New(token, "")
+
+	// 1. Validate the token.
+	login, err := gh.GetAuthenticatedUser()
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, loginResponse{Error: "token validation failed: " + err.Error()})
+		return
+	}
+
+	// 2. Load existing credentials to preserve other fields.
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, loginResponse{Error: "cannot load credentials: " + err.Error()})
+		return
+	}
+	if creds == nil {
+		creds = &config.Credentials{}
+	}
+	creds.GHToken = token
+
+	// 3. Discover or create the sync Gist.
+	gistID, err := discoverOrCreateGistAPI(gh, creds)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, loginResponse{Error: err.Error()})
+		return
+	}
+	creds.GistID = gistID
+
+	// 4. Persist credentials. Token is stored but never returned.
+	if err := config.SaveCredentials(creds); err != nil {
+		writeJSON(w, http.StatusInternalServerError, loginResponse{Error: "cannot save credentials: " + err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, loginResponse{
+		Status: "ok",
+		Login:  login,
+		GistID: gistID,
+	})
+}
+
+// discoverOrCreateGistAPI is the API-layer equivalent of the CLI's
+// discoverOrCreateGist. It finds the clawflow-config Gist or creates one,
+// pulling config on discovery and pushing on creation.
+func discoverOrCreateGistAPI(gh *github.Client, creds *config.Credentials) (string, error) {
+	// If we already have a stored Gist ID, verify it still exists.
+	if creds.GistID != "" {
+		gist, err := gh.GetGist(creds.GistID)
+		if err == nil && gist != nil {
+			return gist.ID, nil
+		}
+		// Gist gone — fall through to search.
+	}
+
+	// Search for an existing Gist with the canonical description.
+	gist, err := gh.FindGistByDescription(config.GistDescription)
+	if err != nil {
+		return "", fmt.Errorf("cannot search gists: %w", err)
+	}
+
+	if gist != nil {
+		// Found — pull config from it (best-effort).
+		if content, ferr := clawsync.FetchGistContent(gh, gist.ID); ferr == nil {
+			_ = config.ApplyGistConfig(content)
+		}
+		return gist.ID, nil
+	}
+
+	// No existing Gist — create one and push current local config.
+	content, cerr := clawsync.BuildGistContent()
+	if cerr != nil {
+		// Seed with an empty placeholder if there's no local config yet.
+		content = "# clawflow config — managed by clawflow login\nrepos: {}\n"
+	}
+	newGist, err := gh.CreateGist(config.GistDescription, map[string]string{
+		config.GistConfigFilename: content,
+	})
+	if err != nil {
+		return "", fmt.Errorf("cannot create config Gist: %w", err)
+	}
+	return newGist.ID, nil
+}
+
+// recordLastSynced stamps the current UTC time into credentials.yaml so
+// GET /api/sync/status can surface it. Best-effort: failures are silently
+// ignored because the sync itself already succeeded.
+func recordLastSynced() error {
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		return err
+	}
+	if creds == nil {
+		creds = &config.Credentials{}
+	}
+	creds.LastSyncedAt = time.Now().UTC().Format(time.RFC3339)
+	return config.SaveCredentials(creds)
+}

--- a/internal/api/sync_test.go
+++ b/internal/api/sync_test.go
@@ -1,0 +1,206 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupTestHome creates a temporary home directory and points the test process
+// at it so config/credentials reads and writes don't touch the real user home.
+// It also clears token env vars that LoadCredentials merges in.
+// Returns a cleanup function.
+func setupTestHome(t *testing.T) (string, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	// Pre-create the config directory so Save/Load don't fail on mkdir.
+	if err := os.MkdirAll(filepath.Join(dir, ".clawflow", "config"), 0o755); err != nil {
+		t.Fatalf("setup: mkdir: %v", err)
+	}
+	origHome := os.Getenv("HOME")
+	origGHToken := os.Getenv("GH_TOKEN")
+	origGitLabToken := os.Getenv("GITLAB_TOKEN")
+	os.Setenv("HOME", dir)
+	os.Unsetenv("GH_TOKEN")
+	os.Unsetenv("GITLAB_TOKEN")
+	return dir, func() {
+		os.Setenv("HOME", origHome)
+		if origGHToken != "" {
+			os.Setenv("GH_TOKEN", origGHToken)
+		}
+		if origGitLabToken != "" {
+			os.Setenv("GITLAB_TOKEN", origGitLabToken)
+		}
+	}
+}
+
+// TestHandleSyncStatus_NoCredentials verifies that the endpoint returns a
+// zero-value response (not an error) when no credentials file exists yet.
+func TestHandleSyncStatus_NoCredentials(t *testing.T) {
+	_, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/sync/status", nil)
+	w := httptest.NewRecorder()
+	HandleSyncStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp syncStatusResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.GHTokenSet {
+		t.Error("gh_token_set should be false when no credentials exist")
+	}
+	if resp.GistID != "" {
+		t.Errorf("gist_id should be empty, got %q", resp.GistID)
+	}
+}
+
+// TestHandleSyncStatus_MethodNotAllowed verifies that non-GET requests are rejected.
+func TestHandleSyncStatus_MethodNotAllowed(t *testing.T) {
+	_, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sync/status", nil)
+	w := httptest.NewRecorder()
+	HandleSyncStatus(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+// TestHandleSyncPush_NoToken verifies that push returns 400 when no token is configured.
+func TestHandleSyncPush_NoToken(t *testing.T) {
+	_, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sync/push", nil)
+	w := httptest.NewRecorder()
+	HandleSyncPush(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp syncPushResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("expected non-empty error field")
+	}
+}
+
+// TestHandleSyncPull_NoToken verifies that pull returns 400 when no token is configured.
+func TestHandleSyncPull_NoToken(t *testing.T) {
+	_, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sync/pull", nil)
+	w := httptest.NewRecorder()
+	HandleSyncPull(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp syncPullResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("expected non-empty error field")
+	}
+}
+
+// TestHandleSyncPull_NoGistID verifies that pull returns 400 when a token is
+// present but no Gist ID has been stored yet.
+func TestHandleSyncPull_NoGistID(t *testing.T) {
+	home, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	// Write credentials with a token but no gist_id.
+	credsYAML := "gh_token: ghp_testtoken\n"
+	if err := os.WriteFile(filepath.Join(home, ".clawflow", "config", "credentials.yaml"), []byte(credsYAML), 0o600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/sync/pull", nil)
+	w := httptest.NewRecorder()
+	HandleSyncPull(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp syncPullResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("expected non-empty error field")
+	}
+}
+
+// TestHandleLogin_MissingToken verifies that login returns 400 when the
+// request body omits the token field.
+func TestHandleLogin_MissingToken(t *testing.T) {
+	_, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]string{"token": ""})
+	req := httptest.NewRequest(http.MethodPost, "/api/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	HandleLogin(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp loginResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error == "" {
+		t.Error("expected non-empty error field")
+	}
+}
+
+// TestHandleLogin_InvalidJSON verifies that login returns 400 on malformed JSON.
+func TestHandleLogin_InvalidJSON(t *testing.T) {
+	_, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/login", bytes.NewBufferString("{bad json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	HandleLogin(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleLogin_MethodNotAllowed verifies that GET is rejected.
+func TestHandleLogin_MethodNotAllowed(t *testing.T) {
+	_, cleanup := setupTestHome(t)
+	defer cleanup()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/login", nil)
+	w := httptest.NewRecorder()
+	HandleLogin(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,6 +200,12 @@ type Credentials struct {
 	ClaudeChatModel     string `yaml:"claude_chat_model,omitempty"`
 	ClaudeEvalModel     string `yaml:"claude_eval_model,omitempty"`
 	ClaudeOperatorModel string `yaml:"claude_operator_model,omitempty"`
+
+	// LastSyncedAt is an RFC3339 timestamp recording when the config was
+	// last successfully pushed or pulled via the sync API. It is stored in
+	// credentials.yaml (alongside GistID) because it is machine-specific
+	// metadata, not part of the synced config payload itself.
+	LastSyncedAt string `yaml:"last_synced_at,omitempty"`
 }
 
 // Default model identifiers used when the corresponding Credentials

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,0 +1,107 @@
+// Package sync provides shared helpers for pushing and pulling ClawFlow
+// config to/from a private GitHub Gist. Both the CLI commands (sync push/pull,
+// login) and the HTTP API handlers reuse these functions so the logic lives
+// in exactly one place.
+package sync
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/vcs/github"
+)
+
+// Client returns a GitHub client and the stored Gist ID from credentials.
+// Returns an error when no token is configured.
+func Client() (*github.Client, string, error) {
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		return nil, "", fmt.Errorf("cannot load credentials: %w", err)
+	}
+	if creds == nil || creds.GHToken == "" {
+		return nil, "", fmt.Errorf("no GitHub token found — run 'clawflow login <token>' first")
+	}
+	gh := github.New(creds.GHToken, "")
+	return gh, creds.GistID, nil
+}
+
+// BuildGistContent serialises the current local config into a YAML string
+// suitable for uploading to the sync Gist. Credentials and local_path are
+// intentionally excluded.
+func BuildGistContent() (string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return "", err
+	}
+	b, err := config.MarshalForGist(cfg)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// FetchGistContent retrieves the config.yaml content from the given Gist.
+func FetchGistContent(gh *github.Client, gistID string) ([]byte, error) {
+	gist, err := gh.GetGist(gistID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot fetch Gist %s: %w", gistID, err)
+	}
+	f, ok := gist.Files[config.GistConfigFilename]
+	if !ok {
+		return nil, fmt.Errorf("Gist %s has no %s file", gistID, config.GistConfigFilename)
+	}
+	return []byte(f.Content), nil
+}
+
+// PushToGist uploads content to an existing Gist or creates a new one.
+// Returns the Gist ID (which may be newly created if none existed).
+func PushToGist(gh *github.Client, gistID, content string) (string, error) {
+	files := map[string]string{config.GistConfigFilename: content}
+
+	if gistID != "" {
+		// Try to update the existing Gist.
+		_, err := gh.UpdateGist(gistID, files)
+		if err == nil {
+			return gistID, nil
+		}
+		// Gist may have been deleted — fall through to create.
+		fmt.Fprintf(os.Stderr, "Stored Gist %s not accessible (%v), creating new one...\n", gistID, err)
+	}
+
+	// Search for an existing Gist with the canonical description before creating.
+	existing, err := gh.FindGistByDescription(config.GistDescription)
+	if err != nil {
+		return "", fmt.Errorf("cannot search Gists: %w", err)
+	}
+	if existing != nil {
+		_, err := gh.UpdateGist(existing.ID, files)
+		if err != nil {
+			return "", fmt.Errorf("cannot update Gist: %w", err)
+		}
+		return existing.ID, nil
+	}
+
+	// Create a brand-new private Gist.
+	newGist, err := gh.CreateGist(config.GistDescription, files)
+	if err != nil {
+		return "", fmt.Errorf("cannot create Gist: %w", err)
+	}
+	return newGist.ID, nil
+}
+
+// SaveGistID persists the Gist ID into credentials.yaml.
+func SaveGistID(gistID string) error {
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		return err
+	}
+	if creds == nil {
+		creds = &config.Credentials{}
+	}
+	if creds.GistID == gistID {
+		return nil // already stored
+	}
+	creds.GistID = gistID
+	return config.SaveCredentials(creds)
+}


### PR DESCRIPTION
Fixes #96

## What changed

**New package: `internal/sync`**
Extracted `PushToGist`, `FetchGistContent`, `BuildGistContent`, `SaveGistID`, and `Client` from the CLI command files into a shared `internal/sync` package. Both the CLI (`sync push/pull`, `login`) and the new HTTP handlers now call the same functions.

**New file: `internal/api/sync.go`**
Four HTTP handlers:
- `GET /api/sync/status` — returns `{gist_id, gh_token_set, last_synced_at}`; credentials never exposed
- `POST /api/sync/push` — serialises local config (no credentials/local_path) and uploads to Gist
- `POST /api/sync/pull` — fetches Gist and merges into local config via `config.ApplyGistConfig` (union merge, settings cloud-wins)
- `POST /api/login` — validates token via `gh.GetAuthenticatedUser()`, discovers/creates Gist, persists credentials; token never echoed back

**Routes registered in `cmd/clawflow/commands/web.go`**

**`internal/config.Credentials` gets `LastSyncedAt`** — RFC3339 timestamp stamped on every successful push or pull.

**Tests: `internal/api/sync_test.go`**
8 handler tests covering method-not-allowed, missing token, missing Gist ID, invalid JSON, and zero-credential status responses. All use `httptest.NewRecorder` with an isolated temp home dir.

## What was tested
- `go test ./...` — all packages pass
- `go build ./...` — clean build