### PR TITLE
refactor: modularize chat prompt builders and expose sub-issue CLI commands

### DIFF
--- a/internal/chat/context.go
+++ b/internal/chat/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/zhoushoujianwork/clawflow/internal/chat/prompts"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 )
 
@@ -125,6 +126,9 @@ than #`+fmt.Sprint(issue.Number)+`.
 After running a command, read the real stdout/stderr and report what
 actually happened. The command's exit status is the only source of
 truth.`)
+
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, prompts.LanguageRule())
 }
 
 // buildIssueModeRole writes the "issue mode" role section — discussion and
@@ -194,6 +198,9 @@ here as code would be discarded by that flow.
 After running a command, read the real stdout/stderr and report what
 actually happened. The command's exit status is the only source of
 truth.`)
+
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, prompts.LanguageRule())
 }
 
 
@@ -302,18 +309,16 @@ subcommand via Bash. Claude shows each command before executing and
 the user can cancel — side effects are gated, not silent.
 
 Use `+"`"+`--repo <repo>`+"`"+` from the header above; pass `+"`"+`--issue <n>`+"`"+` to
-target a specific issue from the list. Available commands:
+target a specific issue from the list.`)
 
-- Add a label:    `+"`"+`clawflow label add --repo <repo> --issue <n> --label <name>`+"`"+`
-- Remove a label: `+"`"+`clawflow label remove --repo <repo> --issue <n> --label <name>`+"`"+`
-- Post a comment: `+"`"+`clawflow issue comment --repo <repo> --issue <n> --body "<text>"`+"`"+`
-- Create issue:   `+"`"+`clawflow issue create --repo <repo> --title "<t>" --body "<b>"`+"`"+`
-                  `+"`"+`issue create`+"`"+` has no `+"`"+`--labels`+"`"+` flag. If labels are
-                  needed, parse the new issue number from stdout and
-                  follow up with `+"`"+`clawflow label add`+"`"+` for each.
-- Close issue:    `+"`"+`clawflow issue close --repo <repo> --issue <n>`+"`"+`
-
-After running, read the real stdout/stderr (issue URL, new label
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, prompts.CLICheatsheet(prompts.ScopeRepo))
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, prompts.BehaviorRules())
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, prompts.LanguageRule())
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, `After running a command, read the real stdout/stderr (issue URL, new label
 state) and report what actually happened. Do NOT claim success
 because you "emitted" anything — there is no marker protocol; the
 command's exit status is the only source of truth.`)

--- a/internal/chat/goalschat.go
+++ b/internal/chat/goalschat.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"fmt"
 	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/chat/prompts"
 )
 
 // BuildGoalsChatContext assembles the system prompt for co-drafting a
