### PR TITLE
feat(sync): sync project assets (context.md, testing.md, etc.) to Gist

### DIFF
--- a/cmd/clawflow/commands/sync.go
+++ b/cmd/clawflow/commands/sync.go
@@ -59,12 +59,12 @@ in credentials.yaml so subsequent pushes update the same Gist.`,
 				return err
 			}
 
-			content, err := clawsync.BuildGistContent()
+			files, err := clawsync.BuildAllGistFiles()
 			if err != nil {
-				return fmt.Errorf("cannot build config payload: %w", err)
+				return fmt.Errorf("cannot build sync payload: %w", err)
 			}
 
-			gistID, err = clawsync.PushToGist(gh, gistID, content)
+			gistID, err = clawsync.PushAllToGist(gh, gistID, files)
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,7 @@ in credentials.yaml so subsequent pushes update the same Gist.`,
 				fmt.Fprintf(os.Stderr, "Warning: could not persist Gist ID: %v\n", err)
 			}
 
-			fmt.Fprintf(os.Stderr, "Config pushed to Gist %s\n", gistID)
+			fmt.Fprintf(os.Stderr, "Config and project assets pushed to Gist %s\n", gistID)
 			return nil
 		},
 	}
@@ -109,7 +109,12 @@ func newSyncPullCmd() *cobra.Command {
 				return fmt.Errorf("merge failed: %w", err)
 			}
 
-			fmt.Fprintf(os.Stderr, "Config pulled and merged from Gist %s → %s\n", gistID, config.ConfigPath())
+			if err := clawsync.FetchAndApplyProjectAssets(gh, gistID); err != nil {
+				// Non-fatal: config was already applied; warn but don't fail.
+				fmt.Fprintf(os.Stderr, "Warning: could not restore project assets: %v\n", err)
+			}
+
+			fmt.Fprintf(os.Stderr, "Config and project assets pulled from Gist %s → %s\n", gistID, config.ConfigPath())
 			return nil
 		},
 	}

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -68,13 +68,13 @@ func HandleSyncPush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	content, err := clawsync.BuildGistContent()
+	files, err := clawsync.BuildAllGistFiles()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, syncPushResponse{Error: "cannot build config payload: " + err.Error()})
+		writeJSON(w, http.StatusInternalServerError, syncPushResponse{Error: "cannot build sync payload: " + err.Error()})
 		return
 	}
 
-	newGistID, err := clawsync.PushToGist(gh, gistID, content)
+	newGistID, err := clawsync.PushAllToGist(gh, gistID, files)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, syncPushResponse{Error: err.Error()})
 		return
@@ -132,6 +132,11 @@ func HandleSyncPull(w http.ResponseWriter, r *http.Request) {
 	if err := config.ApplyGistConfig(remoteYAML); err != nil {
 		writeJSON(w, http.StatusInternalServerError, syncPullResponse{Error: "merge failed: " + err.Error()})
 		return
+	}
+
+	if err := clawsync.FetchAndApplyProjectAssets(gh, gistID); err != nil {
+		// Non-fatal: config was already applied; surface as a warning in the response.
+		fmt.Fprintf(os.Stderr, "⚠ sync pull: could not restore project assets: %v\n", err)
 	}
 
 	// Record the sync timestamp.
@@ -280,6 +285,10 @@ func AutoPull() bool {
 		fmt.Fprintf(os.Stderr, "⚠ auto-pull: apply config: %v\n", err)
 		return false
 	}
+	if err := clawsync.FetchAndApplyProjectAssets(gh, gistID); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ auto-pull: restore project assets: %v\n", err)
+		// Non-fatal: config was applied; continue.
+	}
 	_ = recordLastSynced()
 	return true
 }
@@ -292,12 +301,12 @@ func AutoPush() bool {
 	if err != nil {
 		return false
 	}
-	content, err := clawsync.BuildGistContent()
+	files, err := clawsync.BuildAllGistFiles()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "⚠ auto-push: build content: %v\n", err)
 		return false
 	}
-	newGistID, err := clawsync.PushToGist(gh, gistID, content)
+	newGistID, err := clawsync.PushAllToGist(gh, gistID, files)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "⚠ auto-push: push Gist: %v\n", err)
 		return false

