### PR TITLE
fix: write status=finalizing to prevent duplicate re-runs after crash

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -722,6 +722,29 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		_ = eventsFile.Close()
 	}
 
+	// Write status=finalizing immediately after operator.Run() returns
+	// successfully. This is the first post-claude action, before usage
+	// extraction, worktree cleanup, or any other work. If the process is
+	// killed in the window between here and the final WriteRunMeta below,
+	// the reconciler will see "finalizing" (not "running") and know that
+	// VCS side-effects already completed — it will promote to "success"
+	// without re-queuing the issue for a duplicate run.
+	if runErr == nil && output != "" {
+		finalizingMeta := snapshot.RunMeta{
+			Operator:    j.op.Name,
+			Repo:        j.repo,
+			IssueNumber: j.sub.Number,
+			IssueTitle:  j.sub.Title,
+			IssueState:  j.sub.State,
+			StartedAt:   startedAt.UTC(),
+			Status:      "finalizing",
+			Summary:     output,
+		}
+		if err := snapshot.WriteRunMeta(runDir, finalizingMeta); err != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ finalizing meta: %v\n", prefix, err)
+		}
+	}
+
 	// Detect transient rate-limit errors before deciding on the run status.
 	// A rate-limited run is NOT a permanent failure: the issue keeps its
 	// trigger labels and will be retried on the next pass. We also signal

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -240,10 +240,14 @@ type RunMeta struct {
 	// would carry "0001-01-01T00:00:00Z" and the dashboard's duration math
 	// would render it as a giant negative offset.
 	EndedAt     *time.Time `json:"ended_at,omitempty"`
-	// Status is one of "running", "success", "failed", "skipped", "cancelled".
+	// Status is one of "running", "finalizing", "success", "failed", "skipped", "cancelled".
 	// "cancelled" is set only by /api/run/cancel after the runner process
 	// is killed — it lets the dashboard distinguish a user-initiated kill
 	// from an organic crash ("failed").
+	// "finalizing" is written immediately after operator.Run() returns
+	// successfully, before usage extraction and meta cleanup. If the process
+	// is killed in this window, the reconciler treats it as completed (not
+	// stale) and promotes it to "success" without re-queuing the issue.
 	Status  string `json:"status"`
 	PRUrl   string `json:"pr_url,omitempty"`
 	Error   string `json:"error,omitempty"`
@@ -692,7 +696,7 @@ func MarkRunningAsCancelled(repo string, issueNum int, reason string) int {
 		if err := json.Unmarshal(data, &m); err != nil {
 			continue
 		}
-		if m.Status != "running" {
+		if m.Status != "running" && m.Status != "finalizing" {
 			continue
 		}
 		m.Status = "cancelled"
@@ -984,6 +988,31 @@ func reconcileStaleRunsAt(runsRoot string, staleAfter time.Duration) (int, error
 			if err := json.Unmarshal(data, &m); err != nil {
 				return nil
 			}
+
+			// A run stuck in "finalizing" means operator.Run() completed
+			// (VCS side-effects done: comment posted, outcome label applied,
+			// trigger labels removed) but the process was killed before
+			// WriteRunMeta could record the terminal status. The issue will
+			// not re-trigger because its trigger labels are already gone.
+			// Just backfill usage and promote to "success".
+			if m.Status == "finalizing" {
+				if !runnerStillAlive(m.Repo, m.IssueNumber, m.StartedAt) {
+					if u, uErr := ExtractUsage(eventsPath); uErr == nil && u != nil {
+						m.Usage = u
+					}
+					m.Status = "success"
+					if m.EndedAt == nil || m.EndedAt.IsZero() {
+						t := time.Now().UTC()
+						m.EndedAt = &t
+					}
+					m.Error = "reconciled: runner exited after finalizing VCS side-effects but before writing terminal meta"
+					if err := WriteRunMeta(path, m); err == nil {
+						fixed++
+					}
+				}
+				return nil
+			}
+
 			if m.Status != "running" {
 				return nil
 			}
@@ -1168,7 +1197,7 @@ func ConsecutiveFailures(repo string, issueNum int) int {
 		if err := json.Unmarshal(data, &m); err != nil {
 			continue
 		}
-		if m.Status == "running" {
+		if m.Status == "running" || m.Status == "finalizing" {
 			continue
 		}
 		runs = append(runs, runEntry{startedAt: m.StartedAt, status: m.Status})
@@ -1236,7 +1265,7 @@ func collectRunEntries(root string) []RunIndexEntry {
 		// Backfill Usage on terminated runs so historical data on disk gets
 		// reflected in /usage on the next refresh. Best-effort: any error
 		// here is non-fatal — we still want the index entry.
-		if m.Usage == nil && m.Status != "" && m.Status != "running" {
+		if m.Usage == nil && m.Status != "" && m.Status != "running" && m.Status != "finalizing" {
 			runDir := filepath.Dir(path)
 			if u, err := ExtractUsage(filepath.Join(runDir, "events.jsonl")); err == nil && u != nil {
 				m.Usage = u
@@ -1252,7 +1281,7 @@ func collectRunEntries(root string) []RunIndexEntry {
 		// at index time. The dashboard renders this as a green "live"
 		// badge so users can distinguish "actively running, just quietly
 		// retrying upstream" from "frozen, will be reconciled soon".
-		if m.Status == "running" && runnerStillAlive(m.Repo, m.IssueNumber, m.StartedAt) {
+		if (m.Status == "running" || m.Status == "finalizing") && runnerStillAlive(m.Repo, m.IssueNumber, m.StartedAt) {
 			alive := true
 			entry.RunnerAlive = &alive
 		}
@@ -1432,7 +1461,7 @@ func collectPilotRunEntries(root string) []PilotRunIndexEntry {
 		if err := json.Unmarshal(data, &m); err != nil {
 			return nil
 		}
-		if m.Usage == nil && m.Status != "" && m.Status != "running" {
+		if m.Usage == nil && m.Status != "" && m.Status != "running" && m.Status != "finalizing" {
 			runDir := filepath.Dir(path)
 			if u, err := ExtractUsage(filepath.Join(runDir, "events.jsonl")); err == nil && u != nil {
 				m.Usage = u

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -717,6 +717,94 @@ func TestReconcileStaleRuns_ErrorResult_ReconciledAsFailed(t *testing.T) {
 	}
 }
 
+// TestReconcileStaleRuns_Finalizing_PromotedToSuccess verifies that a run
+// stuck in "finalizing" (process killed after operator.Run() completed VCS
+// side-effects but before WriteRunMeta wrote the terminal status) is promoted
+// to "success" by the reconciler without re-queuing the issue.
+func TestReconcileStaleRuns_Finalizing_PromotedToSuccess(t *testing.T) {
+	root := t.TempDir()
+	start := time.Now().UTC().Add(-5 * time.Minute)
+	stuck := &RunMeta{
+		Operator:    "implement",
+		Repo:        "owner/repo",
+		IssueNumber: 55,
+		StartedAt:   start,
+		Status:      "finalizing",
+		Summary:     "PR opened at https://github.com/owner/repo/pull/42",
+	}
+	events := `{"type":"system","subtype":"init"}` + "\n" +
+		`{"type":"result","subtype":"success","is_error":false,"duration_ms":60000,"num_turns":3,"result":"done","total_cost_usd":0.20,"usage":{"input_tokens":2000,"output_tokens":200,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"modelUsage":{}}` + "\n"
+
+	dir := makeRunDir(t, root, "owner__repo", 55, start, stuck, events)
+
+	n, err := reconcileStaleRunsAt(root, time.Hour)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("fixed=%d, want 1 (finalizing run with dead runner should be promoted)", n)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	var m RunMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.Status != "success" {
+		t.Errorf("status=%q, want \"success\"", m.Status)
+	}
+	if m.EndedAt == nil {
+		t.Error("EndedAt should be populated after reconciliation")
+	}
+	if m.Usage == nil {
+		t.Error("expected usage to be backfilled from events.jsonl")
+	}
+	if m.Error == "" {
+		t.Error("Error field should describe the reconciliation reason")
+	}
+}
+
+// TestReconcileStaleRuns_Finalizing_RunnerAlive_Untouched verifies that a
+// "finalizing" run whose runner PID is still alive is left alone — the runner
+// is still in the process of writing the terminal meta.
+func TestReconcileStaleRuns_Finalizing_RunnerAlive_Untouched(t *testing.T) {
+	root := t.TempDir()
+	start := time.Now().UTC().Add(-1 * time.Minute)
+
+	stuck := &RunMeta{
+		Operator:    "implement",
+		Repo:        "owner/repo",
+		IssueNumber: 55,
+		StartedAt:   start,
+		Status:      "finalizing",
+	}
+	dir := makeRunDir(t, root, "owner__repo", 55, start, stuck, `{"type":"system","subtype":"init"}`+"\n")
+
+	prev := runnerStillAlive
+	t.Cleanup(func() { runnerStillAlive = prev })
+	runnerStillAlive = func(repo string, issueNum int, metaStart time.Time) bool {
+		return repo == "owner/repo" && issueNum == 55
+	}
+
+	n, err := reconcileStaleRunsAt(root, time.Hour)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("fixed=%d, want 0 (finalizing run with live runner should be left alone)", n)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "meta.json"))
+	var got RunMeta
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	if got.Status != "finalizing" {
+		t.Errorf("status=%q, want finalizing (untouched)", got.Status)
+	}
+}
 
 // --- MigrateLegacyDataDir tests ----------------------------------------
 


### PR DESCRIPTION
Fixes #109

## What changed

**cmd/clawflow/commands/run.go**: Immediately after operator.Run() returns successfully (VCS side-effects done: comment posted, outcome label applied, trigger labels removed), write meta.json with status=finalizing. This is the first post-claude action, before usage extraction and worktree cleanup.

**internal/snapshot/snapshot.go**:
- Added status=finalizing to the RunMeta.Status comment documenting valid values
- Reconciler: status=finalizing with a dead runner PID is promoted to status=success (backfills usage from events.jsonl) — issue is NOT re-queued
- Reconciler: status=finalizing with a live runner PID is left untouched (runner is still writing terminal meta)
- Cancel path now also cancels finalizing runs (user-initiated kill should override any state)
- Consecutive-failure counter skips finalizing runs (same treatment as running)
- Usage backfill and RunnerAlive badge checks include finalizing status

**internal/snapshot/snapshot_test.go**: Two new tests covering the new reconciler branches.

## Why this works

Before this fix, the kill window between operator.Run() returning and WriteRunMeta() executing left meta.json at status=running. The reconciler could not distinguish "completed but not finalized" from "killed mid-run", so it re-queued the issue — causing cloud-bucket-sync #6 to run 3x in a row today.

After this fix, the reconciler sees status=finalizing and knows VCS side-effects already completed. It promotes to status=success without touching the issue's labels.

## Testing

- go test ./internal/snapshot/... — all pass including 2 new tests
- go test ./internal/operator/... — all pass
- go build ./... fails only on the pre-existing embed.go: web/dist not found (web/dist is built by CI, not checked in)