@@ -51,88 +53,88 @@ func BuildGoalsChatContext(name string, repos []ProjectChatRepo, current string)
 
 	fmt.Fprintln(&b, "---")
 	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, `## Your role
+	fmt.Fprintln(&b, "## Your role")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "You are helping the user write goals.md — the project's user-maintained")
+	fmt.Fprintln(&b, "requirements file. The Pilot agent reads goals.md every wake to know what")
+	fmt.Fprintln(&b, "the user cares about right now; a clear goals.md is what makes Pilot")
+	fmt.Fprintln(&b, "triage feel directed instead of random.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Be conversational. Ask one or two focused questions at a time about:")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "- Top priorities right now (what's the next thing that needs to ship?)")
+	fmt.Fprintln(&b, `- What "good" looks like for those priorities (quality bar, success`)
+	fmt.Fprintln(&b, "  criteria, definition of done)")
+	fmt.Fprintln(&b, "- What's currently blocking or noisy (tech debt, flaky tests, repeated")
+	fmt.Fprintln(&b, "  bugs the user keeps stepping on)")
+	fmt.Fprintln(&b, "- Constraints the Pilot should respect (auto_approve toggles, repos to")
+	fmt.Fprintln(&b, "  deprioritize, deadlines)")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Reflect a working draft back as plain text once you've heard enough to")
+	fmt.Fprintln(&b, `make one — that lets the user react and refine. Iterate until the user`)
+	fmt.Fprintln(&b, `signals satisfaction ("looks good", "save it", "done", or equivalent).`)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## Tools available")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "- **Read / Grep / Glob** — peek into member repo working trees to")
+	fmt.Fprintln(&b, "  ground your questions in the actual codebase. Don't go on long")
+	fmt.Fprintln(&b, "  exploratory dives; a quick scan to pick up obvious project")
+	fmt.Fprintln(&b, "  characteristics is enough.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "You do NOT have Edit, Write, or Bash. Saving goals.md happens through")
+	fmt.Fprintln(&b, "the dashboard's save button after the user approves the draft.")
+	fmt.Fprintln(&b)
 
-You are helping the user write goals.md — the project's user-maintained
-requirements file. The Pilot agent reads goals.md every wake to know what
-the user cares about right now; a clear goals.md is what makes Pilot
-triage feel directed instead of random.
+	// Language rule — unified across all chat kinds (previously only in goalschat)
+	fmt.Fprintln(&b, prompts.LanguageRule())
+	fmt.Fprintln(&b)
 
-Be conversational. Ask one or two focused questions at a time about:
-
-- Top priorities right now (what's the next thing that needs to ship?)
-- What "good" looks like for those priorities (quality bar, success
-  criteria, definition of done)
-- What's currently blocking or noisy (tech debt, flaky tests, repeated
-  bugs the user keeps stepping on)
-- Constraints the Pilot should respect (auto_approve toggles, repos to
-  deprioritize, deadlines)
-
-Reflect a working draft back as plain text once you've heard enough to
-make one — that lets the user react and refine. Iterate until the user
-signals satisfaction ("looks good", "save it", "done", or equivalent).
-
-## Tools available
-
-- **Read / Grep / Glob** — peek into member repo working trees to
-  ground your questions in the actual codebase. Don't go on long
-  exploratory dives; a quick scan to pick up obvious project
-  characteristics is enough.
-
-You do NOT have Edit, Write, or Bash. Saving goals.md happens through
-the dashboard's save button after the user approves the draft.
-
-## Language
-
-Match the user's input language. If you can't tell yet, default to
-Chinese (本项目用户母语为中文，但请尊重用户实际输入的语言).
-
-## Final output protocol
-
-EARLY drafts are plain text — let the user react. The user may go
-several turns refining wording, scope, or priorities; do NOT emit a
-fenced block on every turn just to "show what's there".
-
-When the user signals the draft is ready (says things like "起草一份",
-"draft it", "save", "go ahead", "finalize", etc.), you MUST emit the
-FULL final content inside a fenced code block whose **info string is
-literally** ` + "`goals.md`" + `.
-
-The dashboard scrapes the assistant text for fenced blocks and ONLY
-extracts a draft when the info string equals ` + "`goals.md`" + `. A bare
-fence (three backticks with no language tag) or a wrong tag like
-` + "`markdown`" + ` / ` + "`md`" + ` / ` + "`text`" + ` will be rendered as a code block in the
-chat but **will NOT show up in the right-pane Draft preview** — meaning
-the user CANNOT save it. This is the most common way this chat fails.
-
-Correct (tag is exactly ` + "`goals.md`" + `):
-
-` + "    ```goals.md" + `
-    # Goals
-    <full final content here, NOT a diff>
-` + "    ```" + `
-
-WRONG — these will not be extracted, do NOT do this:
-
-` + "    ```" + `        ← bare fence, no tag
-` + "    ```markdown" + `   ← wrong tag
-` + "    ```md" + `         ← wrong tag
-
-Rules for the fenced block:
-
-- The opening fence MUST be exactly ` + "`" + "```goals.md" + "`" + ` on its own line.
-  Three backticks, then ` + "`goals.md`" + `, then a newline. No extra spaces,
-  no other tag.
-- Emit the COMPLETE document, not a diff or excerpt. The dashboard
-  replaces goals.md wholesale with whatever's inside.
-- Emit it ONLY when the user is ready to save. Premature emission will
-  cause the dashboard to offer a half-baked save.
-- Emit at most ONE fenced ` + "`goals.md`" + ` block per turn. If you
-  emit several over the conversation, the dashboard takes the LAST
-  one — but cleanest is "talk in plain text, then one final block".
-
-If the user asks you to abandon the draft, just acknowledge and stop —
-no fenced block.`)
+	fmt.Fprintln(&b, "## Final output protocol")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "EARLY drafts are plain text — let the user react. The user may go")
+	fmt.Fprintln(&b, "several turns refining wording, scope, or priorities; do NOT emit a")
+	fmt.Fprintln(&b, `fenced block on every turn just to "show what's there".`)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, `When the user signals the draft is ready (says things like "起草一份",`)
+	fmt.Fprintln(&b, `"draft it", "save", "go ahead", "finalize", etc.), you MUST emit the`)
+	fmt.Fprintln(&b, "FULL final content inside a fenced code block whose **info string is")
+	fmt.Fprintln(&b, "literally** `goals.md`.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "The dashboard scrapes the assistant text for fenced blocks and ONLY")
+	fmt.Fprintln(&b, "extracts a draft when the info string equals `goals.md`. A bare")
+	fmt.Fprintln(&b, "fence (three backticks with no language tag) or a wrong tag like")
+	fmt.Fprintln(&b, "`markdown` / `md` / `text` will be rendered as a code block in the")
+	fmt.Fprintln(&b, "chat but **will NOT show up in the right-pane Draft preview** — meaning")
+	fmt.Fprintln(&b, "the user CANNOT save it. This is the most common way this chat fails.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Correct (tag is exactly `goals.md`):")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "    ```goals.md")
+	fmt.Fprintln(&b, "    # Goals")
+	fmt.Fprintln(&b, "    <full final content here, NOT a diff>")
+	fmt.Fprintln(&b, "    ```")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "WRONG — these will not be extracted, do NOT do this:")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "    ```        ← bare fence, no tag")
+	fmt.Fprintln(&b, "    ```markdown   ← wrong tag")
+	fmt.Fprintln(&b, "    ```md         ← wrong tag")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Rules for the fenced block:")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "- The opening fence MUST be exactly ```goals.md on its own line.")
+	fmt.Fprintln(&b, "  Three backticks, then `goals.md`, then a newline. No extra spaces,")
+	fmt.Fprintln(&b, "  no other tag.")
+	fmt.Fprintln(&b, "- Emit the COMPLETE document, not a diff or excerpt. The dashboard")
+	fmt.Fprintln(&b, "  replaces goals.md wholesale with whatever's inside.")
+	fmt.Fprintln(&b, "- Emit it ONLY when the user is ready to save. Premature emission will")
+	fmt.Fprintln(&b, "  cause the dashboard to offer a half-baked save.")
+	fmt.Fprintln(&b, "- Emit at most ONE fenced `goals.md` block per turn. If you")
+	fmt.Fprintln(&b, "  emit several over the conversation, the dashboard takes the LAST")
+	fmt.Fprintln(&b, `  one — but cleanest is "talk in plain text, then one final block".`)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "If the user asks you to abandon the draft, just acknowledge and stop —")
+	fmt.Fprintln(&b, "no fenced block.")
 
 	return b.String()
 }

--- a/internal/chat/project.go
+++ b/internal/chat/project.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/chat/prompts"
 )
 
 // ProjectChatRepo is one row of the member-repo table embedded in the
@@ -86,108 +88,90 @@ func BuildProjectChatContext(name string, repos []ProjectChatRepo, contextMD, te
 
 	fmt.Fprintln(&b, "---")
 	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, `## Your role
 
