### PR TITLE
fix: add single-instance run lock to prevent concurrent clawflow run

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -13,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -114,6 +116,48 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 	if lg != nil {
 		snapshot.ReconcileLog = lg
 	}
+
+	// Single-instance lock: prevent concurrent clawflow run invocations
+	// (e.g. cron firing while a previous run is still active). On
+	// contention, log run/skip and exit cleanly so cron doesn't treat
+	// the skip as a failure. Stale locks from crashed processes are
+	// reclaimed automatically via PID-liveness check.
+	if err := snapshot.AcquireRunLock(Version); err != nil {
+		if holder, readErr := snapshot.ReadRunLock(); readErr == nil {
+			lg.Info("run/skip",
+				"pid", os.Getpid(),
+				"holder_pid", holder.PID,
+				"holder_started", holder.StartedAt.Format(time.RFC3339),
+			)
+			fmt.Fprintf(os.Stderr, "⚠ clawflow run already active (pid=%d, started=%s) — skipping\n",
+				holder.PID, holder.StartedAt.Format(time.RFC3339))
+		} else {
+			lg.Info("run/skip", "pid", os.Getpid(), "reason", err.Error())
+			fmt.Fprintf(os.Stderr, "⚠ %v — skipping\n", err)
+		}
+		return nil
+	}
+	// Release the run lock on normal exit. For unhandled signals (SIGINT/
+	// SIGTERM) the lock is also released explicitly before os.Exit so the
+	// next cron tick isn't blocked by a stale file. The PID-liveness check
+	// in AcquireRunLock handles any remaining crash scenarios.
+	defer snapshot.ReleaseRunLock()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	sigDone := make(chan struct{})
+	go func() {
+		select {
+		case <-sigCh:
+			snapshot.ReleaseRunLock()
+			os.Exit(0)
+		case <-sigDone:
+		}
+	}()
+	defer func() {
+		signal.Stop(sigCh)
+		close(sigDone)
+	}()
+
 	lg.Info("run/start", "pid", os.Getpid(), "version", Version, "only_repo", onlyRepo, "only_issue", onlyIssue, "timeout", timeout)
 	defer lg.Info("run/exit", "pid", os.Getpid())
 

--- a/internal/snapshot/lock.go
+++ b/internal/snapshot/lock.go
@@ -185,3 +185,99 @@ func processAlive(pid int) bool {
 	err = proc.Signal(syscall.Signal(0))
 	return err == nil
 }
