### PR TITLE
feat: add ClawFlow automation model to chat system prompts

### DIFF
--- a/internal/chat/project.go
+++ b/internal/chat/project.go
@@ -130,6 +130,10 @@ func BuildProjectChatContext(name string, repos []ProjectChatRepo, contextMD, te
 	fmt.Fprintln(&b, "- **WebFetch** — for issue/PR refs, docs, external context.")
 	fmt.Fprintln(&b)
 
+	// ClawFlow automation model — single source shared with BuildPilotContext
+	fmt.Fprintln(&b, prompts.AutomationModel())
+	fmt.Fprintln(&b)
+
 	// Single-source CLI cheatsheet — ScopeFull includes add-sub/list-sub
 	fmt.Fprintln(&b, prompts.CLICheatsheet(prompts.ScopeFull))
 	fmt.Fprintln(&b)

--- a/internal/chat/project_pilot.go
+++ b/internal/chat/project_pilot.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/chat/prompts"
 )
 
 // PilotRepoDigest is one repo's snapshot at the moment the Pilot
@@ -82,6 +84,10 @@ func BuildPilotContext(
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, "Member repos and your working files are described in this directory's")
 	fmt.Fprintln(&b, "CLAUDE.md (already loaded). The sections below are per-wake state.")
+	fmt.Fprintln(&b)
+
+	// ClawFlow automation model — single source shared with BuildProjectChatContext
+	fmt.Fprintln(&b, prompts.AutomationModel())
 	fmt.Fprintln(&b)
 
 	fmt.Fprintln(&b, "## Project context (context.md — your own memory)")

--- a/internal/chat/project_test.go
+++ b/internal/chat/project_test.go
@@ -279,6 +279,77 @@ func TestBuildPilotContext_StandardPlays(t *testing.T) {
 	}
 }
 
