### PR TITLE
fix: per-operator quiet window to prevent false-positive reconciliation

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -732,7 +732,7 @@ func WritePending(entries []PendingEntry) error {
 	return writeJSON(filepath.Join(DataDir(), "pending.json"), entries)
 }
 
-// quietWindow is how long events.jsonl can sit untouched before a
+// DefaultQuietWindow is how long events.jsonl can sit untouched before a
 // status="running" meta is considered orphaned. Live runs flush
 // stream-json events every few hundred ms; if nothing has hit the
 // file for a couple of minutes the runner process is gone (kill,
@@ -740,7 +740,26 @@ func WritePending(entries []PendingEntry) error {
 // inter-event gap (claude can pause ~30 s mid-tool-use) and shorter
 // than the default per-operator timeout (60 min) so dashboard
 // reflects reality long before the timeout-based path triggers.
-const quietWindow = 2 * time.Minute
+var DefaultQuietWindow = 2 * time.Minute
+
+// OperatorQuietWindows overrides DefaultQuietWindow for specific operators
+// whose workloads routinely produce long gaps between stream events (e.g.
+// running tests, large file writes, extended reasoning chains). Keys are
+// operator names as stored in RunMeta.Operator (the SKILL.md filename stem).
+var OperatorQuietWindows = map[string]time.Duration{
+	// implement tasks can pause 5+ minutes during `go test`, large file
+	// writes, or multi-step reasoning — 10 min avoids false-positive kills.
+	"implement": 10 * time.Minute,
+}
+
+// quietWindowFor returns the quiet-window threshold for the given operator,
+// falling back to DefaultQuietWindow when no override is registered.
+func quietWindowFor(operator string) time.Duration {
+	if d, ok := OperatorQuietWindows[operator]; ok {
+		return d
+	}
+	return DefaultQuietWindow
+}
 
 // LogSink is the small subset of internal/log.Logger that the reconciler
 // needs to record events. Defined here as an interface so the snapshot
@@ -848,9 +867,10 @@ func extractTerminalResult(eventsPath string) (subtype string, resultText string
 //     SIGTERM) before finalizing the meta. Without this, the dashboard
 //     would show a frozen "running" row forever.
 //   - meta.json with status="running" whose events.jsonl hasn't been
-//     written to in `quietWindow`: also rewrite to "failed" (interrupted
-//     process). Catches an interrupt within 2 min instead of waiting
-//     out the full per-operator timeout.
+//     written to in the operator's quiet window (DefaultQuietWindow for
+//     most operators, longer for complex ones like "implement"): rewrite
+//     to "failed" (interrupted process). Catches an interrupt well before
+//     the full per-operator staleAfter timeout.
 //   - run dir that contains events.jsonl but no meta.json: synthesize a
 //     "failed" meta from the dir layout (repo / issue / timestamp) and
 //     events.jsonl mtime. Possible when WriteRunMeta itself failed for
@@ -910,29 +930,31 @@ func reconcileStaleRunsAt(runsRoot string, staleAfter time.Duration) (int, error
 			}
 			// A run is orphaned if EITHER it's been "running" longer than
 			// the per-operator timeout OR its events.jsonl has gone quiet.
-			// The events-quiet check fires much faster (2 min vs 60 min)
-			// and matches the actual failure mode users hit — they Ctrl-C
-			// or kill the process and want the dashboard to reflect that
-			// without waiting an hour.
+			// The events-quiet check fires much faster than staleAfter and
+			// matches the actual failure mode users hit — they Ctrl-C or
+			// kill the process and want the dashboard to reflect that
+			// without waiting an hour. The threshold is per-operator so
+			// long-running operators (e.g. "implement") get a wider window.
+			qw := quietWindowFor(m.Operator)
 			tooOld := !m.StartedAt.After(cutoff)
 			eventsQuiet := false
 			var lastTouch time.Time
 			if st, err := os.Stat(eventsPath); err == nil {
 				lastTouch = st.ModTime().UTC()
-				eventsQuiet = time.Since(lastTouch) > quietWindow
+				eventsQuiet = time.Since(lastTouch) > qw
 			} else {
 				// No events.jsonl at all: a healthy runner opens the
 				// file and writes claude's `system-init` event within
-				// seconds of starting, so anything past quietWindow
-				// (2 min) with no file means the runner died before
-				// launching claude — flag without waiting the full
-				// staleAfter timeout (default 1h) to land here.
-				eventsQuiet = time.Since(m.StartedAt) > quietWindow
+				// seconds of starting, so anything past the quiet window
+				// with no file means the runner died before launching
+				// claude — flag without waiting the full staleAfter
+				// timeout (default 1h) to land here.
+				eventsQuiet = time.Since(m.StartedAt) > qw
 			}
 			if !tooOld && !eventsQuiet {
 				return nil
 			}
-			// events.jsonl can stall past quietWindow even on a healthy
+			// events.jsonl can stall past the quiet window even on a healthy
 			// runner — claude's API retries on upstream 5xx, a long
 			// `go test` or `Task` subagent call, etc. Before declaring
 			// the runner dead, consult the lockfile written by
@@ -977,7 +999,7 @@ func reconcileStaleRunsAt(runsRoot string, staleAfter time.Duration) (int, error
 				case tooOld && eventsQuiet:
 					m.Error = fmt.Sprintf(
 						"reconciled: stuck in running for >%s and events.jsonl quiet for >%s; runner is gone",
-						staleAfter, quietWindow,
+						staleAfter, qw,
 					)
 				case tooOld:
 					m.Error = fmt.Sprintf(
@@ -987,7 +1009,7 @@ func reconcileStaleRunsAt(runsRoot string, staleAfter time.Duration) (int, error
 				default:
 					m.Error = fmt.Sprintf(
 						"reconciled: events.jsonl quiet for >%s and runner PID is dead/missing (interrupted/killed)",
-						quietWindow,
+						qw,
 					)
 				}
 			}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -341,14 +341,14 @@ func TestReconcileStaleRuns_RecentRunning_Untouched(t *testing.T) {
 }
 
 // A run whose meta.json says "running" but has no events.jsonl AT ALL is
-// reconciled once it's older than quietWindow — RunClaude opens the events
+// reconciled once it's older than DefaultQuietWindow — RunClaude opens the events
 // file before launching claude, so a missing file past that window means
 // the runner died before getting that far. Without this aggressive sweep
 // the dashboard would carry a frozen "running" row for the full staleAfter
 // timeout (default 1h).
 func TestReconcileStaleRuns_NoEventsBeyondQuietWindow_RewrittenToFailed(t *testing.T) {
 	root := t.TempDir()
-	start := time.Now().UTC().Add(-quietWindow - time.Minute) // safely past 2min
+	start := time.Now().UTC().Add(-DefaultQuietWindow - time.Minute) // safely past 2min
 	stuck := &RunMeta{
 		Operator:    "classify",
 		Repo:        "owner/repo",
@@ -363,11 +363,11 @@ func TestReconcileStaleRuns_NoEventsBeyondQuietWindow_RewrittenToFailed(t *testi
 		t.Fatalf("reconcile: %v", err)
 	}
 	if n != 1 {
-		t.Errorf("fixed=%d, want 1 (no events past quietWindow should reconcile)", n)
+		t.Errorf("fixed=%d, want 1 (no events past DefaultQuietWindow should reconcile)", n)
 	}
 }
 
-// A run whose events.jsonl has gone quiet past quietWindow but whose
+// A run whose events.jsonl has gone quiet past DefaultQuietWindow but whose
 // runner PID is still alive (e.g. claude is mid-`api_retry` against an
 // upstream 502, or running a slow tool/subagent) must NOT be marked
 // failed. Without this, `clawflow web`'s minute-tick reconciler races
@@ -375,7 +375,7 @@ func TestReconcileStaleRuns_NoEventsBeyondQuietWindow_RewrittenToFailed(t *testi
 // dashboard while the actual claude subprocess keeps producing work.
 func TestReconcileStaleRuns_QuietButRunnerAlive_Untouched(t *testing.T) {
 	root := t.TempDir()
-	start := time.Now().UTC().Add(-quietWindow - time.Minute)
+	start := time.Now().UTC().Add(-DefaultQuietWindow - time.Minute)
 	live := &RunMeta{
 		Operator:    "implement",
 		Repo:        "owner/repo",
@@ -424,9 +424,9 @@ func TestReconcileStaleRuns_QuietButRunnerAlive_Untouched(t *testing.T) {
 // claimed the runner was gone without ever checking.
 func TestReconcileStaleRuns_QuietRunnerDead_RewrittenToFailed(t *testing.T) {
 	root := t.TempDir()
-	start := time.Now().UTC().Add(-quietWindow - time.Minute)
+	start := time.Now().UTC().Add(-DefaultQuietWindow - time.Minute)
 	dead := &RunMeta{
-		Operator:    "implement",
+		Operator:    "evaluate-bug", // uses DefaultQuietWindow, not an overridden operator
 		Repo:        "owner/repo",
 		IssueNumber: 43,
 		StartedAt:   start,
@@ -459,6 +459,78 @@ func TestReconcileStaleRuns_QuietRunnerDead_RewrittenToFailed(t *testing.T) {
 	}
 	if !strings.Contains(got.Error, "PID is dead/missing") {
 		t.Errorf("Error=%q, want it to mention the real PID check", got.Error)
+	}
+}
+
+// TestReconcileStaleRuns_ImplementOperator_WiderQuietWindow verifies that the
+// "implement" operator is not reconciled when events.jsonl is only past the
+// DefaultQuietWindow (2 min) but within the operator-specific window (10 min).
+// This is the core regression test for issue #105.
+func TestReconcileStaleRuns_ImplementOperator_WiderQuietWindow(t *testing.T) {
+	root := t.TempDir()
+	// Start time is well in the past so tooOld is false (staleAfter=1h).
+	start := time.Now().UTC().Add(-5 * time.Minute)
+	running := &RunMeta{
+		Operator:    "implement",
+		Repo:        "owner/repo",
+		IssueNumber: 77,
+		StartedAt:   start,
+		Status:      "running",
+	}
+	dir := makeRunDir(t, root, "owner__repo", 77, start, running, `{"type":"system","subtype":"init"}`+"\n")
+
+	// Backdate events.jsonl to 3 minutes ago — past DefaultQuietWindow (2 min)
+	// but within the implement override (10 min). A live runner would not be
+	// killed here.
+	threeMinAgo := time.Now().Add(-3 * time.Minute)
+	if err := os.Chtimes(filepath.Join(dir, "events.jsonl"), threeMinAgo, threeMinAgo); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	prev := runnerStillAlive
+	t.Cleanup(func() { runnerStillAlive = prev })
+	runnerStillAlive = func(string, int, time.Time) bool { return false }
+
+	n, err := reconcileStaleRunsAt(root, time.Hour)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("fixed=%d, want 0: implement operator should not be reconciled at 3 min quiet (window is 10 min)", n)
+	}
+}
+
+// TestReconcileStaleRuns_ImplementOperator_PastWiderWindow verifies that an
+// "implement" run IS reconciled once events.jsonl exceeds its 10-min window.
+func TestReconcileStaleRuns_ImplementOperator_PastWiderWindow(t *testing.T) {
+	root := t.TempDir()
+	implementWindow := OperatorQuietWindows["implement"]
+	start := time.Now().UTC().Add(-implementWindow - 5*time.Minute)
+	running := &RunMeta{
+		Operator:    "implement",
+		Repo:        "owner/repo",
+		IssueNumber: 78,
+		StartedAt:   start,
+		Status:      "running",
+	}
+	dir := makeRunDir(t, root, "owner__repo", 78, start, running, `{"type":"system","subtype":"init"}`+"\n")
+
+	// Backdate events.jsonl past the 10-min implement window.
+	pastWindow := time.Now().Add(-implementWindow - time.Minute)
+	if err := os.Chtimes(filepath.Join(dir, "events.jsonl"), pastWindow, pastWindow); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	prev := runnerStillAlive
+	t.Cleanup(func() { runnerStillAlive = prev })
+	runnerStillAlive = func(string, int, time.Time) bool { return false }
+
+	n, err := reconcileStaleRunsAt(root, time.Hour)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("fixed=%d, want 1: implement operator should be reconciled past its 10-min window", n)
 	}
 }
 
@@ -557,7 +629,7 @@ func TestReconcileStaleRuns_Idempotent(t *testing.T) {
 // runner process died before writing the final meta.json.
 func TestReconcileStaleRuns_SuccessResult_ReconciledAsSuccess(t *testing.T) {
 	root := t.TempDir()
-	start := time.Now().UTC().Add(-quietWindow - time.Minute)
+	start := time.Now().UTC().Add(-DefaultQuietWindow - time.Minute)
 	stuck := &RunMeta{
 		Operator:    "evaluate-bug",
 		Repo:        "owner/repo",
@@ -571,7 +643,7 @@ func TestReconcileStaleRuns_SuccessResult_ReconciledAsSuccess(t *testing.T) {
 
 	dir := makeRunDir(t, root, "owner__repo", 42, start, stuck, events)
 	// Backdate events.jsonl mtime so it looks quiet
-	past := time.Now().Add(-quietWindow - 30*time.Second)
+	past := time.Now().Add(-DefaultQuietWindow - 30*time.Second)
 	os.Chtimes(filepath.Join(dir, "events.jsonl"), past, past)
 
 	n, err := reconcileStaleRunsAt(root, time.Hour)
@@ -609,9 +681,9 @@ func TestReconcileStaleRuns_SuccessResult_ReconciledAsSuccess(t *testing.T) {
 // the reconciler still marks the run as "failed".
 func TestReconcileStaleRuns_ErrorResult_ReconciledAsFailed(t *testing.T) {
 	root := t.TempDir()
-	start := time.Now().UTC().Add(-quietWindow - time.Minute)
+	start := time.Now().UTC().Add(-DefaultQuietWindow - time.Minute)
 	stuck := &RunMeta{
-		Operator:    "implement",
+		Operator:    "evaluate-bug", // uses DefaultQuietWindow, not an overridden operator
 		Repo:        "owner/repo",
 		IssueNumber: 99,
 		StartedAt:   start,
@@ -621,7 +693,7 @@ func TestReconcileStaleRuns_ErrorResult_ReconciledAsFailed(t *testing.T) {
 		`{"type":"result","subtype":"error","is_error":true,"duration_ms":5000,"num_turns":1,"result":"something went wrong","total_cost_usd":0.01,"usage":{"input_tokens":100,"output_tokens":10,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"modelUsage":{}}` + "\n"
 
 	dir := makeRunDir(t, root, "owner__repo", 99, start, stuck, events)
-	past := time.Now().Add(-quietWindow - 30*time.Second)
+	past := time.Now().Add(-DefaultQuietWindow - 30*time.Second)
 	os.Chtimes(filepath.Join(dir, "events.jsonl"), past, past)
 
 	n, err := reconcileStaleRunsAt(root, time.Hour)


### PR DESCRIPTION
Fixes #105

## What changed

Replaced the hardcoded `const quietWindow = 2 * time.Minute` in `internal/snapshot/snapshot.go` with a configurable per-operator system:

- `DefaultQuietWindow` (var, 2 min) — unchanged default for all operators
- `OperatorQuietWindows` map — per-operator overrides; `implement` is registered at 10 min
- `quietWindowFor(operator)` helper — resolves the right threshold, falls back to default
- `reconcileStaleRunsAt` now calls `qw := quietWindowFor(m.Operator)` and uses `qw` for both the quiet check and error messages

## Why

The `implement` operator was killed 3 consecutive times on issue #103 because `claude -p` paused >2 min between stream events during `go test` runs and extended reasoning. The 4th attempt succeeded after 18 min / 19 turns. The 2-min threshold was correct for short operators but too aggressive for complex implementation tasks.

## Tests

- Two existing tests that used `Operator: "implement"` with `DefaultQuietWindow`-based offsets were updated to use `evaluate-bug` (which uses the default window) — they were testing dead-runner behavior, not timeout tuning.
- Added `TestReconcileStaleRuns_ImplementOperator_WiderQuietWindow`: verifies implement is NOT reconciled at 3 min quiet (within its 10-min window).
- Added `TestReconcileStaleRuns_ImplementOperator_PastWiderWindow`: verifies implement IS reconciled once past its 10-min window.
- All 18 snapshot tests pass; full `go test ./...` green.