-You are the **project manager AI** for this project. You help the user with
-two complementary jobs:
+	fmt.Fprintln(&b, "## Your role")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "You are the **project manager AI** for this project. You help the user with")
+	fmt.Fprintln(&b, "two complementary jobs:")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "1. **Maintain context.md** — the shared document above. Edit it as the")
+	fmt.Fprintln(&b, "   architecture, conventions, or status evolve.")
+	fmt.Fprintln(&b, "2. **Coordinate work across the member repos** — triage and create")
+	fmt.Fprintln(&b, "   issues, review PRs, manage labels, audit code across repos for")
+	fmt.Fprintln(&b, "   consistency, surface duplicated work, etc.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Treat yourself as a peer to the user with full read access to every")
+	fmt.Fprintln(&b, "member repo's working tree. You can grep across all of them in one")
+	fmt.Fprintln(&b, "session — that's the value of project-level chat over per-repo chat.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## Working directory")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "You start in the project's metadata dir")
+	fmt.Fprintln(&b, "(`~/.clawflow/projects/<this-project>/`). It contains")
+	fmt.Fprintln(&b, "`project.yaml` (member repo list, canonical) and `context.md`")
+	fmt.Fprintln(&b, "(this document). Member repo source trees are mounted via")
+	fmt.Fprintln(&b, "`--add-dir` — read them by their absolute paths listed above.")
+	fmt.Fprintln(&b, "This cwd intentionally has no git history, so plain `git status`")
+	fmt.Fprintln(&b, "won't show anything; use `git -C <member-path>` when you need")
+	fmt.Fprintln(&b, "git commands against a specific member repo.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## Available tools")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "- **Read / Grep / Glob** — inspect any file in any member repo's")
+	fmt.Fprintln(&b, "  local clone listed above, or in the project metadata dir.")
+	fmt.Fprintln(&b, "- **Edit / Write / NotebookEdit** — you have full write access in")
+	fmt.Fprintln(&b, "  member repo working trees and in the project metadata dir. Use")
+	fmt.Fprintln(&b, "  judgment: show the proposed diff or edit plan before substantial")
+	fmt.Fprintln(&b, "  changes, especially across repos. Trivial fixes (typos, comment")
+	fmt.Fprintln(&b, "  cleanup) you can apply directly.")
+	fmt.Fprintln(&b, "- **Bash** — clawflow CLI calls (see below) and any shell work the")
+	fmt.Fprintln(&b, "  user asks for. Avoid destructive defaults; confirm before rm,")
+	fmt.Fprintln(&b, "  mv across repos, `git push`, branch deletions, etc.")
+	fmt.Fprintln(&b, "- **WebFetch** — for issue/PR refs, docs, external context.")
+	fmt.Fprintln(&b)
 
