### PR TITLE
feat: add bound_machine support to Pilot Schedule

### DIFF
--- a/cmd/clawflow/commands/project.go
+++ b/cmd/clawflow/commands/project.go
@@ -56,11 +56,13 @@ func newProjectAutomationCmd() *cobra.Command {
 	cmd.AddCommand(newProjectAutomationEnableCmd())
 	cmd.AddCommand(newProjectAutomationDisableCmd())
 	cmd.AddCommand(newProjectAutomationShowCmd())
+	cmd.AddCommand(newProjectAutomationBindCmd())
 	return cmd
 }
 
 func newProjectAutomationEnableCmd() *cobra.Command {
 	var cooldown int
+	var boundMachine string
 	cmd := &cobra.Command{
 		Use:   "enable <name>",
 		Short: "Enable PM auto-wakeup at the end of each `clawflow run` pass",
@@ -69,11 +71,60 @@ func newProjectAutomationEnableCmd() *cobra.Command {
 			if err := project.SetAutomation(args[0], true, cooldown); err != nil {
 				return err
 			}
+			if cmd.Flags().Changed("bound-machine") {
+				if err := project.SetAutomationBoundMachine(args[0], boundMachine); err != nil {
+					return err
+				}
+			}
 			fmt.Printf("automation enabled for project %q (cooldown: %d min)\n", args[0], cooldown)
+			if boundMachine != "" {
+				fmt.Printf("  bound to machine: %s\n", boundMachine)
+			}
 			return nil
 		},
 	}
 	cmd.Flags().IntVar(&cooldown, "cooldown", 30, "Minutes between PM wakeups (0 = every run pass)")
+	cmd.Flags().StringVar(&boundMachine, "bound-machine", "", "Restrict Pilot wakeups to this hostname (empty = any machine)")
+	return cmd
+}
+
+// newProjectAutomationBindCmd adds or clears the bound_machine for a project's
+// automation without touching the enabled/cooldown state.
+func newProjectAutomationBindCmd() *cobra.Command {
+	var clear bool
+	cmd := &cobra.Command{
+		Use:   "bind <name>",
+		Short: "Set or clear the bound_machine for a project's Pilot automation",
+		Long: `Restrict Pilot wakeups to a specific machine hostname.
+
+Examples:
+  # Bind to the current machine
+  clawflow project automation bind myproject --machine $(hostname)
+
+  # Clear the binding (any machine may wake the Pilot)
+  clawflow project automation bind myproject --clear`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if clear {
+				if err := project.SetAutomationBoundMachine(args[0], ""); err != nil {
+					return err
+				}
+				fmt.Printf("bound_machine cleared for project %q — any machine may wake the Pilot\n", args[0])
+				return nil
+			}
+			machine, _ := cmd.Flags().GetString("machine")
+			if machine == "" {
+				return fmt.Errorf("provide --machine <hostname> or --clear")
+			}
+			if err := project.SetAutomationBoundMachine(args[0], machine); err != nil {
+				return err
+			}
+			fmt.Printf("project %q Pilot bound to machine %q\n", args[0], machine)
+			return nil
+		},
+	}
+	cmd.Flags().String("machine", "", "Hostname to bind to")
+	cmd.Flags().BoolVar(&clear, "clear", false, "Clear the binding so any machine may wake the Pilot")
 	return cmd
 }
 
@@ -102,9 +153,22 @@ func newProjectAutomationShowCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			hostname, _ := os.Hostname()
 			fmt.Printf("Project: %s\n", p.Name)
 			fmt.Printf("Enabled: %t\n", p.Automation.Enabled)
 			fmt.Printf("Cooldown: %d min\n", p.Automation.CooldownMinutes)