+
+// RunLockInfo is the JSON payload written to the process-level run lockfile.
+type RunLockInfo struct {
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"started_at"`
+	Version   string    `json:"version"`
+}
+
+// RunLockPath returns the path to the global run lockfile
+// (~/.clawflow/locks/run.lock).
+func RunLockPath() string {
+	return filepath.Join(LockDir(), "run.lock")
+}
+
+// AcquireRunLock acquires the process-level single-instance lock for
+// `clawflow run`. Returns nil on success. If another live clawflow run
+// process holds the lock, returns an error containing the holder's PID
+// and start time so the caller can log a meaningful skip message.
+// Stale locks (owner PID is dead) are automatically reclaimed using the
+// same O_CREATE|O_EXCL + PID-liveness pattern as AcquireLock.
+func AcquireRunLock(version string) error {
+	path := RunLockPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir lock dir: %w", err)
+	}
+
+	info := RunLockInfo{
+		PID:       os.Getpid(),
+		StartedAt: time.Now().UTC(),
+		Version:   version,
+	}
+	data, err := json.Marshal(info)
+	if err != nil {
+		return err
+	}
+
+	// First attempt: O_CREATE|O_EXCL is atomic — only one caller wins.
+	if err := writeExclusive(path, data); err == nil {
+		return nil
+	} else if !os.IsExist(err) {
+		return fmt.Errorf("create run lockfile: %w", err)
+	}
+
+	// Lock file already exists. Check whether the owner is still alive.
+	existing, readErr := ReadRunLock()
+	if readErr != nil {
+		// Unreadable/corrupt lockfile — remove and retry once.
+		_ = os.Remove(path)
+		if err2 := writeExclusive(path, data); err2 != nil {
+			if os.IsExist(err2) {
+				return fmt.Errorf("run lock already held by another process")
+			}
+			return fmt.Errorf("create run lockfile: %w", err2)
+		}
+		return nil
+	}
+
+	if processAlive(existing.PID) {
+		return fmt.Errorf("another clawflow run is active (pid=%d, started=%s)",
+			existing.PID, existing.StartedAt.Format(time.RFC3339))
+	}
+
+	// Stale lock — owner is dead. Remove and re-acquire with O_EXCL so we
+	// don't race with another process doing the same reclaim.
+	_ = os.Remove(path)
+	if err2 := writeExclusive(path, data); err2 != nil {
+		if os.IsExist(err2) {
+			if info2, readErr2 := ReadRunLock(); readErr2 == nil {
+				return fmt.Errorf("another clawflow run is active (pid=%d, started=%s)",
+					info2.PID, info2.StartedAt.Format(time.RFC3339))
+			}
+			return fmt.Errorf("run lock already held by another process")
+		}
+		return fmt.Errorf("create run lockfile: %w", err2)
+	}
+	return nil
+}
+
+// ReleaseRunLock removes the process-level run lockfile. No-op if missing.
+func ReleaseRunLock() {
+	_ = os.Remove(RunLockPath())
+}
+
+// ReadRunLock parses the run lockfile. Returns an error if the file doesn't
+// exist or can't be parsed.
+func ReadRunLock() (*RunLockInfo, error) {
+	data, err := os.ReadFile(RunLockPath())
+	if err != nil {
+		return nil, err
+	}
+	var info RunLockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/internal/snapshot/runlock_test.go
+++ b/internal/snapshot/runlock_test.go
@@ -1,0 +1,156 @@
+package snapshot
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAcquireRunLock_BasicAcquireRelease(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	// First acquire should succeed.
+	if err := AcquireRunLock("v1.0.0"); err != nil {
+		t.Fatalf("first AcquireRunLock failed: %v", err)
+	}
+
+	// Lock file should exist.
+	path := RunLockPath()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("run lockfile not created: %v", err)
+	}
+
+	// Second acquire from same process should fail (PID is alive).
+	if err := AcquireRunLock("v1.0.0"); err == nil {
+		t.Error("second AcquireRunLock should fail while lock is held")
+	}
+
+	// Release and verify.
+	ReleaseRunLock()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("run lockfile should be removed after ReleaseRunLock")
+	}
+
+	// Re-acquire after release should succeed.
+	if err := AcquireRunLock("v1.0.0"); err != nil {
+		t.Fatalf("re-acquire after release failed: %v", err)
+	}
+	ReleaseRunLock()
+}
+
+func TestAcquireRunLock_ReclaimsStaleLock(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	path := RunLockPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a stale lock with a dead PID (2999999 is extremely unlikely to exist).
+	if err := os.WriteFile(path, []byte(`{"pid":2999999,"started_at":"2026-01-01T00:00:00Z","version":"v0.0.1"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the stale PID is actually dead on this system.
+	if processAlive(2999999) {
+		t.Skip("PID 2999999 is somehow alive on this system")
+	}
+
+	// AcquireRunLock should reclaim the stale lock.
+	if err := AcquireRunLock("v1.0.0"); err != nil {
+		t.Fatalf("AcquireRunLock on stale lock failed: %v", err)
+	}
+
+	// Verify the lock is now ours.
+	info, err := ReadRunLock()
+	if err != nil {
+		t.Fatalf("ReadRunLock: %v", err)
+	}
+	if info.PID != os.Getpid() {
+		t.Errorf("lock PID = %d, want %d", info.PID, os.Getpid())
+	}
+	if info.Version != "v1.0.0" {
+		t.Errorf("lock Version = %q, want %q", info.Version, "v1.0.0")
+	}
+	ReleaseRunLock()
+}
+
+func TestAcquireRunLock_CorruptLockfileReclaimed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	path := RunLockPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a corrupt (non-JSON) lockfile.
+	if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// AcquireRunLock should remove the corrupt file and succeed.
+	if err := AcquireRunLock("v1.0.0"); err != nil {
+		t.Fatalf("AcquireRunLock on corrupt lockfile failed: %v", err)
+	}
+	ReleaseRunLock()
+}
+
+func TestReadRunLock_NoFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	if _, err := ReadRunLock(); err == nil {
+		t.Error("ReadRunLock should return error when no lockfile exists")
+	}
+}
+
+func TestReleaseRunLock_NoOp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	// Should not panic or error on non-existent lockfile.
+	ReleaseRunLock()
+}
+
+// TestAcquireRunLock_ConcurrentExclusion verifies that concurrent callers
+// cannot hold the run lock simultaneously. Run with -race to catch data races.
+func TestAcquireRunLock_ConcurrentExclusion(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	const goroutines = 20
+	var (
+		mu      sync.Mutex
+		winners []int
+		wg      sync.WaitGroup
+	)
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			<-start // all goroutines race from the same starting line
+			if err := AcquireRunLock(fmt.Sprintf("v1.0.%d", id)); err == nil {
+				mu.Lock()
+				winners = append(winners, id)
+				mu.Unlock()
+				// Hold briefly to give other goroutines a chance to try.
+				time.Sleep(5 * time.Millisecond)
+				ReleaseRunLock()
+			}
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	if len(winners) == 0 {
+		t.Error("expected at least one goroutine to acquire the run lock")
+	}
+	t.Logf("%d/%d goroutines acquired the run lock (sequential windows)", len(winners), goroutines)
+}


### PR DESCRIPTION
Fixes #122

## What changed

Added a process-level single-instance lock for `clawflow run` so cron can no longer stack a second invocation on top of an active one.

### `internal/snapshot/lock.go`
- New `RunLockInfo` struct (PID, StartedAt, Version)
- `RunLockPath()` → `~/.clawflow/locks/run.lock`
- `AcquireRunLock(version)` — same O_CREATE|O_EXCL + PID-liveness pattern as the existing per-issue `AcquireLock`. Stale locks (dead PID) are reclaimed automatically; corrupt files are removed and retried.
- `ReleaseRunLock()` / `ReadRunLock()`

### `cmd/clawflow/commands/run.go`
- `runOnce()` calls `AcquireRunLock` immediately after opening the log sink, before any work begins.
- On contention: logs `run/skip pid=N holder_pid=M holder_started=T` and returns `nil` so cron treats the skip as a clean exit (no alert noise).
- `defer ReleaseRunLock()` handles normal exit.
- A SIGINT/SIGTERM handler releases the lock before `os.Exit(0)` so a killed process doesn't block the next cron tick.

### `internal/snapshot/runlock_test.go` (new)
- Basic acquire/release cycle
- Stale-lock reclaim (dead PID)
- Corrupt-file reclaim
- `ReadRunLock` on missing file
- `ReleaseRunLock` no-op
- 20-goroutine concurrent-exclusion test (run with `-race`)

## Testing

```
go test -race ./internal/snapshot/...   # ok
```

All existing snapshot tests continue to pass.