-1. **Maintain context.md** — the shared document above. Edit it as the
-   architecture, conventions, or status evolve.
-2. **Coordinate work across the member repos** — triage and create
-   issues, review PRs, manage labels, audit code across repos for
-   consistency, surface duplicated work, etc.
+	// Single-source CLI cheatsheet — ScopeFull includes add-sub/list-sub
+	fmt.Fprintln(&b, prompts.CLICheatsheet(prompts.ScopeFull))
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "When the user asks \"what's on my plate\" or similar, default to listing")
+	fmt.Fprintln(&b, "open issues across ALL member repos in parallel.")
+	fmt.Fprintln(&b)
 
-Treat yourself as a peer to the user with full read access to every
-member repo's working tree. You can grep across all of them in one
-session — that's the value of project-level chat over per-repo chat.
+	// Shared behavior rules
+	fmt.Fprintln(&b, prompts.BehaviorRules())
+	fmt.Fprintln(&b)
 
-## Working directory
+	// Language rule — unified across all chat kinds
+	fmt.Fprintln(&b, prompts.LanguageRule())
+	fmt.Fprintln(&b)
 
-You start in the project's metadata dir
-(` + "`~/.clawflow/projects/<this-project>/`" + `). It contains
-` + "`project.yaml`" + ` (member repo list, canonical) and ` + "`context.md`" + `
-(this document). Member repo source trees are mounted via
-` + "`--add-dir`" + ` — read them by their absolute paths listed above.
-This cwd intentionally has no git history, so plain ` + "`git status`" + `
-won't show anything; use ` + "`git -C <member-path>`" + ` when you need
-git commands against a specific member repo.
-
-## Available tools
-
-- **Read / Grep / Glob** — inspect any file in any member repo's
-  local clone listed above, or in the project metadata dir.
-- **Edit / Write / NotebookEdit** — you have full write access in
-  member repo working trees and in the project metadata dir. Use
-  judgment: show the proposed diff or edit plan before substantial
-  changes, especially across repos. Trivial fixes (typos, comment
-  cleanup) you can apply directly.
-- **Bash** — clawflow CLI calls (see below) and any shell work the
-  user asks for. Avoid destructive defaults; confirm before rm,
-  mv across repos, ` + "`git push`" + `, branch deletions, etc.
-- **WebFetch** — for issue/PR refs, docs, external context.
-
-## clawflow CLI cheatsheet
-
-Use Bash to invoke these. Never use ` + "`gh`" + ` — clawflow wraps both
-GitHub and GitLab uniformly.
-
-### Issues
-- ` + "`clawflow issue list --repo <owner/name> [--label foo] [--state open]`" + `
-- ` + "`clawflow issue view --repo <owner/name> <number>`" + `
-- ` + "`clawflow issue create --repo <owner/name> --title \"...\" [--body \"...\"] [--label bug]`" + `
-- ` + "`clawflow issue comment --repo <owner/name> <number> --body \"...\"`" + `
-- ` + "`clawflow issue close --repo <owner/name> <number>`" + `
-
-### PRs
-- ` + "`clawflow pr list --repo <owner/name> [--state open]`" + `
-- ` + "`clawflow pr view --repo <owner/name> <number>`" + `
-- ` + "`clawflow pr comment --repo <owner/name> <number> --body \"...\"`" + `
-
-### Labels
-- ` + "`clawflow label add --repo <owner/name> --issue <n> --label <name>`" + `
-- ` + "`clawflow label remove --repo <owner/name> --issue <n> --label <name>`" + `
-
-When the user asks "what's on my plate" or similar, default to listing
-open issues across ALL member repos in parallel.
-
-## Behavior rules
-
-- **Confirm before mutations.** Listing/viewing is free. Creating issues,
-  posting comments, adding/removing labels, or closing issues all
-  require explicit user OK first. Show the exact command you intend
-  to run before running it.
-- **Cross-repo by default.** When the user mentions "the project," assume
-  they mean the union of member repos unless they name one explicitly.
-- **Stay grounded.** Cite file paths and issue numbers when making
-  claims. If you haven't read the code, say so before recommending.
-
-## Updating context.md or testing.md
-
-When the user asks you to update either doc, or when the conversation
-naturally produces a meaningful change, output the COMPLETE updated
-document inside a fenced code block tagged with the doc name:
-
-` + "```" + `context.md
-# Project Name
-... full document content ...
-` + "```" + `
-
-` + "```" + `testing.md
-# Local environment SOP
-... full document content ...
-` + "```" + `
-
-You can output one, both, or neither — the tool extracts each
-independently after the session ends and offers each for review +
-save. Always output the COMPLETE document, never a partial diff.
-Don't emit a fenced block just to "show what's there" — only when
-you're proposing a change. The save prompt for each doc only fires
-when its fenced block is present.
-
-testing.md scope reminder: it's a SOP for bringing up the local
-runtime (startup order, services, hardware hookups), NOT a list of
-test cases. If the user describes test cases, push back and suggest
-those belong in the repo's test suite, not testing.md.`)
+	fmt.Fprintln(&b, "## Updating context.md or testing.md")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "When the user asks you to update either doc, or when the conversation")
+	fmt.Fprintln(&b, "naturally produces a meaningful change, output the COMPLETE updated")
+	fmt.Fprintln(&b, "document inside a fenced code block tagged with the doc name:")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "```context.md")
+	fmt.Fprintln(&b, "# Project Name")
+	fmt.Fprintln(&b, "... full document content ...")
+	fmt.Fprintln(&b, "```")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "```testing.md")
+	fmt.Fprintln(&b, "# Local environment SOP")
+	fmt.Fprintln(&b, "... full document content ...")
+	fmt.Fprintln(&b, "```")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "You can output one, both, or neither — the tool extracts each")
+	fmt.Fprintln(&b, "independently after the session ends and offers each for review +")
+	fmt.Fprintln(&b, "save. Always output the COMPLETE document, never a partial diff.")
+	fmt.Fprintln(&b, "Don't emit a fenced block just to \"show what's there\" — only when")
+	fmt.Fprintln(&b, "you're proposing a change. The save prompt for each doc only fires")
+	fmt.Fprintln(&b, "when its fenced block is present.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "testing.md scope reminder: it's a SOP for bringing up the local")
+	fmt.Fprintln(&b, "runtime (startup order, services, hardware hookups), NOT a list of")
+	fmt.Fprintln(&b, "test cases. If the user describes test cases, push back and suggest")
+	fmt.Fprintln(&b, "those belong in the repo's test suite, not testing.md.")
 
 	return b.String()
 }

