### PR TITLE
feat: issue chat supports issue-mode vs edit-mode selection at launch

### DIFF
--- a/cmd/clawflow/commands/chat.go
+++ b/cmd/clawflow/commands/chat.go
@@ -19,6 +19,7 @@ func NewChatCmd() *cobra.Command {
 		repo  string
 		issue int
 		model string
+		mode  string
 	)
 	cmd := &cobra.Command{
 		Use:   "chat",
@@ -31,15 +32,33 @@ lives in the user's native terminal (no clawflow-side destroy hook),
 and resuming would either strand stale issue data or have two claude
 processes fighting over the same transcript file.
 
+Issue-level chat supports two modes (--mode flag):
+  issue  (default) — discussion and issue-tracker operations only.
+                     Edit/Write/NotebookEdit are disabled. The AI is
+                     prompted to land conclusions as comments, labels,
+                     or sub-issues. Safer default: prevents accidental
+                     file edits during requirements discussions.
+  edit             — full file-editing access (historical behaviour).
+                     Use when you want to hot-fix the issue directly
+                     without going through clawflow run.
+
+The default mode can be persisted in ~/.clawflow/config/credentials.yaml
+as chat_default_mode: issue|edit. The --mode flag overrides it per session.
+
 Examples:
   clawflow chat --repo owner/repo
   clawflow chat --repo owner/repo --issue 42
+  clawflow chat --repo owner/repo --issue 42 --mode edit
   clawflow chat --repo owner/repo --issue 42 --model sonnet`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if repo == "" {
 				return fmt.Errorf("--repo is required")
 			}
-			return runChat(cmd.Context(), repo, issue, model)
+			// Validate --mode when explicitly provided.
+			if mode != "" && mode != "issue" && mode != "edit" {
+				return fmt.Errorf("--mode must be 'issue' or 'edit', got %q", mode)
+			}
+			return runChat(cmd.Context(), repo, issue, model, mode)
 		},
 	}
 	cmd.Flags().StringVar(&repo, "repo", "", "repository (owner/repo)")
@@ -48,10 +67,15 @@ Examples:
 	// resolved below via Credentials.EffectiveChatModel(). An explicit
 	// --model on the CLI still wins.
 	cmd.Flags().StringVar(&model, "model", "", "claude model to use (default: settings → chat_model, falls back to haiku)")
+	// Empty default means "use chat_default_mode from credentials.yaml" —
+	// resolved below via Credentials.EffectiveChatDefaultMode(). Only
+	// applies to issue-level chat (--issue N); repo-level chat is always
+	// read-only regardless of this flag.
+	cmd.Flags().StringVar(&mode, "mode", "", "issue chat mode: 'issue' (default, no file edits) or 'edit' (full access)")
 	return cmd
 }
 
-func runChat(_ context.Context, repo string, issueNum int, model string) error {
+func runChat(_ context.Context, repo string, issueNum int, model string, modeFlag string) error {
 	client, repoCfg, err := newVCSClientForRepo(repo)
 	if err != nil {
 		return err
@@ -93,23 +117,33 @@ func runChat(_ context.Context, repo string, issueNum int, model string) error {
 		model = creds.EffectiveChatModel()
 	}
 
+	// Resolve the issue chat mode: explicit --mode > credentials.yaml
+	// chat_default_mode > built-in default ("issue").
+	// Mode only applies to issue-level chat; repo-level is always read-only.
+	if modeFlag == "" && issueNum > 0 {
+		creds, _ := config.LoadCredentials()
+		modeFlag = creds.EffectiveChatDefaultMode()
+	}
+
 	// Hard-block file mutations and notebook edits for REPO-level chat.
 	// Repo chat is strictly an analysis / planning assistant — code changes
 	// go through `clawflow run` (the implement operator) on a labeled issue.
 	//
-	// ISSUE-level chat (issueNum > 0) is allowed to edit files for hot-fixes:
-	// the user explicitly targeted a specific issue and wants to fix it
-	// directly without going through the full clawflow run pipeline.
-	// The working directory is already pinned to the repo's local clone,
-	// so edits are scoped to that repo. --dangerously-skip-permissions
-	// removes the per-Bash confirmation prompt for both modes.
+	// ISSUE-level chat behaviour depends on mode:
+	//   issue mode (default) — also disallows Edit/Write/NotebookEdit.
+	//     The AI is prompted to land conclusions in the issue tracker.
+	//   edit mode — allows full file editing for hot-fixes without going
+	//     through the full clawflow run pipeline.
+	//
+	// --dangerously-skip-permissions removes the per-Bash confirmation
+	// prompt for both modes.
 	args := []string{
 		"--model", model,
 		"--name", name,
 		"--dangerously-skip-permissions",
 	}
-	if issueNum == 0 {
-		// Repo-level chat: read-only, no file edits
+	if issueNum == 0 || modeFlag != "edit" {
+		// Repo-level chat and issue-mode both block file edits.
 		args = append(args, "--disallowedTools", "Edit,Write,NotebookEdit")
 	}
 	// When the user has explicitly configured an API key in clawflow's
@@ -134,7 +168,7 @@ func runChat(_ context.Context, repo string, issueNum int, model string) error {
 	// above for the full rationale.
 	var systemCtx string
 	if issueNum > 0 {
-		systemCtx, err = buildIssueChatContext(client, repo, issueNum)
+		systemCtx, err = buildIssueChatContext(client, repo, issueNum, modeFlag)
 	} else {
 		systemCtx, err = buildRepoChatContext(client, repo, repoCfg.Platform, repoCfg.BaseBranch)
 	}
@@ -190,7 +224,11 @@ func runChat(_ context.Context, repo string, issueNum int, model string) error {
 	if useBare {
 		bareNote = " --bare (forced, API key takes priority over claude.ai login)"
 	}
-	fmt.Fprintf(os.Stderr, "[clawflow] chat → model=%s key=%s base_url=%s%s\n", model, keyHint, urlHint, bareNote)
+	modeNote := ""
+	if issueNum > 0 {
+		modeNote = fmt.Sprintf(" mode=%s", modeFlag)
+	}
+	fmt.Fprintf(os.Stderr, "[clawflow] chat → model=%s key=%s base_url=%s%s%s\n", model, keyHint, urlHint, bareNote, modeNote)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -198,7 +236,7 @@ func runChat(_ context.Context, repo string, issueNum int, model string) error {
 	return cmd.Run()
 }
 
-func buildIssueChatContext(client vcs.Client, repo string, issueNum int) (string, error) {
+func buildIssueChatContext(client vcs.Client, repo string, issueNum int, mode string) (string, error) {
 	issues, err := client.ListOpenIssues(repo)
 	if err != nil {
 		return "", err
@@ -230,7 +268,10 @@ func buildIssueChatContext(client vcs.Client, repo string, issueNum int) (string
 	}
 
 	comments, _ := client.ListIssueCommentsDetail(repo, issueNum)
-	return chat.BuildIssueContext(repo, issue, comments), nil
+	if mode == "edit" {
+		return chat.BuildIssueContext(repo, issue, comments), nil
+	}
+	return chat.BuildIssueModeContext(repo, issue, comments), nil
 }
 
 func buildRepoChatContext(client vcs.Client, repo, platform, baseBranch string) (string, error) {

--- a/internal/api/chat_spawn.go
+++ b/internal/api/chat_spawn.go
@@ -32,6 +32,7 @@ type chatSpawnRequest struct {
 	Repo    string `json:"repo,omitempty"`
 	Issue   int    `json:"issue,omitempty"`
 	Model   string `json:"model,omitempty"`
+	Mode    string `json:"mode,omitempty"`   // "issue" or "edit" — issue-level chat only
 	Project string `json:"project,omitempty"`
 	Action  string `json:"action,omitempty"` // "generate" or "chat" (project-scoped)
 }
@@ -83,10 +84,14 @@ func HandleChatSpawn(w http.ResponseWriter, r *http.Request) {
 		}
 		parts = []string{shellEscape(self), "project", action, shellEscape(req.Project)}
 	} else {
-		// Repo-scoped spawn: `clawflow chat --repo <r> [--issue <n>]`
+		// Repo-scoped spawn: `clawflow chat --repo <r> [--issue <n>] [--mode <m>]`
 		parts = []string{shellEscape(self), "chat", "--repo", shellEscape(req.Repo)}
 		if req.Issue > 0 {
 			parts = append(parts, "--issue", strconv.Itoa(req.Issue))
+			// Only pass --mode for issue-level chat; validate to avoid injection.
+			if req.Mode == "issue" || req.Mode == "edit" {
+				parts = append(parts, "--mode", req.Mode)
+			}
 		}
 	}
 	if req.Model != "" {

--- a/internal/chat/context.go
+++ b/internal/chat/context.go
@@ -7,8 +7,21 @@ import (
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 )
 
-// BuildIssueContext assembles the system prompt for issue-level chat.
+// BuildIssueContext assembles the system prompt for issue-level chat in
+// edit mode — the AI can read AND modify files in the repo working tree.
 func BuildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment) string {
+	return buildIssueContext(repo, issue, comments, "edit")
+}
+
+// BuildIssueModeContext assembles the system prompt for issue-level chat
+// in issue mode — the AI is restricted to discussion and issue-tracker
+// operations; file editing is disallowed at the claude CLI level.
+func BuildIssueModeContext(repo string, issue vcs.Issue, comments []vcs.IssueComment) string {
+	return buildIssueContext(repo, issue, comments, "issue")
+}
+
+// buildIssueContext is the shared builder. mode is "issue" or "edit".
+func buildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment, mode string) string {
 	var b strings.Builder
 
 	fmt.Fprintln(&b, "# Chat Context")
@@ -37,14 +50,26 @@ func BuildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment
 
 	fmt.Fprintln(&b, "---")
 	fmt.Fprintln(&b)
-	fmt.Fprintf(&b, "## Your role\n\n")
-	fmt.Fprintf(&b, "You are a hands-on development assistant focused EXCLUSIVELY on\n")
-	fmt.Fprintf(&b, "issue #%d in repo %s. You can directly read, analyze, AND fix\n", issue.Number, repo)
-	fmt.Fprintf(&b, "code in this repository. This is the hot-fix path: the user chose\n")
-	fmt.Fprintf(&b, "issue-level chat to resolve this specific issue interactively\n")
-	fmt.Fprintf(&b, "without going through the full `clawflow run` pipeline.\n\n")
 
-	fmt.Fprintln(&b, `## Scope: THIS issue only
+	if mode == "edit" {
+		buildEditModeRole(&b, repo, issue)
+	} else {
+		buildIssueModeRole(&b, repo, issue)
+	}
+
+	return b.String()
+}
+
+// buildEditModeRole writes the "edit mode" role section — full file access.
+func buildEditModeRole(b *strings.Builder, repo string, issue vcs.Issue) {
+	fmt.Fprintf(b, "## Your role\n\n")
+	fmt.Fprintf(b, "You are a hands-on development assistant focused EXCLUSIVELY on\n")
+	fmt.Fprintf(b, "issue #%d in repo %s. You can directly read, analyze, AND fix\n", issue.Number, repo)
+	fmt.Fprintf(b, "code in this repository. This is the hot-fix path: the user chose\n")
+	fmt.Fprintf(b, "issue-level chat to resolve this specific issue interactively\n")
+	fmt.Fprintf(b, "without going through the full `clawflow run` pipeline.\n\n")
+
+	fmt.Fprintln(b, `## Scope: THIS issue only
 
 Your entire focus is issue #`+fmt.Sprint(issue.Number)+`. Do NOT:
 - Create new issues
@@ -100,9 +125,77 @@ than #`+fmt.Sprint(issue.Number)+`.
 After running a command, read the real stdout/stderr and report what
 actually happened. The command's exit status is the only source of
 truth.`)
-
-	return b.String()
 }