+func TestBuildProjectChatContext_AutomationModel(t *testing.T) {
+	repos := []ProjectChatRepo{{Name: "owner/repo-a", LocalPath: "/tmp/repo-a"}}
+	ctx := BuildProjectChatContext("my-proj", repos, "", "")
+
+	// Core automation model concepts must be present
+	if !containsStr(ctx, "ClawFlow automation model") {
+		t.Error("missing automation model section header")
+	}
+	if !containsStr(ctx, "label-driven") {
+		t.Error("missing label-driven description")
+	}
+	if !containsStr(ctx, "ready-for-agent") {
+		t.Error("missing ready-for-agent label in automation model")
+	}
+	if !containsStr(ctx, "agent-running") {
+		t.Error("missing agent-running label in automation model")
+	}
+	if !containsStr(ctx, "agent-evaluated") {
+		t.Error("missing agent-evaluated label in automation model")
+	}
+	if !containsStr(ctx, "agent-failed") {
+		t.Error("missing agent-failed label in automation model")
+	}
+	if !containsStr(ctx, "Execution lifecycle") {
+		t.Error("missing execution lifecycle section")
+	}
+	if !containsStr(ctx, "Standard pipeline") {
+		t.Error("missing standard pipeline section")
+	}
+	// Automation model must appear before the CLI cheatsheet
+	automationIdx := indexStr(ctx, "ClawFlow automation model")
+	cheatsheetIdx := indexStr(ctx, "clawflow CLI cheatsheet")
+	if automationIdx < 0 || cheatsheetIdx < 0 {
+		t.Fatal("automation model or CLI cheatsheet section not found")
+	}
+	if automationIdx > cheatsheetIdx {
+		t.Error("automation model must appear before CLI cheatsheet")
+	}
+}
+
+func TestBuildPilotContext_AutomationModel(t *testing.T) {
+	repos := []PilotRepoDigest{}
+	prompt := BuildPilotContext("my-proj", "", "", "", nil, repos)
+
+	// Core automation model concepts must be present
+	if !containsStr(prompt, "ClawFlow automation model") {
+		t.Error("missing automation model section header in Pilot prompt")
+	}
+	if !containsStr(prompt, "ready-for-agent") {
+		t.Error("missing ready-for-agent label in Pilot automation model")
+	}
+	if !containsStr(prompt, "agent-running") {
+		t.Error("missing agent-running label in Pilot automation model")
+	}
+	if !containsStr(prompt, "Diagnosing a stuck issue") {
+		t.Error("missing stuck-issue diagnosis guide in Pilot automation model")
+	}
+	if !containsStr(prompt, "Standard pipeline") {
+		t.Error("missing standard pipeline section in Pilot automation model")
+	}
+}
+
+func indexStr(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
 func containsStr(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/chat/prompts/module_clawflow_automation.go
+++ b/internal/chat/prompts/module_clawflow_automation.go
@@ -1,0 +1,85 @@
+package prompts
+
+// AutomationModel returns the ClawFlow automation model section — a
+// concise conceptual reference that explains how ClawFlow's label-driven
+// pipeline works. Injected into every chat system prompt so the AI can
+// reason about why issues are stuck, what labels to suggest, and how to
+// draft issue bodies that operators can consume.
+//
+// This is the single source of truth for the automation model. Both
+// BuildProjectChatContext and BuildPilotContext call this function —
+// never copy-paste the content.
+func AutomationModel() string {
+	return `## ClawFlow automation model
+
+ClawFlow is a label-driven workflow engine. Understanding this model lets
+you explain why issues are stuck, suggest the right labels to unblock them,
+and draft issue bodies that operators can actually consume.
+
+### Trigger model
+
+Each operator is defined by a SKILL.md file with a trigger:
+
+    operator fires when:
+      target ∈ {issue, pr}
+      AND all labels_required are present
+      AND no labels_excluded are present
+
+An operator is idempotent: once its outcome label lands, the excluded-label
+guard prevents it from firing again on the same issue.
+
+### Label vocabulary
+
+**Trigger labels** — added by humans or the classify operator to route work:
+
+| Label | Meaning |
+|---|---|
+| ` + "`bug`" + ` | Defect report — triggers ` + "`evaluate-bug`" + ` |
+| ` + "`feature`" + ` / ` + "`feat`" + ` | Feature request — triggers ` + "`evaluate-feat`" + ` |
+| ` + "`question`" + ` | User question — triggers ` + "`reply-question`" + ` |
+| ` + "`ready-for-agent`" + ` | Human approval to implement — triggers ` + "`implement`" + ` |
+| ` + "`tracking`" + ` | Epic/tracking issue — triggers ` + "`decompose`" + ` (with ` + "`ready-for-agent`" + `) |
+| ` + "`progress-check`" + ` | Request a sub-issue progress check — triggers ` + "`track-progress`" + ` |
+| ` + "`agent-mentioned`" + ` | Someone @-mentioned the agent — triggers ` + "`reply-comment`" + ` |
+
+**State labels** — set exclusively by operators, never by humans:
+
+| Label | Meaning |
+|---|---|
+| ` + "`agent-running`" + ` | Operator is mid-flight — issue is locked, treat as read-only |
+| ` + "`agent-evaluated`" + ` | Operator posted an evaluation; awaiting human ` + "`ready-for-agent`" + ` |
+| ` + "`agent-implemented`" + ` | PR opened by the implement operator |
+| ` + "`agent-decomposed`" + ` | Tracking issue broken into sub-issues |
+| ` + "`agent-replied`" + ` | Question or mention answered |
+| ` + "`agent-skipped`" + ` | Operator couldn't proceed (ambiguous, missing info) |
+| ` + "`agent-failed`" + ` | Operator exited with an error |
+
+### Execution lifecycle
+
+1. ` + "`clawflow run`" + ` scans open issues/PRs for matching operators
+2. Runner adds ` + "`agent-running`" + ` lock label
+3. Issue context + operator prompt fed to ` + "`claude -p`" + `
+4. Operator stdout captured; ` + "`<!-- clawflow:outcome=<label> -->`" + ` marker parsed
+5. Cleaned output posted as a comment; outcome label applied; ` + "`agent-running`" + ` removed
+
+Operators communicate **only** through labels and comments — no direct
+coupling between operators, no shared state outside the issue tracker.
+
+### Standard pipeline
+
+` + "```" + `
+new issue (no labels)
+  → classify        → adds bug / feature / question
+  → evaluate-bug    → adds agent-evaluated
+  → human adds ready-for-agent
+  → implement       → opens PR, adds agent-implemented
+` + "```" + `
+
+**Diagnosing a stuck issue:**
+- No trigger label (` + "`bug`" + `, ` + "`feature`" + `, etc.) → ` + "`classify`" + ` hasn't run or was skipped
+- Has ` + "`agent-evaluated`" + ` but no PR → waiting for human to add ` + "`ready-for-agent`" + `
+- Has ` + "`agent-skipped`" + ` → operator needs more info; read the comment to see what's missing
+- Has ` + "`agent-failed`" + ` → operator errored; remove the label once the blocker clears
+- Has ` + "`agent-running`" + ` for >10 min → likely a stale lock; ` + "`clawflow run`" + ` reconciles these
+- Has an excluded label → operator already ran; remove it to re-trigger`
+}


### PR DESCRIPTION
Fixes #118

Added internal/chat/prompts/module_clawflow_automation.go with AutomationModel() — a static conceptual reference explaining ClawFlow's label-driven pipeline.

Covers: trigger model, label vocabulary (trigger vs state labels), execution lifecycle, standard pipeline, and stuck-issue diagnosis guide.

Injected into both BuildProjectChatContext (between Available tools and CLI cheatsheet) and BuildPilotContext (after intro). Both call the same function — no drift.

Two new tests added verifying injection in both prompts. All internal/chat/... tests pass.