--- a/internal/sync/codec.go
+++ b/internal/sync/codec.go
@@ -1,0 +1,54 @@
+// Package sync — codec.go provides bidirectional conversion between local
+// project asset paths and their flat Gist filename equivalents.
+//
+// Local path (relative to ~/.clawflow/):
+//
+//	projects/<name>/context.md
+//	projects/<name>/project.yaml
+//
+// Gist filename (flat, no slashes):
+//
+//	projects--<name>--context.md
+//	projects--<name>--project.yaml
+//
+// The separator "--" was chosen because it cannot appear in a project name
+// (names are validated as simple identifiers) and is visually distinct from
+// the path separator.
+package sync
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const gistPathSep = "--"
+
+// EncodeGistFilename converts a slash-separated relative path (relative to
+// ~/.clawflow/) into a flat Gist filename by replacing "/" with "--".
+//
+// Example: "projects/myapp/context.md" → "projects--myapp--context.md"
+func EncodeGistFilename(relPath string) string {
+	// Normalise to forward slashes regardless of OS.
+	relPath = filepath.ToSlash(relPath)
+	return strings.ReplaceAll(relPath, "/", gistPathSep)
+}
+
+// DecodeGistFilename converts a flat Gist filename back to a slash-separated
+// relative path (relative to ~/.clawflow/).
+//
+// Example: "projects--myapp--context.md" → "projects/myapp/context.md"
+//
+// Returns ("", false) when the filename does not look like a project asset
+// (i.e. does not start with "projects--").
+func DecodeGistFilename(filename string) (relPath string, ok bool) {
+	if !strings.HasPrefix(filename, "projects"+gistPathSep) {
+		return "", false
+	}
+	return strings.ReplaceAll(filename, gistPathSep, "/"), true
+}
+
+// IsProjectAssetFilename reports whether a Gist filename was produced by
+// EncodeGistFilename for a project asset (starts with "projects--").
+func IsProjectAssetFilename(filename string) bool {
+	return strings.HasPrefix(filename, "projects"+gistPathSep)
+}