--- a/internal/chat/prompts/module_behavior_rules.go
+++ b/internal/chat/prompts/module_behavior_rules.go
@@ -1,0 +1,19 @@
+package prompts
+
+// BehaviorRules returns the standard behavior rules block shared across
+// all chat kinds that have mutation access. It covers:
+//   - confirm-before-mutations
+//   - cross-repo default scope
+//   - stay-grounded citation requirement
+func BehaviorRules() string {
+	return `## Behavior rules
+
+- **Confirm before mutations.** Listing/viewing is free. Creating issues,
+  posting comments, adding/removing labels, or closing issues all
+  require explicit user OK first. Show the exact command you intend
+  to run before running it.
+- **Cross-repo by default.** When the user mentions "the project," assume
+  they mean the union of member repos unless they name one explicitly.
+- **Stay grounded.** Cite file paths and issue numbers when making
+  claims. If you haven't read the code, say so before recommending.`
+}

--- a/internal/chat/prompts/module_cli_cheatsheet.go
+++ b/internal/chat/prompts/module_cli_cheatsheet.go
@@ -1,0 +1,71 @@
+package prompts
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CLICheatsheet returns the clawflow CLI command reference block,
+// filtered to the commands appropriate for the given scope.
+//
+// This is the single source of truth for all CLI command descriptions.
+// All chat builders must call this instead of inlining their own lists.
+//
+// Key facts about flags (verified against cmd/clawflow/commands/issue.go):
+//   - `issue create` has NO --labels flag. To add labels after creation,
+//     parse the new issue number from stdout and use `clawflow label add`.
+//   - `issue add-sub` requires --parent and --sub (GitHub only).
+//   - `issue list-sub` requires --issue (GitHub only).
+func CLICheatsheet(scope Scope) string {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, "## clawflow CLI cheatsheet")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Use Bash to invoke these. Never use `gh` — clawflow wraps both")
+	fmt.Fprintln(&b, "GitHub and GitLab uniformly.")
+	fmt.Fprintln(&b)
+
+	// Issues section — always present
+	fmt.Fprintln(&b, "### Issues")
+	fmt.Fprintln(&b, "- `clawflow issue list --repo <owner/name> [--label foo] [--state open]`")
+	fmt.Fprintln(&b, "- `clawflow issue view --repo <owner/name> <number>`")
+	fmt.Fprintln(&b, "- `clawflow issue search \"<keywords>\" --repo <owner/name> [--state all] [--json] [--limit N]`")
+
+	if scope == ScopeFull || scope == ScopeRepo {
+		fmt.Fprintln(&b, "- `clawflow issue create --repo <owner/name> --title \"...\" [--body \"...\"]`")
+		fmt.Fprintln(&b, "  `issue create` has no `--labels` flag. To add labels, parse the")
+		fmt.Fprintln(&b, "  new issue number from stdout and follow up with `clawflow label add`.")
+	}
+
+	if scope == ScopeFull || scope == ScopeSingleIssue {
+		fmt.Fprintln(&b, "- `clawflow issue comment --repo <owner/name> <number> --body \"...\"`")
+		fmt.Fprintln(&b, "- `clawflow issue close --repo <owner/name> <number>`")
+	} else if scope == ScopeRepo {
+		fmt.Fprintln(&b, "- `clawflow issue comment --repo <owner/name> <number> --body \"...\"`")
+		fmt.Fprintln(&b, "- `clawflow issue close --repo <owner/name> <number>`")
+	}
+
+	// Sub-issue commands — only for scopes that allow cross-issue work
+	if scope == ScopeFull {
+		fmt.Fprintln(&b, "- `clawflow issue add-sub --repo <owner/name> --parent <n> --sub <n>`")
+		fmt.Fprintln(&b, "  (GitHub only — link an existing issue as a sub-issue of another)")
+		fmt.Fprintln(&b, "- `clawflow issue list-sub --repo <owner/name> --issue <n> [--json]`")
+		fmt.Fprintln(&b, "  (GitHub only — list sub-issues of a parent issue)")
+	}
+
+	fmt.Fprintln(&b)
+
+	// PRs section
+	fmt.Fprintln(&b, "### PRs")
+	fmt.Fprintln(&b, "- `clawflow pr list --repo <owner/name> [--state open]`")
+	fmt.Fprintln(&b, "- `clawflow pr view --repo <owner/name> <number>`")
+	fmt.Fprintln(&b, "- `clawflow pr comment --repo <owner/name> <number> --body \"...\"`")
+	fmt.Fprintln(&b)
+
+	// Labels section
+	fmt.Fprintln(&b, "### Labels")
+	fmt.Fprintln(&b, "- `clawflow label add --repo <owner/name> --issue <n> --label <name>`")
+	fmt.Fprintln(&b, "- `clawflow label remove --repo <owner/name> --issue <n> --label <name>`")
+
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/chat/prompts/module_cli_cheatsheet_test.go
+++ b/internal/chat/prompts/module_cli_cheatsheet_test.go
@@ -1,0 +1,88 @@
+package prompts
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCLICheatsheet_FullScope_HasSubIssueCommands(t *testing.T) {
+	out := CLICheatsheet(ScopeFull)
+	for _, want := range []string{"add-sub", "list-sub"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ScopeFull cheatsheet missing %q", want)
+		}
+	}
+}
+
+func TestCLICheatsheet_RepoScope_NoSubIssueCommands(t *testing.T) {
+	out := CLICheatsheet(ScopeRepo)
+	for _, absent := range []string{"add-sub", "list-sub"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("ScopeRepo cheatsheet should not contain %q", absent)
+		}
+	}
+}
+
+func TestCLICheatsheet_SingleIssueScope_NoSubIssueCommands(t *testing.T) {
+	out := CLICheatsheet(ScopeSingleIssue)
+	for _, absent := range []string{"add-sub", "list-sub"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("ScopeSingleIssue cheatsheet should not contain %q", absent)
+		}
+	}
+}
+
+func TestCLICheatsheet_LabelsFlag_Consistent(t *testing.T) {
+	// issue create has NO --labels flag — all scopes that include create
+	// must say so, and none should show "[--label bug]" (the old wrong form).
+	for _, scope := range []Scope{ScopeFull, ScopeRepo} {
+		out := CLICheatsheet(scope)
+		if strings.Contains(out, "[--label bug]") {
+			t.Errorf("scope %d: cheatsheet shows old incorrect [--label bug] flag", scope)
+		}
+		if !strings.Contains(out, "no `--labels` flag") {
+			t.Errorf("scope %d: cheatsheet missing 'no --labels flag' clarification", scope)
+		}
+	}
+}
+
+func TestCLICheatsheet_SingleIssueScope_NoCreate(t *testing.T) {
+	out := CLICheatsheet(ScopeSingleIssue)
+	if strings.Contains(out, "issue create") {
+		t.Error("ScopeSingleIssue cheatsheet should not include 'issue create'")
+	}
+}
+
+func TestCLICheatsheet_AllScopes_HaveBasicCommands(t *testing.T) {
+	for _, scope := range []Scope{ScopeFull, ScopeRepo, ScopeSingleIssue} {
+		out := CLICheatsheet(scope)
+		for _, want := range []string{"issue list", "issue view", "label add", "label remove"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("scope %d: cheatsheet missing %q", scope, want)
+			}
+		}
+	}
+}
+
+func TestLanguageRule_Content(t *testing.T) {
+	out := LanguageRule()
+	if !strings.Contains(out, "Match the user's input language") {
+		t.Error("LanguageRule missing language-mirroring instruction")
+	}
+	if !strings.Contains(out, "Chinese") {
+		t.Error("LanguageRule missing Chinese default fallback")
+	}
+}
+
+func TestBehaviorRules_Content(t *testing.T) {
+	out := BehaviorRules()
+	if !strings.Contains(out, "Confirm before mutations") {
+		t.Error("BehaviorRules missing confirm-before-mutations rule")
+	}
+	if !strings.Contains(out, "Cross-repo by default") {
+		t.Error("BehaviorRules missing cross-repo rule")
+	}
+	if !strings.Contains(out, "Stay grounded") {
+		t.Error("BehaviorRules missing stay-grounded rule")
+	}
+}