+
+// buildIssueModeRole writes the "issue mode" role section — discussion and
+// issue-tracker operations only; file editing is blocked at the CLI level.
+func buildIssueModeRole(b *strings.Builder, repo string, issue vcs.Issue) {
+	fmt.Fprintf(b, "## Your role\n\n")
+	fmt.Fprintf(b, "You are a planning and discussion assistant focused EXCLUSIVELY on\n")
+	fmt.Fprintf(b, "issue #%d in repo %s. Your job is to help the user think through\n", issue.Number, repo)
+	fmt.Fprintf(b, "requirements, scope, and next steps — then land every concrete\n")
+	fmt.Fprintf(b, "conclusion on the issue tracker (comment, label, sub-issue).\n\n")
+	fmt.Fprintf(b, "**File editing is disabled in this session.** You cannot invoke\n")
+	fmt.Fprintf(b, "Edit, Write, or NotebookEdit tools. Code snippets in comments are\n")
+	fmt.Fprintf(b, "fine; actually writing files is not.\n\n")
+
+	fmt.Fprintln(b, `## Scope: THIS issue only
+
+Your entire focus is issue #`+fmt.Sprint(issue.Number)+`. Do NOT:
+- Discuss or work on other issues
+- Suggest creating unrelated follow-up issues
+
+If the user asks about something unrelated, remind them this chat
+is scoped to issue #`+fmt.Sprint(issue.Number)+` and suggest they open a
+separate chat for other topics.
+
+## What you CAN do
+
+- **Read code**: grep, cat, git log, git diff — anything read-only.
+  You can suggest code changes in comments, but not write them to disk.
+- **Analyze and discuss**: requirements, design, edge cases, scope.
+- **Label/comment on THIS issue**: update labels or post a comment
+  on issue #`+fmt.Sprint(issue.Number)+` via `+"`"+`clawflow`+"`"+` CLI (see below).
+
+## Lock conclusions into the issue tracker
+
+Whenever the conversation reaches a concrete conclusion (scope decided,
+repro nailed down, fix direction agreed, acceptance criteria clarified),
+that conclusion MUST be persisted on the issue tracker — not just held
+in chat memory. Two valid landing spots:
+
+1. **Post a comment** summarising the conclusion on issue #`+fmt.Sprint(issue.Number)+`.
+   If the conclusion changes scope, restate the new scope so
+   `+"`"+`clawflow run`+"`"+` reads the latest intent.
+2. **Update labels** — add/remove labels to reflect the current state
+   (e.g. `+"`"+`ready-for-agent`+"`"+` when the issue is fully scoped and ready
+   for automated implementation).
+
+Do NOT propose to "go implement this now" from chat. Code changes go
+through `+"`"+`clawflow run`+"`"+` consuming a labeled issue; anything you'd write
+here as code would be discarded by that flow.
+
+## Hard constraints
+
+- Do NOT run `+"`"+`git add`+"`"+`, `+"`"+`git commit`+"`"+`, `+"`"+`git push`+"`"+`, or any tree-mutating
+  git command.
+- Do NOT edit, create, or delete files. Read-only inspection
+  (cat, ls, grep, `+"`"+`git log`+"`"+`, `+"`"+`git diff`+"`"+`) is fine.
+- Do NOT create new issues (`+"`"+`clawflow issue create`+"`"+` is forbidden).
+- Do NOT operate on other issue numbers.
+
+## Allowed VCS commands (THIS issue only)
+
+- Add a label:    `+"`"+`clawflow label add --repo `+repo+` --issue `+fmt.Sprint(issue.Number)+` --label <name>`+"`"+`
+- Remove a label: `+"`"+`clawflow label remove --repo `+repo+` --issue `+fmt.Sprint(issue.Number)+` --label <name>`+"`"+`
+- Post a comment: `+"`"+`clawflow issue comment --repo `+repo+` --issue `+fmt.Sprint(issue.Number)+` --body "<text>"`+"`"+`
+- Close issue:    `+"`"+`clawflow issue close --repo `+repo+` --issue `+fmt.Sprint(issue.Number)+"`"+`
+
+After running a command, read the real stdout/stderr and report what
+actually happened. The command's exit status is the only source of
+truth.`)
+}
+
 
 // BuildRepoContext assembles the system prompt for repo-level chat.
 func BuildRepoContext(repo string, platform string, baseBranch string, issues []vcs.Issue) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,13 @@ type Credentials struct {
 	// credentials.yaml (alongside GistID) because it is machine-specific
 	// metadata, not part of the synced config payload itself.
 	LastSyncedAt string `yaml:"last_synced_at,omitempty"`
+
+	// ChatDefaultMode controls the default mode for issue-level chat sessions.
+	// Valid values: "issue" (default) — disallows Edit/Write/NotebookEdit and
+	// prompts the AI to land conclusions in the issue tracker; "edit" — allows
+	// full file editing (the historical behaviour). The --mode flag on
+	// `clawflow chat` overrides this per-session.
+	ChatDefaultMode string `yaml:"chat_default_mode,omitempty"`
 }
 
 // Default model identifiers used when the corresponding Credentials
