### PR TITLE
fix: detect rate limits and stop cascading queue failures

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -473,6 +475,12 @@ func scanRepoOnce(reg *operator.Registry, fullName string, repoCfg config.Repo, 
 // clone stay serialized. Returns the set of jobs whose operator
 // produced output (i.e. fired), so the caller can deduplicate pending
 // entries.
+//
+// Rate-limit circuit breaker: when any worker detects a transient rate-limit
+// from claude, it sets a shared atomic flag. Subsequent workers check the flag
+// before starting and skip their job (recording status="rate-limited") so the
+// entire queue doesn't cascade into failures. The skipped issues retain their
+// trigger labels and will be retried on the next run pass.
 func runJobsParallel(ctx context.Context, jobs []*runJob, workers int, timeout time.Duration) []firedKey {
 	if len(jobs) == 0 {
 		return nil
@@ -485,10 +493,11 @@ func runJobsParallel(ctx context.Context, jobs []*runJob, workers int, timeout t
 	}
 
 	var (
-		issueLocks sync.Map // key: "<repo>#<issue>" → *sync.Mutex
-		repoLocks  sync.Map // key: "<repo>"          → *sync.Mutex
-		fired      []firedKey
-		firedMu    sync.Mutex
+		issueLocks  sync.Map    // key: "<repo>#<issue>" → *sync.Mutex
+		repoLocks   sync.Map    // key: "<repo>"          → *sync.Mutex
+		fired       []firedKey
+		firedMu     sync.Mutex
+		rateLimited atomic.Bool // set when any worker hits a rate limit
 	)
 
 	mu := func(m *sync.Map, key string) *sync.Mutex {
@@ -503,6 +512,16 @@ func runJobsParallel(ctx context.Context, jobs []*runJob, workers int, timeout t
 		go func() {
 			defer wg.Done()
 			for j := range jobCh {
+				// If a previous worker hit a rate limit, skip remaining
+				// jobs so they aren't permanently marked as failed. They
+				// keep their trigger labels and will be retried next pass.
+				if rateLimited.Load() {
+					prefix := fmt.Sprintf("[%s#%d %s]", j.repo, j.sub.Number, j.op.Name)
+					fmt.Fprintf(os.Stderr, "%s → skipped (rate limit hit earlier in this pass)\n", prefix)
+					runLog.Info("run/skipped_rate_limit", "repo", j.repo, "issue", j.sub.Number, "op", j.op.Name)
+					continue
+				}
+
 				iMu := mu(&issueLocks, fmt.Sprintf("%s#%d", j.repo, j.sub.Number))
 				iMu.Lock()
 				// `implement` mutates a shared local clone (worktree
@@ -514,11 +533,14 @@ func runJobsParallel(ctx context.Context, jobs []*runJob, workers int, timeout t
 					rMu = mu(&repoLocks, j.repo)
 					rMu.Lock()
 				}
-				didFire := runOneOperator(ctx, j, timeout)
+				didFire, hitRateLimit := runOneOperator(ctx, j, timeout)
 				if rMu != nil {
 					rMu.Unlock()
 				}
 				iMu.Unlock()
+				if hitRateLimit {
+					rateLimited.Store(true)
+				}
 				if didFire {
 					firedMu.Lock()
 					fired = append(fired, firedKey{Repo: j.repo, IssueNumber: j.sub.Number, Operator: j.op.Name})
@@ -537,11 +559,14 @@ func runJobsParallel(ctx context.Context, jobs []*runJob, workers int, timeout t
 
 // runOneOperator executes a single operator against its issue and
 // persists meta.json + events.jsonl under the dashboard data dir.
-// Returns true when the operator produced non-empty stdout (i.e.
-// "fired" — its outcome label was applied or its comment was posted).
+// Returns (didFire, hitRateLimit):
+//   - didFire: true when the operator produced non-empty stdout (outcome label applied)
+//   - hitRateLimit: true when claude exited with a transient rate-limit error;
+//     the caller should stop dispatching remaining jobs this pass
+//
 // All log lines are prefixed with "[<repo>#<issue> <op>]" so output
 // from concurrent workers stays disentangleable.
-func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) bool {
+func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didFire bool, hitRateLimit bool) {
 	prefix := fmt.Sprintf("[%s#%d %s]", j.repo, j.sub.Number, j.op.Name)
 	fmt.Printf("%s → start\n", prefix)
 
@@ -551,7 +576,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) bool 
 	if err := snapshot.AcquireLock(j.repo, j.sub.Number, j.op.Name); err != nil {
 		fmt.Fprintf(os.Stderr, "%s ⚠ lock failed (another process owns it): %v\n", prefix, err)
 		runLog.Warn("run/lock_failed", "repo", j.repo, "issue", j.sub.Number, "op", j.op.Name, "err", err.Error())
-		return false
+		return false, false
 	}
 	defer snapshot.ReleaseLock(j.repo, j.sub.Number)
 	runLog.Info("run/lock", "pid", os.Getpid(), "repo", j.repo, "issue", j.sub.Number, "op", j.op.Name)
@@ -565,7 +590,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) bool 
 		freshSub.Labels = freshLabels
 		if ok, reason := operator.MatchesWithReason(&freshSub, j.op); !ok {
 			fmt.Printf("%s → skip (labels changed since poll: %s)\n", prefix, reason)
-			return false
+			return false, false
 		}
 	}
 
@@ -609,7 +634,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) bool 
 		runningMeta.EndedAt = &now
 		_ = snapshot.WriteRunMeta(runDir, runningMeta)
 		checkCircuitBreaker(j, prefix)
-		return false
+		return false, false
 	}
 	workdir := wtResult.Path
 	if wtResult.Resumed {
@@ -651,8 +676,19 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) bool 
 	if eventsFile != nil {
 		_ = eventsFile.Close()
 	}
+
+	// Detect transient rate-limit errors before deciding on the run status.
+	// A rate-limited run is NOT a permanent failure: the issue keeps its
+	// trigger labels and will be retried on the next pass. We also signal
+	// the caller so it can abort the remaining job queue.
+	isRateLimit := runErr != nil && errors.Is(runErr, operator.ErrRateLimit)
+
 	if runErr != nil {
-		fmt.Fprintf(os.Stderr, "%s ✗ claude failed: %v\n", prefix, runErr)
+		if isRateLimit {
+			fmt.Fprintf(os.Stderr, "%s ✗ claude rate limited (will retry next pass): %v\n", prefix, runErr)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s ✗ claude failed: %v\n", prefix, runErr)
+		}
 	} else {
 		fmt.Fprintf(os.Stderr, "%s ✓ claude finished in %s\n", prefix, runDur)
 	}
@@ -668,6 +704,11 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) bool 
 		Summary:     output,
 	}
 	switch {
+	case isRateLimit:
+		// Record as "rate-limited" so the dashboard shows the real reason
+		// and ConsecutiveFailures doesn't count this toward the circuit breaker.
+		rm.Status = "rate-limited"
+		rm.Error = runErr.Error()
 	case runErr != nil:
 		rm.Status = "failed"
 		rm.Error = runErr.Error()
@@ -710,12 +751,15 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) bool 
 	switch rm.Status {
 	case "success":
 		fmt.Printf("%s ✓ done\n", prefix)
-		return true
+		return true, false
 	case "skipped":
-		return true
+		return true, false
+	case "rate-limited":
+		// Signal the caller to abort the queue; do NOT call checkCircuitBreaker.
+		return false, true
 	default:
 		checkCircuitBreaker(j, prefix)
-		return false
+		return false, false
 	}
 }
 

--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -4,15 +4,58 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/zhoushoujianwork/clawflow/internal/claude"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
 )