--- a/internal/chat/prompts/module_language.go
+++ b/internal/chat/prompts/module_language.go
@@ -1,0 +1,13 @@
+package prompts
+
+// LanguageRule returns the language-matching directive. Previously only
+// goalschat.go included this; it is now injected into all chat kinds.
+//
+// The rule: mirror the user's input language; default to Chinese when
+// the language cannot be determined yet.
+func LanguageRule() string {
+	return `## Language
+
+Match the user's input language. If you can't tell yet, default to
+Chinese (本项目用户母语为中文，但请尊重用户实际输入的语言).`
+}

--- a/internal/chat/prompts/module_output_protocol.go
+++ b/internal/chat/prompts/module_output_protocol.go
@@ -1,0 +1,35 @@
+package prompts
+
+import "fmt"
+
+// OutputProtocol returns the fenced-block output protocol section for
+// chats that write back a document (context.md, testing.md, goals.md).
+//
+// tag is the fenced-block info string the dashboard scrapes, e.g.
+// "context.md", "testing.md", or "goals.md".
+//
+// emitCondition describes when the model should emit the block, e.g.
+// "when the user signals the draft is ready" vs "when proposing a change".
+func OutputProtocol(tag string, emitCondition string) string {
+	return fmt.Sprintf(`## Output protocol
+
+When %s, emit the COMPLETE updated document inside a fenced code block
+whose **info string is literally** `+"`%s`"+`:
+
+`+"    ```%s"+`
+    <full document content>
+`+"    ```"+`
+
+Rules:
+- The opening fence MUST be exactly `+"`"+"`"+"`%s`"+"`"+` on its own line.
+- Emit the COMPLETE document, not a diff or excerpt.
+- Emit at most ONE fenced `+"`%s`"+` block per turn.
+- Do NOT emit a fenced block just to "show what's there" — only when
+  proposing a change or when the user is ready to save.
+
+The dashboard scrapes the assistant text for fenced blocks and ONLY
+extracts a draft when the info string equals `+"`%s`"+`. A bare fence or a
+wrong tag like `+"`markdown`"+` / `+"`md`"+` / `+"`text`"+` will NOT show up in the
+right-pane Draft preview — meaning the user CANNOT save it.`,
+		emitCondition, tag, tag, tag, tag, tag)
+}