@@ -236,6 +243,17 @@ const (
 	DefaultEvalModel     = "opus"
 	DefaultOperatorModel = "sonnet"
 )
+
+// EffectiveChatDefaultMode returns the configured default chat mode for
+// issue-level sessions. Valid values are "issue" and "edit"; anything
+// else (including empty) falls back to "issue" — the safer default that
+// prevents accidental file edits.
+func (c *Credentials) EffectiveChatDefaultMode() string {
+	if c != nil && c.ChatDefaultMode == "edit" {
+		return "edit"
+	}
+	return "issue"
+}
 
 // EffectiveChatModel returns the configured chat model, or the
 // built-in default if unset.

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react'
-import { ChevronRight, ExternalLink, MessageSquare } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { ChevronRight, ExternalLink, MessageSquare, Code } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { cn } from '../lib/utils'
 import { issueUrl, repoUrl, type RepoInfoMap } from '../lib/vcsUrls'
@@ -377,6 +377,14 @@ function IssueRow({
   const chatDrawer = useChatDrawer()
   const latest = group.runs[0]
   const k = rowKey(group)
+  // Mode picker state: null = picker hidden, 'issue'|'edit' = picker shown
+  const [showModePicker, setShowModePicker] = useState(false)
+
+  const openChat = (mode: 'issue' | 'edit') => {
+    setShowModePicker(false)
+    void chatDrawer.open({ repo: group.repo, issue: group.issue_number, mode })
+  }
+
   return (
     <div>
       <button
@@ -439,16 +447,49 @@ function IssueRow({
         <span className="text-xs text-muted-foreground shrink-0 tabular-nums w-16 text-right">
           {group.runs.length} {group.runs.length === 1 ? 'run' : 'runs'}
         </span>
-        <button
-          onClick={e => {
-            e.stopPropagation()
-            chatDrawer.open({ repo: group.repo, issue: group.issue_number })
-          }}
-          className="shrink-0 text-muted-foreground hover:text-foreground"
-          title="Chat about this issue"
-        >
-          <MessageSquare className="w-3.5 h-3.5" />
-        </button>
+        {/* Chat button with mode picker */}
+        <div className="relative shrink-0" onClick={e => e.stopPropagation()}>
+          <button
+            onClick={() => setShowModePicker(v => !v)}
+            className="text-muted-foreground hover:text-foreground"
+            title="Chat about this issue"
+            aria-haspopup="true"
+            aria-expanded={showModePicker}
+          >
+            <MessageSquare className="w-3.5 h-3.5" />
+          </button>
+          {showModePicker && (
+            <div
+              className="absolute right-0 top-6 z-20 bg-card border border-border rounded-lg shadow-lg py-1 min-w-[160px]"
+              role="menu"
+            >
+              <button
+                role="menuitem"
+                onClick={() => openChat('issue')}
+                className="w-full flex items-center gap-2 px-3 py-2 text-xs hover:bg-secondary/60 text-left"
+                title="Discuss requirements and land conclusions as comments/labels. File editing disabled."
+              >
+                <MessageSquare className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                <span>
+                  <span className="font-medium text-foreground">Issue mode</span>
+                  <span className="block text-muted-foreground">discuss · no file edits</span>
+                </span>
+              </button>
+              <button
+                role="menuitem"
+                onClick={() => openChat('edit')}
+                className="w-full flex items-center gap-2 px-3 py-2 text-xs hover:bg-secondary/60 text-left"
+                title="Full file-editing access for hot-fixing the issue directly."
+              >
+                <Code className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+                <span>
+                  <span className="font-medium text-foreground">Edit mode</span>
+                  <span className="block text-muted-foreground">hot-fix · full access</span>
+                </span>
+              </button>
+            </div>
+          )}
+        </div>
       </button>
       {expanded && <Timeline group={group} slug={slug} />}
     </div>

--- a/web/src/lib/chatContext.tsx
+++ b/web/src/lib/chatContext.tsx
@@ -4,6 +4,7 @@ interface ChatTarget {
   repo?: string
   issue?: number
   model?: string
+  mode?: 'issue' | 'edit'
   project?: string
   action?: 'generate' | 'chat'
 }


### PR DESCRIPTION
Fixes #112

## What changed

Adds a launch-time mode selector to `clawflow chat` for issue-scoped sessions.

### Two modes

- **issue mode** (new default): `--disallowedTools Edit,Write,NotebookEdit` is passed to claude. The system prompt guides the AI to land conclusions as issue comments, label changes, or sub-issues — not code edits. Safer default: prevents accidental file mutations during requirements discussions.
- **edit mode**: the historical behaviour — full file-editing access for hot-fixing directly without going through `clawflow run`.

### Files changed

| File | Change |
|------|--------|
| `internal/config/config.go` | Add `ChatDefaultMode` field to `Credentials` + `EffectiveChatDefaultMode()` helper |
| `internal/chat/context.go` | Refactor into `buildIssueContext(mode)`; add `BuildIssueModeContext()` with issue-mode prompt |
| `cmd/clawflow/commands/chat.go` | Add `--mode` flag, resolve mode from config fallback, thread through to context builder and disallowedTools |
| `internal/api/chat_spawn.go` | Add `Mode` field to `chatSpawnRequest`; pass `--mode` to CLI when set |
| `web/src/lib/chatContext.tsx` | Add `mode` field to `ChatTarget` interface |
| `web/src/components/IssueList.tsx` | Chat button opens a mode picker (issue/edit) before spawning the terminal |

### Config default

Persist the preferred default in `~/.clawflow/config/credentials.yaml`:
```yaml
chat_default_mode: issue   # or: edit
```
The `--mode` flag overrides it per session.

### Tested

- `go test ./...` — all packages pass
- Build verified with stub `web/dist` (embed requires built frontend; CI handles the full build)