### PR TITLE
fix: add 5-min write-back timeout to prevent runner hang after claude

### DIFF
--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -82,6 +82,17 @@ type RunOptions struct {
 	RunFunc func(ctx context.Context, prompt, workdir string, timeout time.Duration, events io.Writer, model string, systemPrompt ...string) (string, error)
 }
 
+// writeBackTimeout is the maximum time allowed for the post-claude VCS
+// write-back phase (post comment + apply outcome label + remove trigger labels).
+// Without this bound, a stalled GitHub/GitLab API call parks the runner
+// indefinitely until an external process kill (e.g. cron's 60-min SIGKILL)
+// terminates it, losing the claude output and leaving the issue half-processed.
+// See issue #117 for the observed failure mode.
+//
+// Declared as a var (not const) so tests can override it without spawning a
+// real 5-minute wait.
+var writeBackTimeout = 5 * time.Minute
+
 // Run executes one operator against one subject and returns the operator's
 // final stdout text, the outcome label (empty if none), or an error.
 func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions) (string, string, error) {
@@ -132,9 +143,41 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 		return trimmed, "", nil
 	}
 
+	// Write-back phase: post comment, apply outcome label, remove trigger labels.
+	// Run under a deadline so a stalled GitHub/GitLab API call cannot block the
+	// runner indefinitely. Without this, a TCP read that never completes parks
+	// the process until an external 60-min kill fires, losing the claude output.
+	// The goroutine may outlive the timeout if the underlying HTTP call is truly
+	// stuck, but the runner returns promptly and ReconcileStaleRuns handles
+	// recovery on the next scan.
+	writeBackCtx, cancel := context.WithTimeout(ctx, writeBackTimeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runWriteBack(v, op, sub, opts, body, outcome)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			return body, outcome, err
+		}
+	case <-writeBackCtx.Done():
+		return body, outcome, fmt.Errorf("write-back timed out after %v (GitHub/GitLab API stall): %w", writeBackTimeout, writeBackCtx.Err())
+	}
+
+	return body, outcome, nil
+}
+
+// runWriteBack performs the VCS side-effects after claude completes:
+// post the result comment, apply the outcome label, remove trigger labels,
+// and optionally close the issue. Extracted so it can be run under a timeout
+// via a goroutine in Run.
+func runWriteBack(v VCS, op *Operator, sub *Subject, opts RunOptions, body, outcome string) error {
 	if body != "" {
 		if err := v.PostIssueComment(opts.Repo, sub.Number, body); err != nil {
-			return body, outcome, fmt.Errorf("post result comment: %w", err)
+			return fmt.Errorf("post result comment: %w", err)
 		}
 		fmt.Fprintf(os.Stderr, "  ✓ comment posted (%d chars)\n", len(body))
 	}
@@ -145,7 +188,7 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 				"  ⚠ operator %q produced disallowed outcome %q (allowed: %v); skipping label add\n",
 				op.Name, outcome, op.Outcomes)
 		} else if err := v.AddLabel(opts.Repo, sub.Number, outcome); err != nil {
-			return body, outcome, fmt.Errorf("add outcome label %q: %w", outcome, err)
+			return fmt.Errorf("add outcome label %q: %w", outcome, err)
 		} else {
 			fmt.Fprintf(os.Stderr, "  ✓ outcome label %q added\n", outcome)
 			if len(op.Trigger.LabelsRequired) > 0 {
@@ -169,7 +212,7 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 		}
 	}
 
-	return body, outcome, nil
+	return nil
 }
 
 // outcomeAllowed reports whether `label` is in the operator's declared

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -451,6 +451,70 @@ func TestRun_OutcomeAgentClosed_ClosesIssue(t *testing.T) {
 	}
 }
 