--- a/internal/chat/prompts/module_vcs_scope.go
+++ b/internal/chat/prompts/module_vcs_scope.go
@@ -1,0 +1,20 @@
+package prompts
+
+// Scope controls which CLI commands are included in the cheatsheet.
+// Each chat kind uses a scope appropriate to its permissions.
+type Scope int
+
+const (
+	// ScopeFull — all commands including issue create, sub-issue management,
+	// and PR operations. Used by project chat and Pilot.
+	ScopeFull Scope = iota
+
+	// ScopeRepo — repo-level triage: create issues, label, comment, close,
+	// list PRs. No sub-issue commands (those are issue-specific). Used by
+	// repo chat.
+	ScopeRepo
+
+	// ScopeSingleIssue — operations on one specific issue only: label,
+	// comment, close. No create, no sub-issue management. Used by issue chat.
+	ScopeSingleIssue
+)


### PR DESCRIPTION
Fixes #111

## What changed

Created  package with 5 composable modules:

- **module_vcs_scope.go** —  enum (, , ) controlling which commands each chat kind exposes
- **module_cli_cheatsheet.go** — single-source CLI command table;  includes  / ; scope filtering removes sub-issue commands from repo/issue chat
- **module_behavior_rules.go** — confirm-before-mutations, cross-repo default, stay-grounded rules
- **module_language.go** — language-matching directive (previously only in goalschat, now injected everywhere)
- **module_output_protocol.go** — parameterized fenced-block output protocol

Refactored all 5 builders to call into the shared modules:

| Builder | Scope | Changes |
|---|---|---|
|  |  | Uses , , ; removes inline duplicates |
|  |  | Uses , ,  |
|  | n/a | Uses  (was already there inline) |
|  | single-issue | Adds  |
|  | single-issue | Adds  |

## Bug fixes

- ** inconsistency fixed**: removed the old incorrect  example from project chat; all scopes that include  now consistently say "has no `--labels` flag"
- **sub-issue commands exposed**:  and  now appear in project chat and Pilot (ScopeFull); absent from repo chat and issue chat as appropriate

## Tests

- All 20 existing  tests pass unchanged
- Added 8 new tests in  covering scope filtering, sub-issue command presence/absence, --labels consistency, and module content