+
+// ErrRateLimit is returned by RunClaude (and propagated through operator.Run)
+// when the claude CLI exits with a transient rate-limit or quota error.
+// Callers should NOT mark the run as permanently failed — instead they should
+// stop processing the current queue and let the next scheduled run retry.
+var ErrRateLimit = errors.New("claude rate limit")
+
+// rateLimitPatterns are substrings (case-insensitive) that identify a
+// transient rate-limit / quota response from the claude CLI. The list covers:
+//   - Claude Code CLI English output: "You've hit your limit"
+//   - Claude Code CLI Chinese locale: "您已达到限制" (unlikely but defensive)
+//   - HTTP 429 / API error codes surfaced in stderr
+//   - Anthropic credit/quota messages
+var rateLimitPatterns = []string{
+	"hit your limit",
+	"you've hit your limit",
+	"usage limit reached",
+	"rate_limit_error",
+	"rate limit",
+	"429",
+	"quota exceeded",
+	"credit balance is too low",
+	"overloaded_error",
+}
+
+// IsRateLimitError reports whether err or the captured claude output text
+// indicates a transient rate-limit condition. Both are checked because the
+// claude CLI sometimes writes the human-readable message to stdout (captured
+// in output) while the Go error only carries "exit status 1".
+func IsRateLimitError(err error, output string) bool {
+	if err == nil {
+		return false
+	}
+	combined := strings.ToLower(err.Error() + " " + output)
+	for _, pat := range rateLimitPatterns {
+		if strings.Contains(combined, strings.ToLower(pat)) {
+			return true
+		}
+	}
+	return false
+}
 
 // RunClaude executes `claude -p --output-format stream-json` in a subprocess
 // and returns the final result text. If `events` is non-nil, every raw
