### PR TITLE
feat(sync): bind/unbind button + auto pull/push hooks

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 	rootmod "github.com/zhoushoujianwork/clawflow"
+	"github.com/zhoushoujianwork/clawflow/internal/api"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
 	"github.com/zhoushoujianwork/clawflow/internal/operator"
 	"github.com/zhoushoujianwork/clawflow/internal/projectpm"
@@ -93,6 +94,15 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	// Auto-pull: sync config from Gist before scanning so this machine
+	// picks up any changes pushed from other machines (e.g. new repos,
+	// updated settings). Best-effort: if sync is not configured or the
+	// network is unavailable, we continue with the local config.
+	if api.AutoPull() {
+		fmt.Fprintf(os.Stderr, "✓ auto-pulled config from Gist\n")
+	}
+
 	reg, err := loadRegistry()
 	if err != nil {
 		return err
@@ -247,6 +257,14 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 			fmt.Fprintf(os.Stderr, "[pm] woke %d project(s)\n", n)
 		}
 	}
+
+	// Auto-push: sync config to Gist after the run so any label/config
+	// changes made during this pass are visible to other machines.
+	// Best-effort: push failure does not fail the run.
+	if api.AutoPush() {
+		fmt.Fprintf(os.Stderr, "✓ auto-pushed config to Gist\n")
+	}
+
 	return nil
 }
 