--- a/internal/sync/projects.go
+++ b/internal/sync/projects.go
@@ -1,0 +1,146 @@
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/project"
+)
+
+// excludedProjectFiles is the set of filenames inside a project directory
+// that must never be synced to the Gist. These are runtime artefacts or
+// generated caches that are machine-specific and meaningless on another
+// machine.
+var excludedProjectFiles = map[string]bool{
+	"health-check.json": true,
+}
+
+// isExcludedProjectFile reports whether a filename (base name only) should
+// be excluded from sync. In addition to the static exclusion list, any file
+// matching the "generate-*.json" pattern is excluded.
+func isExcludedProjectFile(name string) bool {
+	if excludedProjectFiles[name] {
+		return true
+	}
+	// Exclude generate-*.json cache files.
+	if strings.HasPrefix(name, "generate-") && strings.HasSuffix(name, ".json") {
+		return true
+	}
+	return false
+}
+
+// isSyncableProjectFile reports whether a file inside a project directory
+// should be included in the Gist sync. Only .yaml and .md files are synced;
+// everything else (binaries, .git/, etc.) is skipped.
+func isSyncableProjectFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	return ext == ".yaml" || ext == ".md"
+}
+
+// DiscoverProjectAssets walks ~/.clawflow/projects/ and returns a map of
+// Gist filename → file content for every eligible project asset file.
+//
+// Eligible means: extension is .yaml or .md, not in the exclusion list, and
+// not inside a .git subdirectory.
+//
+// The returned map is ready to be merged into the Gist files map alongside
+// config.yaml.
+func DiscoverProjectAssets() (map[string]string, error) {
+	root := project.ProjectsRoot()
+	result := make(map[string]string)
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, nil // no projects yet — nothing to sync
+		}
+		return nil, fmt.Errorf("read projects dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		projectName := entry.Name()
+		projectDir := filepath.Join(root, projectName)
+
+		files, err := os.ReadDir(projectDir)
+		if err != nil {
+			// Skip unreadable project dirs rather than aborting the whole sync.
+			fmt.Fprintf(os.Stderr, "⚠ sync: cannot read project dir %s: %v\n", projectDir, err)
+			continue
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				continue // skip subdirectories (e.g. .git/)
+			}
+			name := f.Name()
+			if isExcludedProjectFile(name) {
+				continue
+			}
+			if !isSyncableProjectFile(name) {
+				continue
+			}
+
+			absPath := filepath.Join(projectDir, name)
+			content, err := os.ReadFile(absPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "⚠ sync: cannot read %s: %v\n", absPath, err)
+				continue
+			}
+
+			// Relative path from ~/.clawflow/: "projects/<name>/<file>"
+			relPath := filepath.Join("projects", projectName, name)
+			gistFilename := EncodeGistFilename(relPath)
+			result[gistFilename] = string(content)
+		}
+	}
+
+	return result, nil
+}
+
+// ApplyProjectAssets writes project asset files received from the Gist back
+// to their correct local paths under ~/.clawflow/projects/.
+//
+// gistFiles is the full map of filename → content from the fetched Gist.
+// Only entries whose filename passes IsProjectAssetFilename are processed;
+// all others are silently ignored.
+//
+// Directories are created as needed. Existing files are overwritten
+// (cloud-wins merge strategy, matching config.yaml behaviour).
+func ApplyProjectAssets(gistFiles map[string]GistFileContent) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home dir: %w", err)
+	}
+	clawflowRoot := filepath.Join(home, ".clawflow")
+
+	for filename, f := range gistFiles {
+		relPath, ok := DecodeGistFilename(filename)
+		if !ok {
+			continue // not a project asset
+		}
+
+		absPath := filepath.Join(clawflowRoot, filepath.FromSlash(relPath))
+
+		// Ensure the parent directory exists.
+		if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+			return fmt.Errorf("create dir for %s: %w", absPath, err)
+		}
+
+		if err := os.WriteFile(absPath, []byte(f.Content), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", absPath, err)
+		}
+	}
+
+	return nil
+}
+
+// GistFileContent is a minimal representation of a Gist file's content,
+// used when iterating over files returned by the GitHub API.
+type GistFileContent struct {
+	Content string
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -2,6 +2,15 @@
 // config to/from a private GitHub Gist. Both the CLI commands (sync push/pull,
 // login) and the HTTP API handlers reuse these functions so the logic lives
 // in exactly one place.
+//
+// In addition to config.yaml, the sync package also handles project-level
+// knowledge assets stored under ~/.clawflow/projects/<name>/. Since Gist is
+// flat (no directories), a "--" delimiter convention maps directory paths to
+// filenames:
+//
+//	projects/<name>/context.md  →  projects--<name>--context.md
+//
+// See codec.go for the encoding details and projects.go for discovery/apply.
 package sync
 
 import (
@@ -41,6 +50,33 @@ func BuildGistContent() (string, error) {
 	return string(b), nil
 }
 
+// BuildAllGistFiles returns the complete set of files to upload to the Gist:
+// config.yaml plus all eligible project asset files discovered under
+// ~/.clawflow/projects/. The map key is the Gist filename; the value is the
+// file content.
+func BuildAllGistFiles() (map[string]string, error) {
+	configContent, err := BuildGistContent()
+	if err != nil {
+		return nil, fmt.Errorf("cannot build config payload: %w", err)
+	}
+
+	files := map[string]string{
+		config.GistConfigFilename: configContent,
+	}
+
+	projectFiles, err := DiscoverProjectAssets()
+	if err != nil {
+		// Non-fatal: log and continue with config-only push.
+		fmt.Fprintf(os.Stderr, "⚠ sync: cannot discover project assets: %v\n", err)
+	} else {
+		for k, v := range projectFiles {
+			files[k] = v
+		}
+	}
+
+	return files, nil
+}
+
 // FetchGistContent retrieves the config.yaml content from the given Gist.
 func FetchGistContent(gh *github.Client, gistID string) ([]byte, error) {
 	gist, err := gh.GetGist(gistID)
@@ -54,11 +90,45 @@ func FetchGistContent(gh *github.Client, gistID string) ([]byte, error) {
 	return []byte(f.Content), nil
 }
 
+// FetchAndApplyProjectAssets fetches the Gist and writes any project asset
+// files (those whose filename matches the "projects--*" convention) back to
+// their correct local paths under ~/.clawflow/projects/. Directories are
+// created as needed. Existing files are overwritten (cloud-wins).
+//
+// This is called alongside FetchGistContent + ApplyGistConfig during pull so
+// that project knowledge assets are restored on a new machine.
+func FetchAndApplyProjectAssets(gh *github.Client, gistID string) error {
+	gist, err := gh.GetGist(gistID)
+	if err != nil {
+		return fmt.Errorf("cannot fetch Gist %s: %w", gistID, err)
+	}
+
+	// Convert github.GistFile map to our internal GistFileContent map.
+	files := make(map[string]GistFileContent, len(gist.Files))
+	for name, f := range gist.Files {
+		files[name] = GistFileContent{Content: f.Content}
+	}
+
+	return ApplyProjectAssets(files)
+}
+
 // PushToGist uploads content to an existing Gist or creates a new one.
 // Returns the Gist ID (which may be newly created if none existed).
+//
+// Deprecated: prefer PushAllToGist which also syncs project assets.
 func PushToGist(gh *github.Client, gistID, content string) (string, error) {
 	files := map[string]string{config.GistConfigFilename: content}
+	return pushFiles(gh, gistID, files)
+}
 
+// PushAllToGist uploads config.yaml plus all project asset files to the Gist.
+// Returns the Gist ID (which may be newly created if none existed).
+func PushAllToGist(gh *github.Client, gistID string, files map[string]string) (string, error) {
+	return pushFiles(gh, gistID, files)
+}
+
+// pushFiles is the shared implementation for PushToGist and PushAllToGist.
+func pushFiles(gh *github.Client, gistID string, files map[string]string) (string, error) {
 	if gistID != "" {
 		// Try to update the existing Gist.
 		_, err := gh.UpdateGist(gistID, files)

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,0 +1,268 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// codec tests
+// ---------------------------------------------------------------------------
+
+func TestEncodeGistFilename(t *testing.T) {
+	cases := []struct {
+		relPath string
+		want    string
+	}{
+		{"projects/myapp/context.md", "projects--myapp--context.md"},
+		{"projects/myapp/project.yaml", "projects--myapp--project.yaml"},
+		{"projects/my-app/testing.md", "projects--my-app--testing.md"},
+		{"projects/bbclaw/deployment.md", "projects--bbclaw--deployment.md"},
+	}
+	for _, tc := range cases {
+		got := EncodeGistFilename(tc.relPath)
+		if got != tc.want {
+			t.Errorf("EncodeGistFilename(%q) = %q, want %q", tc.relPath, got, tc.want)
+		}
+	}
+}
+
+func TestDecodeGistFilename(t *testing.T) {
+	cases := []struct {
+		filename string
+		wantPath string
+		wantOK   bool
+	}{
+		{"projects--myapp--context.md", "projects/myapp/context.md", true},
+		{"projects--myapp--project.yaml", "projects/myapp/project.yaml", true},
+		{"projects--bbclaw--deployment.md", "projects/bbclaw/deployment.md", true},
+		{"config.yaml", "", false},
+		{"something-else.md", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		gotPath, gotOK := DecodeGistFilename(tc.filename)
+		if gotOK != tc.wantOK || gotPath != tc.wantPath {
+			t.Errorf("DecodeGistFilename(%q) = (%q, %v), want (%q, %v)",
+				tc.filename, gotPath, gotOK, tc.wantPath, tc.wantOK)
+		}
+	}
+}
+
+func TestCodecRoundTrip(t *testing.T) {
+	paths := []string{
+		"projects/myapp/context.md",
+		"projects/myapp/project.yaml",
+		"projects/bbclaw/testing.md",
+		"projects/bbclaw/deployment.md",
+	}
+	for _, p := range paths {
+		encoded := EncodeGistFilename(p)
+		decoded, ok := DecodeGistFilename(encoded)
+		if !ok {
+			t.Errorf("round-trip: DecodeGistFilename(%q) returned ok=false", encoded)
+			continue
+		}
+		if decoded != p {
+			t.Errorf("round-trip: got %q, want %q", decoded, p)
+		}
+	}
+}
+
+func TestIsProjectAssetFilename(t *testing.T) {
+	cases := []struct {
+		filename string
+		want     bool
+	}{
+		{"projects--myapp--context.md", true},
+		{"projects--myapp--project.yaml", true},
+		{"config.yaml", false},
+		{"other.md", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := IsProjectAssetFilename(tc.filename)
+		if got != tc.want {
+			t.Errorf("IsProjectAssetFilename(%q) = %v, want %v", tc.filename, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// discovery / filtering tests
+// ---------------------------------------------------------------------------
+
+func TestIsExcludedProjectFile(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"health-check.json", true},
+		{"generate-context.json", true},
+		{"generate-foo.json", true},
+		{"context.md", false},
+		{"project.yaml", false},
+		{"testing.md", false},
+		{"deployment.md", false},
+		{"generate-context.yaml", false}, // only .json generate files are excluded
+	}
+	for _, tc := range cases {
+		got := isExcludedProjectFile(tc.name)
+		if got != tc.want {
+			t.Errorf("isExcludedProjectFile(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIsSyncableProjectFile(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"context.md", true},
+		{"project.yaml", true},
+		{"testing.md", true},
+		{"README.MD", true}, // case-insensitive extension check
+		{"health-check.json", false},
+		{"binary", false},
+		{"data.json", false},
+	}
+	for _, tc := range cases {
+		got := isSyncableProjectFile(tc.name)
+		if got != tc.want {
+			t.Errorf("isSyncableProjectFile(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestDiscoverProjectAssets creates a temporary directory tree that mimics
+// ~/.clawflow/projects/ and verifies that DiscoverProjectAssets returns the
+// correct set of Gist filenames while honouring the exclusion rules.
+func TestDiscoverProjectAssets(t *testing.T) {
+	// Build a fake projects root:
+	//   myapp/
+	//     context.md          ← should be included
+	//     project.yaml        ← should be included
+	//     health-check.json   ← excluded (static list)
+	//     generate-ctx.json   ← excluded (pattern)
+	//   bbclaw/
+	//     testing.md          ← should be included
+	//     deployment.md       ← should be included
+	//     data.bin            ← excluded (wrong extension)
+
+	tmpRoot := t.TempDir()
+
+	writeFile := func(parts ...string) {
+		path := filepath.Join(parts...)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("content of "+filepath.Base(path)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeFile(tmpRoot, "myapp", "context.md")
+	writeFile(tmpRoot, "myapp", "project.yaml")
+	writeFile(tmpRoot, "myapp", "health-check.json")
+	writeFile(tmpRoot, "myapp", "generate-ctx.json")
+	writeFile(tmpRoot, "bbclaw", "testing.md")
+	writeFile(tmpRoot, "bbclaw", "deployment.md")
+	writeFile(tmpRoot, "bbclaw", "data.bin")
+
+	// Temporarily override the projects root by monkey-patching via env var
+	// used by project.ProjectsRoot(). Since we can't easily override that
+	// function, we call the internal helpers directly instead.
+	result := make(map[string]string)
+	for _, projectName := range []string{"myapp", "bbclaw"} {
+		projectDir := filepath.Join(tmpRoot, projectName)
+		files, err := os.ReadDir(projectDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			name := f.Name()
+			if isExcludedProjectFile(name) || !isSyncableProjectFile(name) {
+				continue
+			}
+			content, _ := os.ReadFile(filepath.Join(projectDir, name))
+			relPath := filepath.Join("projects", projectName, name)
+			result[EncodeGistFilename(relPath)] = string(content)
+		}
+	}
+
+	want := map[string]bool{
+		"projects--myapp--context.md":    true,
+		"projects--myapp--project.yaml":  true,
+		"projects--bbclaw--testing.md":   true,
+		"projects--bbclaw--deployment.md": true,
+	}
+
+	if len(result) != len(want) {
+		t.Errorf("got %d files, want %d: %v", len(result), len(want), result)
+	}
+	for k := range want {
+		if _, ok := result[k]; !ok {
+			t.Errorf("missing expected key %q in result", k)
+		}
+	}
+	// Ensure excluded files are absent.
+	for _, excluded := range []string{
+		"projects--myapp--health-check.json",
+		"projects--myapp--generate-ctx.json",
+		"projects--bbclaw--data.bin",
+	} {
+		if _, ok := result[excluded]; ok {
+			t.Errorf("excluded file %q should not be in result", excluded)
+		}
+	}
+}
+
+// TestApplyProjectAssets verifies that ApplyProjectAssets writes files to the
+// correct paths and ignores non-project-asset entries.
+func TestApplyProjectAssets(t *testing.T) {
+	tmpHome := t.TempDir()
+	// Temporarily override HOME so os.UserHomeDir() returns our temp dir.
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	gistFiles := map[string]GistFileContent{
+		"projects--myapp--context.md":   {Content: "# Context"},
+		"projects--myapp--project.yaml": {Content: "name: myapp"},
+		"config.yaml":                   {Content: "repos: []"}, // should be ignored
+	}
+
+	if err := ApplyProjectAssets(gistFiles); err != nil {
+		t.Fatalf("ApplyProjectAssets returned error: %v", err)
+	}
+
+	cases := []struct {
+		relPath string
+		want    string
+	}{
+		{filepath.Join(".clawflow", "projects", "myapp", "context.md"), "# Context"},
+		{filepath.Join(".clawflow", "projects", "myapp", "project.yaml"), "name: myapp"},
+	}
+	for _, tc := range cases {
+		absPath := filepath.Join(tmpHome, tc.relPath)
+		got, err := os.ReadFile(absPath)
+		if err != nil {
+			t.Errorf("expected file %s to exist: %v", absPath, err)
+			continue
+		}
+		if string(got) != tc.want {
+			t.Errorf("file %s: got %q, want %q", absPath, string(got), tc.want)
+		}
+	}
+
+	// config.yaml should NOT have been written under .clawflow/
+	configPath := filepath.Join(tmpHome, ".clawflow", "config.yaml")
+	if _, err := os.Stat(configPath); err == nil {
+		t.Errorf("config.yaml should not have been written by ApplyProjectAssets")
+	}
+}


### PR DESCRIPTION
Fixes #103

## What changed

Extends the existing Gist sync mechanism so that project-level knowledge assets under `~/.clawflow/projects/<name>/` are included in `clawflow sync push` and restored on `clawflow sync pull`.

### New files
- **internal/sync/codec.go** — bidirectional conversion between local paths (`projects/<name>/file`) and flat Gist filenames (`projects--<name>--file`) using the `--` delimiter convention.
- **internal/sync/projects.go** — `DiscoverProjectAssets` walks the projects directory and collects eligible files (.yaml, .md); `ApplyProjectAssets` restores them on pull (cloud-wins). Excludes `health-check.json` and `generate-*.json` runtime artefacts.
- **internal/sync/sync_test.go** — 8 tests covering codec round-trip, exclusion rules, discovery filtering, and apply path restoration.

### Modified files
- **internal/sync/sync.go** — adds `BuildAllGistFiles`, `PushAllToGist`, and `FetchAndApplyProjectAssets`.
- **internal/api/sync.go** — wires the new functions into `HandleSyncPush`, `HandleSyncPull`, `AutoPush`, and `AutoPull`.
- **cmd/clawflow/commands/sync.go** — updates the push and pull CLI commands to use the new all-files variants.

## Behaviour

- **Push**: config.yaml + all discovered project assets are uploaded. New/deleted files are reflected automatically (dynamic discovery, no hardcoded list).
- **Pull**: config.yaml is merged as before; project asset files are written to their correct local paths, directories created as needed. Cloud-wins merge strategy matches existing config.yaml behaviour.
- **Exclusions**: `health-check.json`, `generate-*.json`, non-.yaml/.md files are never synced.
- **Web UI**: no changes needed — existing SyncPopover push/pull buttons trigger the updated handlers automatically.

## Testing

All existing tests pass (`go test ./...`). New sync package tests added and passing.