@@ -84,7 +127,14 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 	// text deltas for user-facing progress.
 	result, parseErr := parseClaudeStream(stdout, events)
 	if err := cmd.Wait(); err != nil {
-		return result, fmt.Errorf("claude: %w", err)
+		// Wrap transient rate-limit exits with ErrRateLimit so callers can
+		// distinguish them from permanent failures and avoid cascading the
+		// error across the remaining job queue.
+		wrapped := fmt.Errorf("claude: %w", err)
+		if IsRateLimitError(err, result) {
+			return result, fmt.Errorf("%w: %w", ErrRateLimit, wrapped)
+		}
+		return result, wrapped
 	}
 	if parseErr != nil {
 		return result, fmt.Errorf("parse stream: %w", parseErr)

--- a/internal/operator/claude_test.go
+++ b/internal/operator/claude_test.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -156,5 +157,83 @@ func TestParseClaudeStream_MultipleMarkerTurns_LastWins(t *testing.T) {
 	label, _ := parseOutcome(got)
 	if label != "agent-evaluated" {
 		t.Errorf("last marker turn should win; got label %q", label)
+	}
+}
+
+func TestIsRateLimitError(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		output  string
+		want    bool
+	}{
+		{
+			name:   "nil error",
+			err:    nil,
+			output: "",
+			want:   false,
+		},
+		{
+			name:   "generic exit status 1",
+			err:    errors.New("claude: exit status 1"),
+			output: "some unrelated error",
+			want:   false,
+		},
+		{
+			name:   "hit your limit in output",
+			err:    errors.New("claude: exit status 1"),
+			output: "You've hit your limit · resets 3:20am (Asia/Shanghai)",
+			want:   true,
+		},
+		{
+			name:   "hit your limit case-insensitive",
+			err:    errors.New("claude: exit status 1"),
+			output: "YOU'VE HIT YOUR LIMIT",
+			want:   true,
+		},
+		{
+			name:   "rate_limit_error in err",
+			err:    errors.New("claude: rate_limit_error"),
+			output: "",
+			want:   true,
+		},
+		{
+			name:   "429 in output",
+			err:    errors.New("claude: exit status 1"),
+			output: "HTTP 429 Too Many Requests",
+			want:   true,
+		},
+		{
+			name:   "usage limit reached",
+			err:    errors.New("claude: exit status 1"),
+			output: "Usage limit reached for this billing period",
+			want:   true,
+		},
+		{
+			name:   "credit balance is too low",
+			err:    errors.New("claude: exit status 1"),
+			output: "Credit balance is too low to run this request",
+			want:   true,
+		},
+		{
+			name:   "quota exceeded",
+			err:    errors.New("claude: exit status 1"),
+			output: "quota exceeded",
+			want:   true,
+		},
+		{
+			name:   "overloaded_error",
+			err:    errors.New("claude: exit status 1"),
+			output: "overloaded_error: API is temporarily overloaded",
+			want:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsRateLimitError(tc.err, tc.output)
+			if got != tc.want {
+				t.Errorf("IsRateLimitError(%v, %q) = %v, want %v", tc.err, tc.output, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #107

## What changed

**Root cause:** When `claude -p` exits with a transient rate-limit error, the runner had no way to distinguish it from a permanent failure. It recorded `status=failed`, continued dispatching remaining jobs into the same rate-limited API, and each subsequent job failed in ~3s — cascading the single rate limit into a full queue wipeout.

## Changes

### `internal/operator/claude.go`
- Added `ErrRateLimit` sentinel error
- Added `IsRateLimitError(err, output) bool` that matches all known rate-limit patterns case-insensitively: `"hit your limit"`, `"rate_limit_error"`, `"429"`, `"quota exceeded"`, `"credit balance is too low"`, `"overloaded_error"`, `"usage limit reached"`
- `RunClaude` now wraps matching exits with `ErrRateLimit` so callers can type-check with `errors.Is`

### `cmd/clawflow/commands/run.go`
- `runOneOperator` signature changed to return `(didFire bool, hitRateLimit bool)`
- Rate-limited runs are recorded as `status="rate-limited"` (not `"failed"`) — they do **not** trigger `checkCircuitBreaker`, so the circuit breaker counter stays clean
- `runJobsParallel` gains an `atomic.Bool` abort flag; when any worker signals a rate limit, subsequent workers skip their jobs with a log line (`run/skipped_rate_limit`) instead of running them into the same wall

### `internal/operator/claude_test.go`
- 10 table-driven tests for `IsRateLimitError` covering all pattern variants and the nil/generic-error cases

## Behaviour after this fix

Given the scenario from the issue (issues #5–#8 queued, API at rate limit):
- Issue #8 runs, hits rate limit → recorded as `rate-limited`, queue abort flag set
- Issues #7, #6, #5 → skipped with log `run/skipped_rate_limit`, trigger labels preserved
- Next `clawflow run` pass retries all four issues normally
- Circuit breaker is not incremented for any of them