+// TestRun_WriteBackTimeout verifies that when the VCS write-back phase stalls
+// (simulating a hung GitHub/GitLab API call), Run returns an error within the
+// deadline rather than blocking indefinitely. This is the regression test for
+// issue #117, where a stalled TCP read in the finalization block caused the
+// runner to hang for ~47–53 min until an external 60-min process kill fired.
+func TestRun_WriteBackTimeout(t *testing.T) {
+	op := &Operator{
+		Name:      "evaluate-bug",
+		LockLabel: "agent-running",
+		Outcomes:  []string{"agent-evaluated"},
+	}
+	sub := &Subject{Number: 99, Labels: []string{"bug"}}
+
+	// blockingVCS blocks forever on PostIssueComment to simulate a stalled
+	// GitHub API call (TCP connection established, no response received).
+	blockingVCS := &blockingCommentVCS{block: make(chan struct{})}
+	defer close(blockingVCS.block) // unblock goroutine when test exits
+
+	body := "## Eval\n\nRepro: 9/10\n\n<!-- clawflow:outcome=agent-evaluated -->\n"
+
+	// Use a very short timeout so the test completes quickly.
+	origTimeout := writeBackTimeout
+	writeBackTimeout = 100 * time.Millisecond
+	defer func() { writeBackTimeout = origTimeout }()
+
+	start := time.Now()
+	_, _, err := Run(context.Background(), op, sub, blockingVCS, RunOptions{
+		Repo: "r",
+		RunFunc: func(context.Context, string, string, time.Duration, io.Writer, string, ...string) (string, error) {
+			return body, nil
+		},
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("want error when write-back times out, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("want context.DeadlineExceeded in error chain, got: %v", err)
+	}
+	// Should return well within 2× the timeout, not after the full external kill window.
+	if elapsed > 2*time.Second {
+		t.Errorf("Run took %v, want < 2s (write-back timeout not enforced)", elapsed)
+	}
+}
+
+// blockingCommentVCS is a VCS stub whose PostIssueComment blocks until the
+// block channel is closed, simulating a stalled HTTP read.
+type blockingCommentVCS struct {
+	block chan struct{}
+}
+
+func (b *blockingCommentVCS) AddLabel(repo string, issueNumber int, labels ...string) error {
+	return nil
+}
+func (b *blockingCommentVCS) RemoveLabel(repo string, issueNumber int, labels ...string) error {
+	return nil
+}
+func (b *blockingCommentVCS) PostIssueComment(repo string, issueNumber int, body string) error {
+	<-b.block // block until test cleanup closes the channel
+	return nil
+}
+func (b *blockingCommentVCS) CloseIssue(repo string, issueNumber int) error { return nil }
+
 func TestParseOutcome_Direct(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
Fixes #117

## What changed

Extracted the post-claude VCS finalization block (post comment, add outcome label, remove trigger labels, optional close) into a `runWriteBack` helper and runs it in a goroutine under a 5-minute `context.WithTimeout` deadline inside `Run`.

## Why

Without a deadline, a stalled GitHub/GitLab API call (TCP connection established, no response from server) parks the runner indefinitely. The only terminator was an external 60-min process kill (cron/launchd SIGKILL), which:
- lost the claude output (events.jsonl has a `result` event but no comment was posted)
- left the issue with no outcome label and no comment
- forced a full re-run on the next scan, doubling token cost

Two occurrences on 2026-05-08 confirmed the pattern (wall clock exactly ~3600s, error `claude: signal: killed`, events.jsonl ending on `result`).

## Design notes

- The goroutine may outlive the 5-min deadline if the underlying HTTP call is truly stuck at the OS TCP level — Go cannot cancel an in-flight `http.Client.Do` without closing the connection. However, `Run` returns promptly with a `context.DeadlineExceeded`-wrapped error, so the runner moves on and `ReconcileStaleRuns` handles recovery on the next scan.
- `writeBackTimeout` is a `var` (not `const`) so tests can override it without waiting 5 minutes.
- No VCS interface changes — avoids touching dozens of call sites across github/gitlab clients and cmd/.

## Files changed

- `internal/operator/runner.go` — extracted `runWriteBack`, added goroutine + timeout select in `Run`
- `internal/operator/runner_test.go` — `TestRun_WriteBackTimeout`: injects a blocking VCS stub, asserts Run returns within 2s with `context.DeadlineExceeded`

## Testing

All `internal/operator` tests pass. The `embed.go` failures in top-level packages are pre-existing (require a built `web/dist` not present in the worktree).