### PR TITLE
feat(settings): add Sync section to Settings page

### DIFF
--- a/web/src/routes/_app.settings.tsx
+++ b/web/src/routes/_app.settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useCallback, useEffect, useState } from 'react'
-import { Check, Loader2, AlertCircle, X, Eye, EyeOff, Folder, ChevronRight, Home } from 'lucide-react'
+import { Check, Loader2, AlertCircle, X, Eye, EyeOff, Folder, ChevronRight, Home, Copy, ExternalLink, RefreshCw, Upload, Download, LogOut } from 'lucide-react'
 import { cn } from '../lib/utils'
 
 interface SettingsView {
@@ -92,6 +92,7 @@ function SettingsPage() {
           <ClaudeSection view={data.claude} onSaved={refresh} />
           <TokensSection view={data.tokens} onSaved={refresh} />
           <GlobalSection view={data.global} onSaved={refresh} />
+          <SyncSection />
         </>
       )}
     </div>
@@ -641,6 +642,319 @@ function GlobalSection({
 }
 
 // -----------------------------------------------------------------------------
+// Sync
+// -----------------------------------------------------------------------------
+
+interface SyncStatus {
+  gist_id: string
+  gh_token_set: boolean
+  last_synced_at?: string
+}
+
+function SyncSection() {
+  const [status, setStatus] = useState<SyncStatus | null>(null)
+  const [loadErr, setLoadErr] = useState<string | null>(null)
+
+  // Login form state
+  const [token, setToken] = useState('')
+  const [showToken, setShowToken] = useState(false)
+  const [loginBusy, setLoginBusy] = useState(false)
+  const [loginMsg, setLoginMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  // Login result — GitHub username returned by POST /api/login
+  const [ghLogin, setGhLogin] = useState<string | null>(null)
+
+  // Action state
+  const [pushBusy, setPushBusy] = useState(false)
+  const [pushMsg, setPushMsg] = useState<{ ok: boolean; text: string } | null>(null)
+  const [pullBusy, setPullBusy] = useState(false)
+  const [pullMsg, setPullMsg] = useState<{ ok: boolean; text: string } | null>(null)
+  const [disconnectBusy, setDisconnectBusy] = useState(false)
+  const [disconnectMsg, setDisconnectMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  // Clipboard copy state for Gist ID
+  const [copied, setCopied] = useState(false)
+
+  const loadStatus = useCallback(() => {
+    setLoadErr(null)
+    fetch('/api/sync/status', { cache: 'no-store' })
+      .then(r => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then((d: SyncStatus) => setStatus(d))
+      .catch(e => setLoadErr(String(e.message || e)))
+  }, [])
+
+  useEffect(() => { loadStatus() }, [loadStatus])
+
+  const handleLogin = () => {
+    setLoginBusy(true); setLoginMsg(null)
+    fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    })
+      .then(r => r.json())
+      .then(d => {
+        if (d.status === 'ok') {
+          setLoginMsg({ ok: true, text: `Connected as ${d.login}` })
+          setGhLogin(d.login)
+          setToken('')
+          loadStatus()
+        } else {
+          setLoginMsg({ ok: false, text: d.error || 'Login failed' })
+        }
+      })
+      .catch(e => setLoginMsg({ ok: false, text: String(e.message || e) }))
+      .finally(() => setLoginBusy(false))
+  }
+
+  const handlePush = () => {
+    setPushBusy(true); setPushMsg(null)
+    fetch('/api/sync/push', { method: 'POST' })
+      .then(r => r.json())
+      .then(d => {
+        if (d.status === 'ok') {
+          setPushMsg({ ok: true, text: 'Config pushed' + (d.gist_id ? ` · ${d.gist_id.slice(0, 8)}…` : '') })
+          loadStatus()
+        } else {
+          setPushMsg({ ok: false, text: d.error || 'Push failed' })
+        }
+      })
+      .catch(e => setPushMsg({ ok: false, text: String(e.message || e) }))
+      .finally(() => setPushBusy(false))
+  }
+
+  const handlePull = () => {
+    setPullBusy(true); setPullMsg(null)
+    fetch('/api/sync/pull', { method: 'POST' })
+      .then(r => r.json())
+      .then(d => {
+        if (d.status === 'ok') {
+          setPullMsg({ ok: true, text: 'Config pulled and merged' })
+          loadStatus()
+        } else {
+          setPullMsg({ ok: false, text: d.error || 'Pull failed' })
+        }
+      })
+      .catch(e => setPullMsg({ ok: false, text: String(e.message || e) }))
+      .finally(() => setPullBusy(false))
+  }
+
+  const handleDisconnect = () => {
+    if (!window.confirm('Disconnect GitHub sync?\n\nThis clears the stored token and Gist ID. Your local config is not affected.')) return
+    setDisconnectBusy(true); setDisconnectMsg(null)
+    fetch('/api/settings/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gh_token: '' }),
+    })
+      .then(async r => {
+        const d = await r.json().catch(() => null)
+        if (!r.ok) throw new Error((d && d.error) || `HTTP ${r.status}`)
+      })
+      .then(() => {
+        setDisconnectMsg({ ok: true, text: 'Disconnected' })
+        setGhLogin(null)
+        loadStatus()
+      })
+      .catch(e => setDisconnectMsg({ ok: false, text: String(e.message || e) }))
+      .finally(() => setDisconnectBusy(false))
+  }
+
+  const copyGistID = (id: string) => {
+    navigator.clipboard.writeText(id).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }).catch(() => {})
+  }
+
+  const connected = status?.gh_token_set ?? false
+  const gistID = status?.gist_id ?? ''
+
+  return (
+    <Card
+      title="Sync"
+      hint="Sync repos and settings across machines via a private GitHub Gist. Credentials and local_path are never synced."
+    >
+      {loadErr && (
+        <div className="text-xs text-red-700 bg-red-50 border border-red-200 px-2 py-1.5 rounded">
+          Failed to load sync status: {loadErr}
+        </div>
+      )}
+
+      {/* Connection status */}
+      {status && (
+        <Row label="Status">
+          {connected ? (
+            <div className="flex-1 flex flex-col gap-1">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded border bg-green-50 border-green-200 text-green-700">
+                  <Check className="w-3 h-3" />
+                  Connected{ghLogin ? ` as ${ghLogin}` : ''}
+                </span>
+              </div>
+              {gistID && (
+                <div className="flex items-center gap-1.5 mt-0.5">
+                  <span className="text-xs text-muted-foreground">Gist ID:</span>
+                  <code className="text-xs font-mono text-foreground bg-secondary px-1.5 py-0.5 rounded select-all">
+                    {gistID}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={() => copyGistID(gistID)}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    title="Copy Gist ID"
+                    aria-label="Copy Gist ID"
+                  >
+                    {copied ? <Check className="w-3.5 h-3.5 text-green-600" /> : <Copy className="w-3.5 h-3.5" />}
+                  </button>
+                  <a
+                    href={`https://gist.github.com/${gistID}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    title="Open Gist on GitHub"
+                    aria-label="Open Gist on GitHub"
+                  >
+                    <ExternalLink className="w-3.5 h-3.5" />
+                  </a>
+                </div>
+              )}
+              {status.last_synced_at && (
+                <div className="text-[11px] text-muted-foreground">
+                  Last synced: {new Date(status.last_synced_at).toLocaleString()}
+                </div>
+              )}
+            </div>
+          ) : (
+            <span className="text-xs text-muted-foreground">Not connected</span>
+          )}
+        </Row>
+      )}
+
+      {/* Connect form — shown when not connected */}
+      {status && !connected && (
+        <Row label="GitHub token" hint={
+          <>
+            Needs the <code className="text-[10px] bg-secondary px-0.5 rounded">gist</code> scope.{' '}
+            <a
+              href="https://github.com/settings/tokens/new?scopes=gist&description=clawflow-sync"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              Create token on GitHub
+            </a>
+          </>
+        }>
+          <div className="flex-1 flex gap-2 items-center">
+            <input
+              type={showToken ? 'text' : 'password'}
+              value={token}
+              onChange={e => setToken(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter' && token) handleLogin() }}
+              placeholder="ghp_…"
+              className="flex-1 text-sm font-mono px-2 py-1 border border-border rounded bg-background"
+              aria-label="GitHub personal access token"
+            />
+            <button
+              type="button"
+              onClick={() => setShowToken(s => !s)}
+              className="text-muted-foreground hover:text-foreground"
+              title={showToken ? 'Hide' : 'Show'}
+              aria-label={showToken ? 'Hide token' : 'Show token'}
+            >
+              {showToken ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+            </button>
+            <button
+              type="button"
+              onClick={handleLogin}
+              disabled={!token || loginBusy}
+              className={cn(
+                'text-sm px-3 py-1 rounded border',
+                token && !loginBusy
+                  ? 'bg-secondary hover:bg-secondary/70 border-border text-foreground'
+                  : 'bg-muted text-muted-foreground border-border cursor-not-allowed',
+              )}
+            >
+              {loginBusy ? <Loader2 className="w-3 h-3 animate-spin inline mr-1" /> : null}
+              Connect
+            </button>
+          </div>
+          {loginMsg && (
+            <div className="mt-1">
+              <Status ok={loginMsg.ok} text={loginMsg.text} />
+            </div>
+          )}
+        </Row>
+      )}
+
+      {/* Actions — shown when connected */}
+      {status && connected && (
+        <Row label="Actions">
+          <div className="flex-1 flex flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={handlePush}
+                disabled={pushBusy}
+                className="text-sm px-3 py-1 rounded border border-border hover:bg-secondary/50 text-foreground inline-flex items-center gap-1.5"
+              >
+                {pushBusy
+                  ? <Loader2 className="w-3 h-3 animate-spin" />
+                  : <Upload className="w-3 h-3" />}
+                Push config
+              </button>
+              <button
+                type="button"
+                onClick={handlePull}
+                disabled={pullBusy}
+                className="text-sm px-3 py-1 rounded border border-border hover:bg-secondary/50 text-foreground inline-flex items-center gap-1.5"
+              >
+                {pullBusy
+                  ? <Loader2 className="w-3 h-3 animate-spin" />
+                  : <Download className="w-3 h-3" />}
+                Pull config
+              </button>
+              <button
+                type="button"
+                onClick={loadStatus}
+                className="text-sm px-2 py-1 rounded border border-border hover:bg-secondary/50 text-muted-foreground"
+                title="Refresh sync status"
+                aria-label="Refresh sync status"
+              >
+                <RefreshCw className="w-3 h-3" />
+              </button>
+              <button
+                type="button"
+                onClick={handleDisconnect}
+                disabled={disconnectBusy}
+                className="text-sm px-3 py-1 rounded border border-red-200 text-red-600 hover:bg-red-50 transition-colors inline-flex items-center gap-1.5"
+              >
+                {disconnectBusy
+                  ? <Loader2 className="w-3 h-3 animate-spin" />
+                  : <LogOut className="w-3 h-3" />}
+                Disconnect
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {pushMsg && <Status ok={pushMsg.ok} text={pushMsg.text} />}
+              {pullMsg && <Status ok={pullMsg.ok} text={pullMsg.text} />}
+              {disconnectMsg && <Status ok={disconnectMsg.ok} text={disconnectMsg.text} />}
+            </div>
+          </div>
+        </Row>
+      )}
+
+      {/* Info text */}
+      <div className="text-[11px] text-muted-foreground/80 pt-1 space-y-0.5 border-t border-border mt-1">
+        <p><span className="font-medium text-muted-foreground">Synced:</span> repos list, global settings, operator config.</p>
+        <p><span className="font-medium text-muted-foreground">Never synced:</span> credentials (tokens, API keys) and local_path overrides — these stay local.</p>
+      </div>
+    </Card>
+  )
+}
+
+// -----------------------------------------------------------------------------
 // Reusable bits
 // -----------------------------------------------------------------------------
 
@@ -656,7 +970,7 @@ function Card({ title, hint, children }: { title: string; hint?: string; childre
   )
 }
 
-function Row({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+function Row({ label, hint, children }: { label: string; hint?: React.ReactNode; children: React.ReactNode }) {
   return (
     <div className="flex items-start gap-3">
       <label className="text-xs text-muted-foreground w-40 shrink-0 pt-1.5">{label}</label>


### PR DESCRIPTION
Fixes #98

## What changed

Added a new **Sync** section to the Settings page (), rendered after the Global section.

### Disconnected state
- Token input (password field with show/hide toggle) + **Connect** button
- Calls `POST /api/login` to validate the token, discover/create the Gist, and persist credentials
- Hint text with a direct link to create a GitHub token with the `gist` scope

### Connected state
- Green "Connected" badge (shows GitHub login name after connecting in the same session)
- Full Gist ID displayed in a monospace code block with a **copy-to-clipboard** button and an **open on GitHub** link
- Last-synced timestamp when available
- **Push config** button → `POST /api/sync/push`
- **Pull config** button → `POST /api/sync/pull`
- **Refresh** button to re-fetch sync status without a full page reload
- **Disconnect** button → `POST /api/settings/tokens` with `{"gh_token": ""}` (clears token, prompts confirmation)

### Info text
Brief explanation of what is synced (repos, settings) and what is never synced (credentials, local_path).

## Other changes
- `Row` component's `hint` prop widened from `string` to `React.ReactNode` to support the JSX link in the token hint.
- Added lucide icons: `Copy`, `ExternalLink`, `RefreshCw`, `Upload`, `Download`, `LogOut`.

## Testing
- `tsc --noEmit`: clean
- `vite build`: clean (601 kB bundle, no errors)