+			if p.Automation.BoundMachine != "" {
+				if hostname != "" && p.Automation.BoundMachine == hostname {
+					fmt.Printf("Bound machine: %s (current host matches ✓)\n", p.Automation.BoundMachine)
+				} else if hostname != "" {
+					fmt.Printf("Bound machine: %s (current host: %s — skipped on this machine)\n",
+						p.Automation.BoundMachine, hostname)
+				} else {
+					fmt.Printf("Bound machine: %s\n", p.Automation.BoundMachine)
+				}
+			} else {
+				fmt.Println("Bound machine: (any)")
+			}
 			if p.Automation.LastWokenAt != "" {
 				fmt.Printf("Last woken: %s\n", p.Automation.LastWokenAt)
 				if rem := p.CooldownRemaining(time.Now()); rem > 0 {

--- a/internal/pilot/schedule.go
+++ b/internal/pilot/schedule.go
@@ -71,9 +71,37 @@ func Schedule(ctx context.Context, perWakeTimeout time.Duration) (int, error) {
 		return 0, nil
 	}
 
+	// Resolve the current machine's hostname once. Used to skip projects
+	// bound to a different machine. Non-fatal: an empty hostname means no
+	// projects will be skipped by the binding check (conservative / safe).
+	hostname, _ := os.Hostname()
+
+	cfg, err := config.Load()
+	if err != nil {
+		return 0, fmt.Errorf("load config: %w", err)
+	}
+	creds, _ := config.LoadCredentials()
+
 	now := time.Now()
 	var ready []*project.Project
 	for _, p := range projects {
+		// Skip projects bound to a different machine. A project with no
+		// BoundMachine (empty string) is processed by every machine —
+		// the common case. When hostname resolution failed (empty string),
+		// we conservatively process all projects so a misconfigured machine
+		// doesn't silently drop work.
+		if p.Automation.BoundMachine != "" && hostname != "" && p.Automation.BoundMachine != hostname {
+			fmt.Fprintf(os.Stderr, "[pilot] %s: bound to %s, skipping (current machine: %s)\n",
+				p.Name, p.Automation.BoundMachine, hostname)
+			continue
+		}
+		// When require_binding is set globally, skip projects that have no
+		// BoundMachine configured. Mirrors the repo-level RequireBinding
+		// behaviour in run.go.
+		if cfg.Settings.RequireBinding && p.Automation.BoundMachine == "" && hostname != "" {
+			fmt.Fprintf(os.Stderr, "[pilot] %s: no bound_machine and require_binding is set, skipping\n", p.Name)
+			continue
+		}
 		if rem := p.CooldownRemaining(now); rem > 0 {
 			fmt.Fprintf(os.Stderr, "[pilot] %s: cooldown %s remaining — skip\n", p.Name, rem.Round(time.Second))
 			continue
@@ -83,12 +111,6 @@ func Schedule(ctx context.Context, perWakeTimeout time.Duration) (int, error) {
 	if len(ready) == 0 {
 		return 0, nil
 	}
-
-	cfg, err := config.Load()
-	if err != nil {
-		return 0, fmt.Errorf("load config: %w", err)
-	}
-	creds, _ := config.LoadCredentials()
 
 	woken := 0
 	for _, p := range ready {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -41,10 +41,18 @@ type Project struct {
 // LastWokenAt is the RFC3339 UTC timestamp of the last PM invocation;
 // the runner stamps it after each wake (success or failure) to anchor
 // the next cooldown window.
+//
+// BoundMachine, when non-empty, restricts Pilot wakeups to the machine
+// whose hostname matches this value. An empty BoundMachine means any
+// machine may wake the Pilot (the default, backward-compatible behaviour).
+// This mirrors the repo-level BoundMachine in RepoConfig and is the
+// recommended way to prevent duplicate Pilot wakeups in multi-machine
+// deployments.
 type Automation struct {
 	Enabled         bool   `yaml:"enabled"`
 	CooldownMinutes int    `yaml:"cooldown_minutes,omitempty"`
 	LastWokenAt     string `yaml:"last_woken_at,omitempty"`
+	BoundMachine    string `yaml:"bound_machine,omitempty"`
 }
 
 // ProjectsRoot returns ~/.clawflow/projects.
@@ -424,6 +432,20 @@ func SetAutomation(name string, enabled bool, cooldownMinutes int) error {
 	if cooldownMinutes >= 0 {
 		p.Automation.CooldownMinutes = cooldownMinutes
 	}
+	p.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	return save(p)
+}
+
+// SetAutomationBoundMachine sets or clears the BoundMachine for a project's
+// automation. Pass an empty string to clear the binding (any machine may wake
+// the Pilot). This is a separate function from SetAutomation so callers can
+// update the binding without touching the enabled/cooldown state.
+func SetAutomationBoundMachine(name, boundMachine string) error {
+	p, err := Get(name)
+	if err != nil {
+		return err
+	}
+	p.Automation.BoundMachine = boundMachine
 	p.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	return save(p)
 }


### PR DESCRIPTION
Fixes #113

## What changed

**`internal/project/project.go`**
- Added `BoundMachine string` (yaml: `bound_machine,omitempty`) to the `Automation` struct
- Added `SetAutomationBoundMachine(name, boundMachine string) error` helper so the binding can be updated independently of the enabled/cooldown state
- Empty string preserves backward-compatible behaviour (any machine may wake the Pilot)

**`internal/pilot/schedule.go`**
- Resolves `os.Hostname()` once at the top of `Schedule()`, matching the pattern in `run.go`
- Binding check runs *before* cooldown check so a skipped project never touches `MarkWoken` and doesn't pollute the cooldown window on the other machine
- Two skip conditions (with stderr log lines for observability):
  1. BoundMachine set and doesn't match current host → skip with log
  2. `require_binding` set globally but project has no BoundMachine → skip with log
- Hostname resolution failure (empty string) falls through to process all projects — same conservative behaviour as repo-level

**`cmd/clawflow/commands/project.go`**
- `automation enable` gains `--bound-machine` flag
- New `automation bind` subcommand with `--machine <hostname>` / `--clear` flags
- `automation show` now prints `Bound machine:` with a match/skip indicator based on current hostname

## Testing

- `go vet ./internal/project/... ./internal/pilot/... ./cmd/clawflow/...` — clean
- `go test ./internal/project/... ./internal/pilot/...` — both pass