### PR TITLE
fix: wrap entire pilot wake in top-level timeout context

### DIFF
--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -123,9 +123,24 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 		return "", fmt.Errorf("claude start: %w", err)
 	}
 
+	// Guard: if the context fires while we're reading (e.g. orphaned child
+	// processes keep the pipe open after the main claude process is killed),
+	// close stdout to unblock the scanner. exec.CommandContext kills the
+	// direct child but not its grandchildren, so without this the scanner
+	// can block indefinitely past the deadline.
+	pipeGuardDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = stdout.Close()
+		case <-pipeGuardDone:
+		}
+	}()
+
 	// Parse stream line-by-line so we can tee to events.jsonl and extract
 	// text deltas for user-facing progress.
 	result, parseErr := parseClaudeStream(stdout, events)
+	close(pipeGuardDone) // stop the guard goroutine whether we timed out or not
 	if err := cmd.Wait(); err != nil {
 		// Wrap transient rate-limit exits with ErrRateLimit so callers can
 		// distinguish them from permanent failures and avoid cascading the

--- a/internal/pilot/schedule.go
+++ b/internal/pilot/schedule.go
@@ -146,6 +146,18 @@ func Schedule(ctx context.Context, perWakeTimeout time.Duration) (int, error) {
 // Each wake is persisted to ~/.clawflow/data/pilot-runs/<project>/<ts>/
 // with meta.json + events.jsonl so the dashboard can show Pilot activity.
 func wake(ctx context.Context, p *project.Project, cfg *config.Config, creds *config.Credentials, timeout time.Duration) error {
+	// Bound the ENTIRE wake — including pre-claude digest fetches and
+	// post-claude finalization — to the configured timeout. Without this,
+	// the deadline only covers the `claude -p` subprocess; any blocking
+	// downstream call (context.md write, snapshot index, VCS digest fetch)
+	// can hang indefinitely after claude exits. This is the same class of
+	// bug fixed for the operator runner in #117.
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
 	// Pilot wakes happen inside `clawflow run` (process owns the run.log
 	// handle) but emitting them on a separate "pilot" log keeps the run
 	// tail readable. Open per-wake — wakes are tens of seconds apart and
@@ -200,6 +212,14 @@ func wake(ctx context.Context, p *project.Project, cfg *config.Config, creds *co
 	if err != nil {
 		meta.Status = "failed"
 		meta.Error = err.Error()
+		// When the top-level deadline fires, resultLine is empty because
+		// claude never emitted a PILOT-RESULT. Fill it with a diagnostic
+		// message so pilot/end is never logged with result="" on timeout.
+		if resultLine == "" && ctx.Err() != nil {
+			elapsed := endedAt.Sub(startedAt).Round(time.Second)
+			resultLine = fmt.Sprintf("PILOT-RESULT: pilot deadline exceeded after %s (configured timeout=%s)", elapsed, timeout)
+			meta.Result = resultLine
+		}
 	} else {
 		meta.Status = "success"
 		// On success, look for an updated context.md in the output and


### PR DESCRIPTION
Fixes #121

## What changed

The configured pilot timeout was only applied to the `claude -p` subprocess (via `context.WithTimeout` inside `RunClaude`). Post-processing steps — context.md write, snapshot index, VCS digest fetches — ran with the original unbounded context, so the pilot process could hang indefinitely after claude exited. This explains the 10h21m wall time despite a 1h timeout.

### Two-part fix

**1. `internal/pilot/schedule.go` — top-level deadline in `wake()`**

Derive `context.WithTimeout(ctx, timeout)` at the very top of `wake()` so the deadline covers the full execution, not just the claude subprocess. On timeout, a diagnostic `PILOT-RESULT` line is written so `pilot/end` is never logged with `result=""` when the deadline fires.

**2. `internal/operator/claude.go` — pipe-close guard in `RunClaude()`**

Add a goroutine that closes stdout when the context fires. `exec.CommandContext` kills the direct child but not its grandchildren; orphaned subprocesses can keep the pipe open and block `parseClaudeStream`'s scanner indefinitely past the deadline. Closing the pipe unblocks the scanner regardless of child process state.

## Testing

- `go test ./internal/pilot/... ./internal/operator/...` — passes
- Pattern mirrors the #117 write-back deadline fix (same class of bug, pilot layer)

## Acceptance criteria

- `pilot/end` is never emitted with empty `result` when the deadline fires
- Actual wall-clock duration ≤ `PilotTimeout` + small OS scheduling slack under any blocking downstream call