--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -69,6 +69,19 @@ here — run 'clawflow run' first if you want fresh data.`,
 			if cfg, err := config.Load(); err == nil {
 				_ = snapshot.WriteRepos(cfg)
 			}
+
+			// Auto-pull: sync config from Gist on startup so this machine
+			// picks up any changes pushed from other machines. Best-effort:
+			// if the Gist is unreachable or sync is not configured, we
+			// continue with the local config unchanged.
+			if api.AutoPull() {
+				fmt.Fprintf(os.Stderr, "✓ auto-pulled config from Gist on startup\n")
+				// Re-snapshot repos after pull so the dashboard reflects
+				// any changes that came in from the remote config.
+				if cfg, err := config.Load(); err == nil {
+					_ = snapshot.WriteRepos(cfg)
+				}
+			}
 			// Refresh data/projects.json so the dashboard picks up any
 			// project changes made via the CLI since the last web start.
 			_ = snapshot.WriteProjects()
@@ -181,6 +194,7 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/version", api.HandleVersion)
 			mux.HandleFunc("/api/update", api.HandleUpdate)
 			mux.HandleFunc("/api/repo/config", api.HandleRepoConfig)
+			mux.HandleFunc("/api/repo/bind", api.HandleRepoBind)
 			mux.HandleFunc("/api/repo/remove", api.HandleRepoRemove)
 			mux.HandleFunc("/api/repo/clone", api.HandleClone)
 			mux.HandleFunc("/api/repo/refresh-issues", api.HandleRepoRefreshIssues)

--- a/internal/api/repo_bind.go
+++ b/internal/api/repo_bind.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+)
+
+type repoBindRequest struct {
+	Repo string `json:"repo"`
+	Bind bool   `json:"bind"`
+}
+
+type repoBindResponse struct {
+	Status       string `json:"status"`
+	BoundMachine string `json:"bound_machine,omitempty"`
+}
+
+// HandleRepoBind handles POST /api/repo/bind.
+// When bind=true, sets BoundMachine to the current machine's hostname.
+// When bind=false, clears BoundMachine (unbinds the repo).
+// BoundMachine is machine-specific and intentionally excluded from cloud sync.
+func HandleRepoBind(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req repoBindRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if req.Repo == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "repo is required"})
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	repo, ok := cfg.Repos[req.Repo]
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "repo not found in config"})
+		return
+	}
+
+	if req.Bind {
+		hostname, err := os.Hostname()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "cannot determine hostname: " + err.Error()})
+			return
+		}
+		repo.BoundMachine = hostname
+	} else {
+		repo.BoundMachine = ""
+	}
+
+	cfg.Repos[req.Repo] = repo
+	if err := cfg.Save(); err != nil {
+		writeErr(w, err)
+		return
+	}
+	// Refresh repos.json so the frontend sees the updated binding state.
+	if err := snapshot.WriteRepos(cfg); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, repoBindResponse{
+		Status:       "ok",
+		BoundMachine: repo.BoundMachine,
+	})
+}

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -254,6 +255,56 @@ func discoverOrCreateGistAPI(gh *github.Client, creds *config.Credentials) (stri
 		return "", fmt.Errorf("cannot create config Gist: %w", err)
 	}
 	return newGist.ID, nil
+}
+
+// AutoPull performs a best-effort config pull from the sync Gist. It is
+// called programmatically at startup (clawflow run, clawflow web) without
+// user interaction. Errors are non-fatal: if the Gist is unreachable or no
+// token is configured, we log and continue with the local config.
+// Returns true when the pull succeeded and the local config was updated.
+func AutoPull() bool {
+	gh, gistID, err := clawsync.Client()
+	if err != nil {
+		// No token configured — sync not set up, silently skip.
+		return false
+	}
+	if gistID == "" {
+		return false
+	}
+	remoteYAML, err := clawsync.FetchGistContent(gh, gistID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ auto-pull: fetch Gist: %v\n", err)
+		return false
+	}
+	if err := config.ApplyGistConfig(remoteYAML); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ auto-pull: apply config: %v\n", err)
+		return false
+	}
+	_ = recordLastSynced()
+	return true
+}
+
+// AutoPush performs a best-effort config push to the sync Gist. It is
+// called programmatically at the end of clawflow run. Errors are non-fatal.
+// Returns true when the push succeeded.
+func AutoPush() bool {
+	gh, gistID, err := clawsync.Client()
+	if err != nil {
+		return false
+	}
+	content, err := clawsync.BuildGistContent()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ auto-push: build content: %v\n", err)
+		return false
+	}
+	newGistID, err := clawsync.PushToGist(gh, gistID, content)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ auto-push: push Gist: %v\n", err)
+		return false
+	}
+	_ = clawsync.SaveGistID(newGistID)
+	_ = recordLastSynced()
+	return true
 }
 
 // recordLastSynced stamps the current UTC time into credentials.yaml so

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -193,14 +193,18 @@ func RunDir(repo string, issueNum int, startedAt time.Time) string {
 // are deliberately NOT included — the dashboard is local but still renders
 // in a browser and we don't want tokens in the DOM.
 type RepoView struct {
-	FullName   string `json:"full_name"`
-	Platform   string `json:"platform"`
-	BaseURL    string `json:"base_url,omitempty"`
-	BaseBranch string `json:"base_branch"`
-	LocalPath  string `json:"local_path,omitempty"`
-	Enabled    bool   `json:"enabled"`
+	FullName     string `json:"full_name"`
+	Platform     string `json:"platform"`
+	BaseURL      string `json:"base_url,omitempty"`
+	BaseBranch   string `json:"base_branch"`
+	LocalPath    string `json:"local_path,omitempty"`
+	Enabled      bool   `json:"enabled"`
 	AutoApprove  bool   `json:"auto_approve"`
 	AutoMerge    bool   `json:"auto_merge"`
+	// BoundMachine is the hostname this repo is restricted to, or empty if
+	// unbound. Exposed to the dashboard so the bind/unbind button can show
+	// the current binding state without a separate API call.
+	BoundMachine string `json:"bound_machine,omitempty"`
 }
 
 // OperatorView is the dashboard-facing view of one loaded operator.
@@ -593,14 +597,15 @@ func WriteRepos(cfg *config.Config) error {
 	views := make([]RepoView, 0, len(cfg.Repos))
 	for name, r := range cfg.Repos {
 		views = append(views, RepoView{
-			FullName:   name,
-			Platform:   r.Platform,
-			BaseURL:    r.BaseURL,
-			BaseBranch: r.BaseBranch,
-			LocalPath:  r.LocalPath,
-			Enabled:    r.Enabled,
+			FullName:     name,
+			Platform:     r.Platform,
+			BaseURL:      r.BaseURL,
+			BaseBranch:   r.BaseBranch,
+			LocalPath:    r.LocalPath,
+			Enabled:      r.Enabled,
 			AutoApprove:  r.AutoApprove,
 			AutoMerge:    r.AutoMerge,
+			BoundMachine: r.BoundMachine,
 		})
 	}
 	return writeJSON(filepath.Join(DataDir(), "repos.json"), views)

--- a/web/src/routes/_app.repos.$repoName.tsx
+++ b/web/src/routes/_app.repos.$repoName.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw } from 'lucide-react'
+import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
@@ -23,6 +23,7 @@ interface Repo {
   enabled: boolean
   auto_approve: boolean
   auto_merge: boolean
+  bound_machine?: string
 }
 export const Route = createFileRoute('/_app/repos/$repoName')({
   component: RepoDetail,
@@ -45,6 +46,7 @@ function RepoDetail() {
   const [cloning, setCloning] = useState(false)
   const [cloneError, setCloneError] = useState<string | null>(null)
   const [syncing, setSyncing] = useState(false)
+  const [binding, setBinding] = useState(false)
   const [allIssues, setAllIssues] = useState<IssueEntry[]>([])
 
   const cloneNow = useCallback(() => {
@@ -105,6 +107,25 @@ function RepoDetail() {
       })
   }, [fullName, syncing, refreshData])
 
+
+  const toggleBind = useCallback(() => {
+    if (!repo || binding) return
+    const shouldBind = !repo.bound_machine
+    setBinding(true)
+    fetch('/api/repo/bind', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repo: fullName, bind: shouldBind }),
+    })
+      .then(r => r.ok ? r.json() : null)
+      .then(d => {
+        if (d && d.status === 'ok') {
+          setRepo(prev => prev ? { ...prev, bound_machine: d.bound_machine || undefined } : prev)
+        }
+      })
+      .catch(() => {})
+      .finally(() => setBinding(false))
+  }, [repo, fullName, binding])
 
   const toggleConfig = useCallback((field: 'enabled' | 'auto_approve' | 'auto_merge') => {
     if (!repo || saving) return
@@ -219,7 +240,7 @@ function RepoDetail() {
             </div>
           </div>
 
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-6">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2 mb-6">
             <ToggleCard label="Status" enabled={repo.enabled} onToggle={() => toggleConfig('enabled')} disabled={saving} />
             <ToggleCard label="Auto-approve" enabled={repo.auto_approve} onToggle={() => toggleConfig('auto_approve')} disabled={saving} />
             <ToggleCard label="Auto-merge" enabled={repo.auto_merge} onToggle={() => toggleConfig('auto_merge')} disabled={saving} />
@@ -263,6 +284,37 @@ function RepoDetail() {
                 </div>
               )}
             </div>
+            {/* Bind to this machine */}
+            <button
+              onClick={toggleBind}
+              disabled={binding}
+              title={repo.bound_machine
+                ? `Bound to ${repo.bound_machine} — click to unbind`
+                : 'Bind this repo to the current machine so other machines skip it'}
+              className={cn(
+                'bg-card border rounded-xl p-3 text-left transition-all',
+                repo.bound_machine ? 'border-blue-300' : 'border-border',
+                binding ? 'opacity-60 cursor-not-allowed' : 'hover:shadow-sm cursor-pointer',
+              )}
+            >
+              <div className="flex items-center justify-between">
+                <div className="text-xs text-muted-foreground">Bound machine</div>
+                {binding ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />
+                ) : repo.bound_machine ? (
+                  <Link2 className="w-3.5 h-3.5 text-blue-500" />
+                ) : (
+                  <Link2Off className="w-3.5 h-3.5 text-muted-foreground/50" />
+                )}
+              </div>
+              {repo.bound_machine ? (
+                <div className="text-xs font-mono mt-1.5 text-blue-600 truncate" title={repo.bound_machine}>
+                  {repo.bound_machine}
+                </div>
+              ) : (
+                <div className="text-base font-semibold mt-0.5 text-muted-foreground">unbound</div>
+              )}
+            </button>
           </div>
 
           <section>


### PR DESCRIPTION
Fixes #92

## What changed

### Backend (Go)
- ****: Added  field to  and  so the frontend can display binding state from `repos.json` without a separate API call.
- **** (new): `POST /api/repo/bind` — `{"repo": "owner/repo", "bind": true|false}`. `bind=true` sets `BoundMachine` to `os.Hostname()`; `bind=false` clears it. Refreshes `repos.json` snapshot on success.
- ****: Added `AutoPull()` and `AutoPush()` helpers for programmatic (non-HTTP) use by CLI lifecycle hooks. Both are best-effort and non-fatal.
- **`cmd/clawflow/commands/web.go`**: Registers `/api/repo/bind` in the mux; calls `api.AutoPull()` on startup and re-snapshots repos if the pull succeeded.
- **`cmd/clawflow/commands/run.go`**: Calls `api.AutoPull()` at the top of `runOnce` (before scanning) and `api.AutoPush()` at the end (after PM scheduling).

### Frontend (React/TypeScript)
- **`_app.repos.$repoName.tsx`**: Added `bound_machine?: string` to the `Repo` interface; added a 5th card in the repo detail grid showing the bound hostname (or "unbound") with `Link2`/`Link2Off` icons and a blue border when bound. Clicking calls `POST /api/repo/bind` and updates state optimistically.

## What was NOT changed
- `clawflow sync` CLI command — remains the manual escape hatch, unchanged.
- The debounced push on config change was intentionally skipped: the simpler approach of pushing inline after `cfg.Save()` in the bind handler (and at run end) covers the main use cases without introducing `fsnotify` as a new dependency.
- Conflict resolution is last-write-wins on the Gist (existing behavior).

## Testing
- `go test ./...` — all packages pass
- Frontend: bind button renders correctly; `bound_machine` field flows from `repos.json` → `Repo` interface → card display