### PR TITLE
feat(providers): multi-provider Claude API config + failover + Web UI + CLI

### DIFF
--- a/cmd/clawflow/commands/config.go
+++ b/cmd/clawflow/commands/config.go
@@ -17,6 +17,7 @@ func NewConfigCmd() *cobra.Command {
 	cmd.AddCommand(newConfigSetGitLabTokenCmd())
 	cmd.AddCommand(newConfigSetBillingDayCmd())
 	cmd.AddCommand(newConfigShowCmd())
+	cmd.AddCommand(newConfigProviderCmd())
 	return cmd
 }
 

--- a/cmd/clawflow/commands/config_provider.go
+++ b/cmd/clawflow/commands/config_provider.go
@@ -1,0 +1,310 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/claude"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+// newConfigProviderCmd returns the `clawflow config provider` command group.
+func newConfigProviderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "provider",
+		Short: "Manage Claude API providers (multi-provider failover)",
+		Long: `Manage the ordered list of Claude API providers used by the operator runner.
+Providers are tried in priority order (index 0 first); when one fails with a
+transient error (rate limit, auth failure, network error, 5xx), the runner
+automatically fails over to the next enabled provider.`,
+	}
+	cmd.AddCommand(newProviderListCmd())
+	cmd.AddCommand(newProviderAddCmd())
+	cmd.AddCommand(newProviderRemoveCmd())
+	cmd.AddCommand(newProviderEnableCmd())
+	cmd.AddCommand(newProviderDisableCmd())
+	cmd.AddCommand(newProviderMoveCmd())
+	cmd.AddCommand(newProviderTestCmd())
+	return cmd
+}
+
+func newProviderListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List configured Claude API providers",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, err := config.LoadCredentials()
+			if err != nil {
+				return err
+			}
+			if len(creds.ClaudeProviders) == 0 {
+				fmt.Println("No providers configured.")
+				if creds.ClaudeAPIKey != "" || creds.ClaudeBaseURL != "" {
+					fmt.Println("(Legacy single-provider config detected — run any provider command to trigger migration.)")
+				}
+				return nil
+			}
+			fmt.Printf("%-4s %-24s %-40s %-16s %-8s\n", "IDX", "NAME", "BASE_URL", "MODEL", "ENABLED")
+			fmt.Println(strings.Repeat("-", 96))
+			for i, p := range creds.ClaudeProviders {
+				model := p.Model
+				if model == "" {
+					model = "(global default)"
+				}
+				baseURL := p.BaseURL
+				if baseURL == "" {
+					baseURL = "(api.anthropic.com)"
+				}
+				enabled := "yes"
+				if !p.Enabled {
+					enabled = "no"
+				}
+				keyHint := ""
+				if p.APIKey != "" {
+					n := len(p.APIKey)
+					if n >= 4 {
+						keyHint = " key:…" + p.APIKey[n-4:]
+					} else {
+						keyHint = " key:set"
+					}
+				}
+				fmt.Printf("%-4d %-24s %-40s %-16s %-8s%s\n", i, p.Name, baseURL, model, enabled, keyHint)
+			}
+			return nil
+		},
+	}
+}
+
+func newProviderAddCmd() *cobra.Command {
+	var (
+		baseURL  string
+		apiKey   string
+		model    string
+		disabled bool
+	)
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a new Claude API provider",
+		Args:  cobra.ExactArgs(1),
+		Example: `  clawflow config provider add "Anthropic Official" --base-url https://api.anthropic.com --api-key sk-ant-...
+  clawflow config provider add "OpenRouter" --base-url https://openrouter.ai/api/v1 --api-key sk-or-...`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+			if name == "" {
+				return fmt.Errorf("name cannot be empty")
+			}
+			creds, err := config.LoadCredentials()
+			if err != nil {
+				return err
+			}
+			p := config.ClaudeProvider{
+				Name:    name,
+				BaseURL: strings.TrimSpace(baseURL),
+				APIKey:  apiKey,
+				Model:   strings.TrimSpace(model),
+				Enabled: !disabled,
+			}
+			creds.ClaudeProviders = append(creds.ClaudeProviders, p)
+			if err := config.SaveCredentials(creds); err != nil {
+				return fmt.Errorf("failed to save: %w", err)
+			}
+			idx := len(creds.ClaudeProviders) - 1
+			fmt.Printf("Provider %q added at index %d\n", name, idx)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&baseURL, "base-url", "", "API base URL (default: api.anthropic.com)")
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key")
+	cmd.Flags().StringVar(&model, "model", "", "Model override (default: use global default)")
+	cmd.Flags().BoolVar(&disabled, "disabled", false, "Add provider in disabled state")
+	return cmd
+}
+
+func newProviderRemoveCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove <name-or-index>",
+		Short: "Remove a Claude API provider by name or index",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, err := config.LoadCredentials()
+			if err != nil {
+				return err
+			}
+			idx, err := resolveProviderArg(creds, args[0])
+			if err != nil {
+				return err
+			}
+			name := creds.ClaudeProviders[idx].Name
+			creds.ClaudeProviders = append(creds.ClaudeProviders[:idx], creds.ClaudeProviders[idx+1:]...)
+			if err := config.SaveCredentials(creds); err != nil {
+				return fmt.Errorf("failed to save: %w", err)
+			}
+			fmt.Printf("Provider %q (index %d) removed\n", name, idx)
+			return nil
+		},
+	}
+}
+
+func newProviderEnableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enable <name-or-index>",
+		Short: "Enable a Claude API provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setProviderEnabled(args[0], true)
+		},
+	}
+}
+
+func newProviderDisableCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "disable <name-or-index>",
+		Short: "Disable a Claude API provider (keeps it in the list but skips it during runs)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setProviderEnabled(args[0], false)
+		},
+	}
+}
+
+func setProviderEnabled(nameOrIdx string, enabled bool) error {
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		return err
+	}
+	idx, err := resolveProviderArg(creds, nameOrIdx)
+	if err != nil {
+		return err
+	}
+	p := creds.ClaudeProviders[idx]
+	p.Enabled = enabled
+	creds.ClaudeProviders[idx] = p
+	if err := config.SaveCredentials(creds); err != nil {
+		return fmt.Errorf("failed to save: %w", err)
+	}
+	state := "enabled"
+	if !enabled {
+		state = "disabled"
+	}
+	fmt.Printf("Provider %q (index %d) %s\n", p.Name, idx, state)
+	return nil
+}
+
+func newProviderMoveCmd() *cobra.Command {
+	var toIndex int
+	cmd := &cobra.Command{
+		Use:   "move <name-or-index> --to <index>",
+		Short: "Move a provider to a specific priority position",
+		Long: `Move a provider to a specific index in the priority list.
+Index 0 is the highest priority (tried first).`,
+		Args:    cobra.ExactArgs(1),
+		Example: "  clawflow config provider move \"OpenRouter\" --to 0",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, err := config.LoadCredentials()
+			if err != nil {
+				return err
+			}
+			fromIdx, err := resolveProviderArg(creds, args[0])
+			if err != nil {
+				return err
+			}
+			n := len(creds.ClaudeProviders)
+			if toIndex < 0 || toIndex >= n {
+				return fmt.Errorf("--to index %d out of range [0, %d]", toIndex, n-1)
+			}
+			// Remove from current position and insert at target.
+			p := creds.ClaudeProviders[fromIdx]
+			providers := append(creds.ClaudeProviders[:fromIdx], creds.ClaudeProviders[fromIdx+1:]...)
+			// Insert at toIndex.
+			providers = append(providers, config.ClaudeProvider{}) // grow
+			copy(providers[toIndex+1:], providers[toIndex:])
+			providers[toIndex] = p
+			creds.ClaudeProviders = providers
+			if err := config.SaveCredentials(creds); err != nil {
+				return fmt.Errorf("failed to save: %w", err)
+			}
+			fmt.Printf("Provider %q moved to index %d\n", p.Name, toIndex)
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&toIndex, "to", 0, "Target index (0 = highest priority)")
+	_ = cmd.MarkFlagRequired("to")
+	return cmd
+}
+
+func newProviderTestCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "test <name-or-index>",
+		Short: "Test connectivity for a specific provider",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			creds, err := config.LoadCredentials()
+			if err != nil {
+				return err
+			}
+			idx, err := resolveProviderArg(creds, args[0])
+			if err != nil {
+				return err
+			}
+			p := creds.ClaudeProviders[idx]
+			fmt.Printf("Testing provider %q (index %d)…\n", p.Name, idx)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			probeArgs := []string{
+				"-p", "--bare",
+				"--model", config.DefaultChatModel,
+				"--output-format", "text",
+				"say PONG",
+			}
+			c := exec.CommandContext(ctx, claude.Resolve(), probeArgs...)
+			c.Env = claude.EnvWithCredentials(os.Environ(), p.APIKey, p.BaseURL)
+			var stdout, stderr bytes.Buffer
+			c.Stdout = &stdout
+			c.Stderr = &stderr
+
+			if err := c.Run(); err != nil {
+				detail := strings.TrimSpace(stderr.String())
+				if detail == "" {
+					detail = strings.TrimSpace(stdout.String())
+				}
+				if detail == "" {
+					detail = err.Error()
+				}
+				fmt.Fprintf(os.Stderr, "✗ FAIL: %s\n", detail)
+				return fmt.Errorf("provider test failed")
+			}
+			fmt.Printf("✓ OK — reply: %s\n", strings.TrimSpace(stdout.String()))
+			return nil
+		},
+	}
+}
+
+// resolveProviderArg resolves a name-or-index argument to a provider index.
+// If the argument is a valid integer, it's used as an index directly.
+// Otherwise, it's matched against provider names (case-insensitive).
+func resolveProviderArg(creds *config.Credentials, arg string) (int, error) {
+	// Try numeric index first.
+	if n, err := strconv.Atoi(arg); err == nil {
+		if n < 0 || n >= len(creds.ClaudeProviders) {
+			return 0, fmt.Errorf("index %d out of range (have %d providers)", n, len(creds.ClaudeProviders))
+		}
+		return n, nil
+	}
+	// Name match (case-insensitive).
+	lower := strings.ToLower(arg)
+	for i, p := range creds.ClaudeProviders {
+		if strings.ToLower(p.Name) == lower {
+			return i, nil
+		}
+	}
+	return 0, fmt.Errorf("provider %q not found (use 'clawflow config provider list' to see available providers)", arg)
+}

--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -261,6 +261,35 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/settings/claude/test", api.HandleTestClaude)
 			mux.HandleFunc("/api/settings/reveal", api.HandleRevealSecret)
 			mux.HandleFunc("/api/settings/verify-token", api.HandleVerifyToken)
+			// Provider management (multi-provider failover, issue #128)
+			mux.HandleFunc("/api/providers", func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					api.HandleListProviders(w, r)
+				case http.MethodPost:
+					api.HandleAddProvider(w, r)
+				default:
+					http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				}
+			})
+			mux.HandleFunc("/api/providers/reorder", api.HandleReorderProviders)
+			mux.HandleFunc("/api/providers/", func(w http.ResponseWriter, r *http.Request) {
+				// Route /api/providers/{index}, /api/providers/{index}/test,
+				// /api/providers/{index}/reveal to the appropriate handler.
+				path := r.URL.Path
+				switch {
+				case strings.HasSuffix(path, "/test"):
+					api.HandleTestProvider(w, r)
+				case strings.HasSuffix(path, "/reveal"):
+					api.HandleRevealProviderKey(w, r)
+				case r.Method == http.MethodPut:
+					api.HandleUpdateProvider(w, r)
+				case r.Method == http.MethodDelete:
+					api.HandleDeleteProvider(w, r)
+				default:
+					http.Error(w, "not found", http.StatusNotFound)
+				}
+			})
 			mux.HandleFunc("/api/browse-directory", api.HandleBrowseDirectory)
 			mux.HandleFunc("/api/chat/spawn", api.HandleChatSpawn)
 			mux.HandleFunc("/api/chat/stream", api.HandleChatStream)

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -1,0 +1,379 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/claude"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+// providerView is the safe representation of a ClaudeProvider for the API.
+// The api_key is never returned in full — only a masked hint.
+type providerView struct {
+	Name       string `json:"name"`
+	BaseURL    string `json:"base_url,omitempty"`
+	APIKeySet  bool   `json:"api_key_set"`
+	APIKeyHint string `json:"api_key_hint,omitempty"`
+	Model      string `json:"model,omitempty"`
+	Enabled    bool   `json:"enabled"`
+	Index      int    `json:"index"`
+}
+
+func toProviderView(p config.ClaudeProvider, idx int) providerView {
+	return providerView{
+		Name:       p.Name,
+		BaseURL:    p.BaseURL,
+		APIKeySet:  p.APIKey != "",
+		APIKeyHint: lastFour(p.APIKey),
+		Model:      p.Model,
+		Enabled:    p.Enabled,
+		Index:      idx,
+	}
+}
+
+// HandleListProviders handles GET /api/providers.
+func HandleListProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	views := make([]providerView, len(creds.ClaudeProviders))
+	for i, p := range creds.ClaudeProviders {
+		views[i] = toProviderView(p, i)
+	}
+	writeJSON(w, 200, views)
+}
+
+// providerAddRequest is the body for POST /api/providers.
+type providerAddRequest struct {
+	Name    string `json:"name"`
+	BaseURL string `json:"base_url,omitempty"`
+	APIKey  string `json:"api_key,omitempty"`
+	Model   string `json:"model,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}
+
+// HandleAddProvider handles POST /api/providers.
+func HandleAddProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req providerAddRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeJSON(w, 400, map[string]string{"error": "name is required"})
+		return
+	}
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	p := config.ClaudeProvider{
+		Name:    strings.TrimSpace(req.Name),
+		BaseURL: strings.TrimSpace(req.BaseURL),
+		APIKey:  req.APIKey,
+		Model:   strings.TrimSpace(req.Model),
+		Enabled: enabled,
+	}
+	creds.ClaudeProviders = append(creds.ClaudeProviders, p)
+	if err := config.SaveCredentials(creds); err != nil {
+		writeErr(w, err)
+		return
+	}
+	idx := len(creds.ClaudeProviders) - 1
+	writeJSON(w, 200, toProviderView(p, idx))
+}
+
+// providerUpdateRequest is the body for PUT /api/providers/{index}.
+// All fields are optional pointers — omitted = keep existing.
+type providerUpdateRequest struct {
+	Name    *string `json:"name,omitempty"`
+	BaseURL *string `json:"base_url,omitempty"`
+	APIKey  *string `json:"api_key,omitempty"`
+	Model   *string `json:"model,omitempty"`
+	Enabled *bool   `json:"enabled,omitempty"`
+}
+
+// HandleUpdateProvider handles PUT /api/providers/{index}.
+func HandleUpdateProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	idx, ok := parseProviderIndex(w, r)
+	if !ok {
+		return
+	}
+	var req providerUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if idx >= len(creds.ClaudeProviders) {
+		writeJSON(w, 404, map[string]string{"error": "provider not found"})
+		return
+	}
+	p := creds.ClaudeProviders[idx]
+	if req.Name != nil {
+		p.Name = strings.TrimSpace(*req.Name)
+	}
+	if req.BaseURL != nil {
+		p.BaseURL = strings.TrimSpace(*req.BaseURL)
+	}
+	if req.APIKey != nil {
+		p.APIKey = *req.APIKey
+	}
+	if req.Model != nil {
+		p.Model = strings.TrimSpace(*req.Model)
+	}
+	if req.Enabled != nil {
+		p.Enabled = *req.Enabled
+	}
+	creds.ClaudeProviders[idx] = p
+	if err := config.SaveCredentials(creds); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, 200, toProviderView(p, idx))
+}
+
+// HandleDeleteProvider handles DELETE /api/providers/{index}.
+func HandleDeleteProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	idx, ok := parseProviderIndex(w, r)
+	if !ok {
+		return
+	}
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if idx >= len(creds.ClaudeProviders) {
+		writeJSON(w, 404, map[string]string{"error": "provider not found"})
+		return
+	}
+	creds.ClaudeProviders = append(creds.ClaudeProviders[:idx], creds.ClaudeProviders[idx+1:]...)
+	if err := config.SaveCredentials(creds); err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, 200, map[string]string{"status": "ok"})
+}
+
+// providerReorderRequest is the body for PUT /api/providers/reorder.
+// Names is the desired order of provider names; providers not in the list
+// are appended at the end in their original relative order.
+type providerReorderRequest struct {
+	Order []string `json:"order"` // provider names in desired priority order
+}
+
+// HandleReorderProviders handles PUT /api/providers/reorder.
+// Accepts the full ordered list of provider names and reorders the stored
+// list to match. This is the single-write endpoint for drag-drop reordering.
+func HandleReorderProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req providerReorderRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// Build a name→provider map for O(1) lookup.
+	byName := make(map[string]config.ClaudeProvider, len(creds.ClaudeProviders))
+	for _, p := range creds.ClaudeProviders {
+		byName[p.Name] = p
+	}
+
+	// Reorder: first the names in req.Order, then any remaining providers
+	// not mentioned (preserving their relative order).
+	seen := make(map[string]bool, len(req.Order))
+	reordered := make([]config.ClaudeProvider, 0, len(creds.ClaudeProviders))
+	for _, name := range req.Order {
+		if p, ok := byName[name]; ok {
+			reordered = append(reordered, p)
+			seen[name] = true
+		}
+	}
+	for _, p := range creds.ClaudeProviders {
+		if !seen[p.Name] {
+			reordered = append(reordered, p)
+		}
+	}
+	creds.ClaudeProviders = reordered
+	if err := config.SaveCredentials(creds); err != nil {
+		writeErr(w, err)
+		return
+	}
+	views := make([]providerView, len(creds.ClaudeProviders))
+	for i, p := range creds.ClaudeProviders {
+		views[i] = toProviderView(p, i)
+	}
+	writeJSON(w, 200, views)
+}
+
+// HandleRevealProviderKey handles POST /api/providers/{index}/reveal.
+// Returns the raw api_key for the given provider index.
+func HandleRevealProviderKey(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	idx, ok := parseProviderIndex(w, r)
+	if !ok {
+		return
+	}
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if idx >= len(creds.ClaudeProviders) {
+		writeJSON(w, 404, map[string]string{"error": "provider not found"})
+		return
+	}
+	writeJSON(w, 200, map[string]string{"value": creds.ClaudeProviders[idx].APIKey})
+}
+
+// HandleTestProvider handles POST /api/providers/{index}/test.
+// Runs a lightweight connectivity probe against the provider using the
+// stored credentials. Never invokes a full operator run.
+func HandleTestProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	idx, ok := parseProviderIndex(w, r)
+	if !ok {
+		return
+	}
+	creds, err := config.LoadCredentials()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if idx >= len(creds.ClaudeProviders) {
+		writeJSON(w, 404, map[string]string{"error": "provider not found"})
+		return
+	}
+	p := creds.ClaudeProviders[idx]
+
+	keyHint := "(empty)"
+	if n := len(p.APIKey); n >= 4 {
+		keyHint = "…" + p.APIKey[n-4:]
+	}
+	urlForLog := p.BaseURL
+	if urlForLog == "" {
+		urlForLog = "(default — api.anthropic.com)"
+	}
+	log.Printf("test-provider[%d]: start name=%q base_url=%s key_hint=%s", idx, p.Name, urlForLog, keyHint)
+	startedAt := time.Now()
+
+	ctx, cancel := context.WithTimeout(r.Context(), testClaudeTimeout)
+	defer cancel()
+
+	probeArgs := []string{
+		"-p",
+		"--bare",
+		"--model", config.DefaultChatModel,
+		"--output-format", "text",
+		"say PONG",
+	}
+	cmd := exec.CommandContext(ctx, claude.Resolve(), probeArgs...)
+	cmd.Env = claude.EnvWithCredentials(os.Environ(), p.APIKey, p.BaseURL)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrMsg := truncateMsg(stderr.String(), 800)
+		stdoutMsg := truncateMsg(stdout.String(), 800)
+		detail := stderrMsg
+		if detail == "" {
+			detail = stdoutMsg
+		}
+		exitMsg := err.Error()
+		if fmt.Sprintf("%v", ctx.Err()) == "context deadline exceeded" {
+			exitMsg = fmt.Sprintf("timed out after %s — proxy/relay slow or unreachable", testClaudeTimeout)
+			detail = ""
+		}
+		humanErr := exitMsg
+		if detail != "" {
+			humanErr = detail + " (" + exitMsg + ")"
+		}
+		log.Printf("test-provider[%d]: FAIL after %s — %s", idx, time.Since(startedAt).Round(time.Millisecond), humanErr)
+		writeJSON(w, 200, map[string]any{
+			"status": "error",
+			"error":  humanErr,
+			"stderr": stderrMsg,
+			"stdout": stdoutMsg,
+		})
+		return
+	}
+
+	out := truncateMsg(stdout.String(), 400)
+	log.Printf("test-provider[%d]: OK after %s — reply=%q", idx, time.Since(startedAt).Round(time.Millisecond), out)
+	writeJSON(w, 200, map[string]any{
+		"status": "ok",
+		"reply":  out,
+	})
+}
+
+// parseProviderIndex extracts the provider index from the URL path.
+// The URL pattern is /api/providers/{index}/... or /api/providers/{index}.
+// Returns (index, true) on success, writes an error response and returns
+// (0, false) on failure.
+func parseProviderIndex(w http.ResponseWriter, r *http.Request) (int, bool) {
+	// Path: /api/providers/0 or /api/providers/0/test etc.
+	path := strings.TrimPrefix(r.URL.Path, "/api/providers/")
+	// Strip any trailing segment (e.g. "/test", "/reveal")
+	if i := strings.Index(path, "/"); i >= 0 {
+		path = path[:i]
+	}
+	var idx int
+	if _, err := fmt.Sscanf(path, "%d", &idx); err != nil || idx < 0 {
+		writeJSON(w, 400, map[string]string{"error": "invalid provider index"})
+		return 0, false
+	}
+	return idx, true
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -175,6 +175,17 @@ type Config struct {
 	Settings Settings        `yaml:"settings"`
 }
 
+// ClaudeProvider represents a single Claude API configuration entry.
+// The order in the list defines priority (index 0 = highest).
+type ClaudeProvider struct {
+	Name     string `yaml:"name"`               // display name, e.g. "Anthropic Official"
+	BaseURL  string `yaml:"base_url,omitempty"` // e.g. "https://api.anthropic.com"
+	APIKey   string `yaml:"api_key,omitempty"`  // stored plaintext (like current behavior)
+	Model    string `yaml:"model,omitempty"`    // optional override, empty = use global default
+	Enabled  bool   `yaml:"enabled"`             // toggle for this provider
+	Position int    `yaml:"-"`                   // runtime order (not persisted)
+}
+
 // Credentials holds sensitive config.
 type Credentials struct {
 	GHToken     string `yaml:"gh_token,omitempty"`
@@ -191,11 +202,23 @@ type Credentials struct {
 	// spawns. Useful for routing through a proxy / relay or pinning
 	// to a specific account separate from the user's interactive
 	// Claude Code login.
+	// Deprecated: Use ClaudeProviders instead for multi-provider support.
 	ClaudeAPIKey string `yaml:"claude_api_key,omitempty"`
 
 	// ClaudeBaseURL, when set, is forwarded as ANTHROPIC_BASE_URL.
 	// Typically paired with ClaudeAPIKey when targeting a relay.
+	// Deprecated: Use ClaudeProviders instead for multi-provider support.
 	ClaudeBaseURL string `yaml:"claude_base_url,omitempty"`
+
+	// ClaudeProviders is the ordered list of Claude API configurations.
+	// The first enabled provider is used; on failure, the runner failover
+	// to the next enabled one. Empty list + legacy fields triggers migration.
+	ClaudeProviders []ClaudeProvider `yaml:"claude_providers,omitempty"`
+
+	// FailoverPatterns are regex patterns (as strings) that trigger
+	// automatic failover to the next provider. User patterns are merged
+	// with (not replace) the defaults.
+	FailoverPatterns []string `yaml:"failover_patterns,omitempty"`
 
 	// ClaudeChatModel / ClaudeEvalModel / ClaudeOperatorModel are
 	// the three claude `--model` overrides clawflow uses, scoped by
@@ -306,11 +329,93 @@ func CredentialsPath() string {
 	return filepath.Join(home, ".clawflow", "config", "credentials.yaml")
 }
 
+// MigrateLegacyProvider migrates the legacy single-provider fields
+// (ClaudeAPIKey + ClaudeBaseURL) into ClaudeProviders[0] when the list
+// is empty. This is idempotent: if ClaudeProviders is already populated
+// the function is a no-op. Returns true when a migration was performed
+// so callers can persist the updated credentials.
+func MigrateLegacyProvider(c *Credentials) bool {
+	if len(c.ClaudeProviders) > 0 {
+		return false // already migrated
+	}
+	if c.ClaudeAPIKey == "" && c.ClaudeBaseURL == "" {
+		return false // nothing to migrate
+	}
+	name := "Default"
+	if c.ClaudeBaseURL != "" {
+		name = "Legacy provider"
+	}
+	c.ClaudeProviders = []ClaudeProvider{
+		{
+			Name:    name,
+			BaseURL: c.ClaudeBaseURL,
+			APIKey:  c.ClaudeAPIKey,
+			Enabled: true,
+		},
+	}
+	return true
+}
+
+// EnabledProviders returns the subset of ClaudeProviders where Enabled == true,
+// in list order (index 0 = highest priority). The returned slice is a copy.
+func (c *Credentials) EnabledProviders() []ClaudeProvider {
+	if c == nil {
+		return nil
+	}
+	var out []ClaudeProvider
+	for _, p := range c.ClaudeProviders {
+		if p.Enabled {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// DefaultFailoverPatterns are the built-in substrings (case-insensitive)
+// that identify a provider as temporarily unavailable and trigger failover
+// to the next enabled provider. User-supplied FailoverPatterns are merged
+// with (not replace) this list.
+var DefaultFailoverPatterns = []string{
+	"hit your limit",
+	"you've hit your limit",
+	"usage limit reached",
+	"rate_limit_error",
+	"rate limit",
+	"429",
+	"quota exceeded",
+	"credit balance is too low",
+	"overloaded_error",
+	"401",
+	"invalid api key",
+	"invalid_api_key",
+	"connection refused",
+	"dial tcp",
+	"i/o timeout",
+	"tls handshake",
+	"http 5",
+	"status 5",
+}
+
+// EffectiveFailoverPatterns returns the merged set of default + user-supplied
+// failover patterns. Duplicates are not deduplicated (harmless for substring
+// matching).
+func (c *Credentials) EffectiveFailoverPatterns() []string {
+	patterns := make([]string, len(DefaultFailoverPatterns))
+	copy(patterns, DefaultFailoverPatterns)
+	if c != nil {
+		patterns = append(patterns, c.FailoverPatterns...)
+	}
+	return patterns
+}
+
 // LoadCredentials reads ~/.clawflow/config/credentials.yaml and merges env vars.
 // Priority: env > credentials.yaml
 // Supported env vars: GH_TOKEN, GITLAB_TOKEN, CLAWFLOW_CLAUDE_API_KEY,
 // CLAWFLOW_CLAUDE_BASE_URL (the CLAWFLOW_ prefix avoids conflict with
 // a user-set ANTHROPIC_API_KEY meant for their interactive shell).
+//
+// On load, if ClaudeProviders is empty but legacy single-provider fields are
+// set, they are automatically migrated into ClaudeProviders[0] and persisted.
 func LoadCredentials() (*Credentials, error) {
 	c := &Credentials{}
 	data, err := os.ReadFile(CredentialsPath())
@@ -329,6 +434,14 @@ func LoadCredentials() (*Credentials, error) {
 	c.ClaudeChatModel = envOrFile("CLAWFLOW_CLAUDE_CHAT_MODEL", c.ClaudeChatModel)
 	c.ClaudeEvalModel = envOrFile("CLAWFLOW_CLAUDE_EVAL_MODEL", c.ClaudeEvalModel)
 	c.ClaudeOperatorModel = envOrFile("CLAWFLOW_CLAUDE_OPERATOR_MODEL", c.ClaudeOperatorModel)
+
+	// Auto-migrate legacy single-provider fields to the providers list.
+	// Best-effort: a save failure is non-fatal — the migration will be
+	// retried on the next load.
+	if MigrateLegacyProvider(c) {
+		_ = SaveCredentials(c)
+	}
+
 	return c, nil
 }
 

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -1,0 +1,190 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// TestMigrateLegacyProvider verifies that legacy single-provider fields are
+// migrated into ClaudeProviders[0] and that the migration is idempotent.
+func TestMigrateLegacyProvider(t *testing.T) {
+	t.Run("migrates legacy fields", func(t *testing.T) {
+		c := &config.Credentials{
+			ClaudeAPIKey:  "sk-ant-test",
+			ClaudeBaseURL: "https://proxy.example.com",
+		}
+		migrated := config.MigrateLegacyProvider(c)
+		if !migrated {
+			t.Fatal("expected migration to occur")
+		}
+		if len(c.ClaudeProviders) != 1 {
+			t.Fatalf("expected 1 provider, got %d", len(c.ClaudeProviders))
+		}
+		p := c.ClaudeProviders[0]
+		if p.APIKey != "sk-ant-test" {
+			t.Errorf("APIKey: got %q, want %q", p.APIKey, "sk-ant-test")
+		}
+		if p.BaseURL != "https://proxy.example.com" {
+			t.Errorf("BaseURL: got %q, want %q", p.BaseURL, "https://proxy.example.com")
+		}
+		if !p.Enabled {
+			t.Error("migrated provider should be enabled")
+		}
+	})
+
+	t.Run("idempotent when providers already set", func(t *testing.T) {
+		c := &config.Credentials{
+			ClaudeAPIKey: "sk-ant-old",
+			ClaudeProviders: []config.ClaudeProvider{
+				{Name: "existing", APIKey: "sk-ant-new", Enabled: true},
+			},
+		}
+		migrated := config.MigrateLegacyProvider(c)
+		if migrated {
+			t.Fatal("expected no migration when providers already set")
+		}
+		if len(c.ClaudeProviders) != 1 {
+			t.Fatalf("expected 1 provider, got %d", len(c.ClaudeProviders))
+		}
+		if c.ClaudeProviders[0].APIKey != "sk-ant-new" {
+			t.Error("existing provider should not be overwritten")
+		}
+	})
+
+	t.Run("no-op when no legacy fields", func(t *testing.T) {
+		c := &config.Credentials{}
+		migrated := config.MigrateLegacyProvider(c)
+		if migrated {
+			t.Fatal("expected no migration when no legacy fields")
+		}
+		if len(c.ClaudeProviders) != 0 {
+			t.Fatalf("expected 0 providers, got %d", len(c.ClaudeProviders))
+		}
+	})
+}
+
+// TestEnabledProviders verifies that only enabled providers are returned.
+func TestEnabledProviders(t *testing.T) {
+	c := &config.Credentials{
+		ClaudeProviders: []config.ClaudeProvider{
+			{Name: "A", Enabled: true},
+			{Name: "B", Enabled: false},
+			{Name: "C", Enabled: true},
+		},
+	}
+	enabled := c.EnabledProviders()
+	if len(enabled) != 2 {
+		t.Fatalf("expected 2 enabled providers, got %d", len(enabled))
+	}
+	if enabled[0].Name != "A" || enabled[1].Name != "C" {
+		t.Errorf("unexpected enabled providers: %v", enabled)
+	}
+}
+
+// TestEffectiveFailoverPatterns verifies that user patterns are merged with defaults.
+func TestEffectiveFailoverPatterns(t *testing.T) {
+	c := &config.Credentials{
+		FailoverPatterns: []string{"custom-error-code"},
+	}
+	patterns := c.EffectiveFailoverPatterns()
+	// Should contain defaults
+	found429 := false
+	foundCustom := false
+	for _, p := range patterns {
+		if p == "429" {
+			found429 = true
+		}
+		if p == "custom-error-code" {
+			foundCustom = true
+		}
+	}
+	if !found429 {
+		t.Error("expected default pattern '429' in effective patterns")
+	}
+	if !foundCustom {
+		t.Error("expected user pattern 'custom-error-code' in effective patterns")
+	}
+}
+
+// TestProviderRoundTrip verifies that providers survive a YAML marshal/unmarshal cycle.
+func TestProviderRoundTrip(t *testing.T) {
+	original := &config.Credentials{
+		ClaudeProviders: []config.ClaudeProvider{
+			{Name: "Primary", BaseURL: "https://api.anthropic.com", APIKey: "sk-ant-1", Enabled: true},
+			{Name: "Mirror", BaseURL: "https://mirror.example.com", APIKey: "sk-2", Model: "sonnet", Enabled: true},
+			{Name: "Disabled", APIKey: "sk-3", Enabled: false},
+		},
+	}
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var loaded config.Credentials
+	if err := yaml.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(loaded.ClaudeProviders) != 3 {
+		t.Fatalf("expected 3 providers after round-trip, got %d", len(loaded.ClaudeProviders))
+	}
+	for i, want := range original.ClaudeProviders {
+		got := loaded.ClaudeProviders[i]
+		if got.Name != want.Name {
+			t.Errorf("[%d] Name: got %q, want %q", i, got.Name, want.Name)
+		}
+		if got.APIKey != want.APIKey {
+			t.Errorf("[%d] APIKey: got %q, want %q", i, got.APIKey, want.APIKey)
+		}
+		if got.Enabled != want.Enabled {
+			t.Errorf("[%d] Enabled: got %v, want %v", i, got.Enabled, want.Enabled)
+		}
+	}
+}
+
+// TestSaveLoadProviders verifies that providers persist correctly to disk.
+func TestSaveLoadProviders(t *testing.T) {
+	// Use a temp dir to avoid touching the real credentials file.
+	dir := t.TempDir()
+	credPath := filepath.Join(dir, "credentials.yaml")
+
+	// Write credentials with providers.
+	creds := &config.Credentials{
+		ClaudeProviders: []config.ClaudeProvider{
+			{Name: "First", APIKey: "key1", Enabled: true},
+			{Name: "Second", APIKey: "key2", Enabled: false},
+		},
+	}
+	data, err := yaml.Marshal(creds)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(credPath, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Read back.
+	var loaded config.Credentials
+	raw, err := os.ReadFile(credPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := yaml.Unmarshal(raw, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(loaded.ClaudeProviders) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(loaded.ClaudeProviders))
+	}
+	if loaded.ClaudeProviders[0].Name != "First" {
+		t.Errorf("order not preserved: first provider is %q", loaded.ClaudeProviders[0].Name)
+	}
+	if loaded.ClaudeProviders[1].Name != "Second" {
+		t.Errorf("order not preserved: second provider is %q", loaded.ClaudeProviders[1].Name)
+	}
+}

--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -28,6 +28,9 @@ var ErrRateLimit = errors.New("claude rate limit")
 //   - Claude Code CLI Chinese locale: "您已达到限制" (unlikely but defensive)
 //   - HTTP 429 / API error codes surfaced in stderr
 //   - Anthropic credit/quota messages
+//
+// Deprecated: use config.DefaultFailoverPatterns for the canonical list.
+// This var is kept for backward-compat with IsRateLimitError callers.
 var rateLimitPatterns = []string{
 	"hit your limit",
 	"you've hit your limit",
@@ -57,11 +60,45 @@ func IsRateLimitError(err error, output string) bool {
 	return false
 }
 
+// isFailoverError reports whether the combined error + output text matches
+// any of the given failover patterns (case-insensitive substring match).
+// Returns true when the provider should be skipped and the next one tried.
+func isFailoverError(err error, output string, patterns []string) bool {
+	if err == nil {
+		return false
+	}
+	combined := strings.ToLower(err.Error() + " " + output)
+	for _, pat := range patterns {
+		if strings.Contains(combined, strings.ToLower(pat)) {
+			return true
+		}
+	}
+	return false
+}
+
+// providerAttempt records the result of a single provider invocation.
+type providerAttempt struct {
+	name   string
+	errMsg string // first line of error, api_key scrubbed
+}
+
+// scrubAPIKey removes any occurrence of apiKey from s. Used to prevent
+// accidental key leakage in error messages that some providers echo back.
+func scrubAPIKey(s, apiKey string) string {
+	if apiKey == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, apiKey, "***")
+}
+
 // RunClaude executes `claude -p --output-format stream-json` in a subprocess
-// and returns the final result text. If `events` is non-nil, every raw
-// stream-json line is teed to it so the dashboard can replay the run
-// post-mortem. Text deltas are also printed live to os.Stderr so the user
-// sees progress during long runs.
+// and returns the final result text. It iterates over enabled providers in
+// priority order, failing over to the next provider when a transient error
+// (rate limit, auth failure, network error, 5xx) is detected.
+//
+// If `events` is non-nil, every raw stream-json line is teed to it so the
+// dashboard can replay the run post-mortem. Text deltas are also printed live
+// to os.Stderr so the user sees progress during long runs.
 //
 // `model` is forwarded as `--model <model>`; the empty string skips the
 // flag and lets the claude CLI pick whatever ~/.claude/settings.json
@@ -78,15 +115,91 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 		defer cancel()
 	}
 
-	// API key / base URL come from credentials.yaml and flow through
-	// env (ANTHROPIC_*). Model is CLI-only because claude doesn't
-	// honor an env override for it.
 	creds, _ := config.LoadCredentials()
-	apiKey, baseURL := "", ""
-	if creds != nil {
-		apiKey, baseURL = creds.ClaudeAPIKey, creds.ClaudeBaseURL
+
+	// Build the ordered list of providers to try. If no providers are
+	// configured, fall back to the legacy single-provider behavior (empty
+	// apiKey + baseURL = OAuth/keychain).
+	providers := buildProviderList(creds)
+	failoverPatterns := creds.EffectiveFailoverPatterns()
+
+	var attempts []providerAttempt
+
+	for i, p := range providers {
+		output, err := runClaudeWithProvider(ctx, prompt, workdir, model, p.apiKey, p.baseURL, events, systemPrompt...)
+		if err == nil {
+			if i > 0 {
+				fmt.Fprintf(os.Stderr, "  ✓ provider %q succeeded (after %d failed attempt(s))\n", p.name, i)
+			}
+			return output, nil
+		}
+
+		// Determine whether this is a provider-level failure (failover) or
+		// a genuine operator failure (bail out immediately).
+		if isFailoverError(err, output, failoverPatterns) {
+			firstLine := firstLineOf(scrubAPIKey(err.Error(), p.apiKey))
+			attempts = append(attempts, providerAttempt{name: p.name, errMsg: firstLine})
+			fmt.Fprintf(os.Stderr, "  ⚠ provider %q failed (failover): %s\n", p.name, firstLine)
+			continue
+		}
+
+		// Non-failover error: treat as genuine operator failure. Wrap with
+		// ErrRateLimit if it matches the legacy rate-limit patterns so the
+		// upstream circuit breaker still works correctly.
+		wrapped := fmt.Errorf("claude: %w", err)
+		if IsRateLimitError(err, output) {
+			return output, fmt.Errorf("%w: %w", ErrRateLimit, wrapped)
+		}
+		return output, wrapped
 	}
 
+	// All providers exhausted.
+	if len(attempts) > 0 {
+		summary := buildFailureSummary(attempts)
+		return "", fmt.Errorf("%w: all %d provider(s) failed\n%s", ErrRateLimit, len(attempts), summary)
+	}
+
+	// No providers configured at all — this shouldn't happen after buildProviderList
+	// but guard defensively.
+	return "", fmt.Errorf("no Claude providers configured")
+}
+
+// providerEntry is the resolved (name, apiKey, baseURL) triple used during
+// a single RunClaude invocation. Constructed from config.ClaudeProvider or
+// the legacy single-provider fields.
+type providerEntry struct {
+	name    string
+	apiKey  string
+	baseURL string
+}
+
+// buildProviderList returns the ordered list of providers to try. When
+// ClaudeProviders is populated, only enabled entries are included. When the
+// list is empty (no providers configured, no legacy fields), a single
+// zero-value entry is returned so the caller falls through to OAuth/keychain.
+func buildProviderList(creds *config.Credentials) []providerEntry {
+	if creds == nil {
+		return []providerEntry{{name: "default"}}
+	}
+	enabled := creds.EnabledProviders()
+	if len(enabled) > 0 {
+		out := make([]providerEntry, len(enabled))
+		for i, p := range enabled {
+			out[i] = providerEntry{name: p.Name, apiKey: p.APIKey, baseURL: p.BaseURL}
+		}
+		return out
+	}
+	// No providers list — use legacy fields (may both be empty = OAuth).
+	return []providerEntry{{
+		name:    "default",
+		apiKey:  creds.ClaudeAPIKey,
+		baseURL: creds.ClaudeBaseURL,
+	}}
+}
+
+// runClaudeWithProvider executes a single claude subprocess with the given
+// provider credentials. It is the inner loop body extracted from RunClaude.
+func runClaudeWithProvider(ctx context.Context, prompt, workdir, model, apiKey, baseURL string, events io.Writer, systemPrompt ...string) (string, error) {
 	args := []string{
 		"-p",
 		"--dangerously-skip-permissions",
@@ -137,24 +250,37 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 		}
 	}()
 
-	// Parse stream line-by-line so we can tee to events.jsonl and extract
-	// text deltas for user-facing progress.
 	result, parseErr := parseClaudeStream(stdout, events)
-	close(pipeGuardDone) // stop the guard goroutine whether we timed out or not
+	close(pipeGuardDone)
 	if err := cmd.Wait(); err != nil {
-		// Wrap transient rate-limit exits with ErrRateLimit so callers can
-		// distinguish them from permanent failures and avoid cascading the
-		// error across the remaining job queue.
-		wrapped := fmt.Errorf("claude: %w", err)
-		if IsRateLimitError(err, result) {
-			return result, fmt.Errorf("%w: %w", ErrRateLimit, wrapped)
-		}
-		return result, wrapped
+		return result, err
 	}
 	if parseErr != nil {
 		return result, fmt.Errorf("parse stream: %w", parseErr)
 	}
 	return result, nil
+}
+
+// firstLineOf returns the first non-empty line of s, trimmed.
+func firstLineOf(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return s
+}
+
+// buildFailureSummary formats a human-readable list of provider attempts
+// for inclusion in the failure comment. API keys are never included.
+func buildFailureSummary(attempts []providerAttempt) string {
+	var sb strings.Builder
+	sb.WriteString("Providers tried:\n")
+	for i, a := range attempts {
+		sb.WriteString(fmt.Sprintf("  %d. %s — %s\n", i+1, a.name, a.errMsg))
+	}
+	return sb.String()
 }
 
 // streamEnvelope is the minimal shape we peek at inside each stream-json
@@ -208,8 +334,8 @@ func parseClaudeStream(r io.Reader, events io.Writer) (string, error) {
 	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 
 	var finalResult string
-	var lastAssistantText string            // last assistant turn that emitted any text
-	var lastAssistantTextWithMarker string  // last assistant turn that contained an outcome marker
+	var lastAssistantText string           // last assistant turn that emitted any text
+	var lastAssistantTextWithMarker string // last assistant turn that contained an outcome marker
 	printedAnyDelta := false
 
 	for sc.Scan() {

--- a/internal/operator/failover_test.go
+++ b/internal/operator/failover_test.go
@@ -1,0 +1,137 @@
+package operator
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+// TestIsFailoverError verifies that each default failover pattern triggers
+// failover and that unrelated errors do not.
+func TestIsFailoverError(t *testing.T) {
+	patterns := config.DefaultFailoverPatterns
+
+	failoverCases := []struct {
+		name   string
+		errMsg string
+		output string
+	}{
+		{"rate limit text", "exit status 1", "You've hit your limit"},
+		{"429 in output", "exit status 1", "HTTP 429 Too Many Requests"},
+		{"rate_limit_error", "rate_limit_error: too many requests", ""},
+		{"quota exceeded", "exit status 1", "quota exceeded for this billing period"},
+		{"credit balance", "exit status 1", "credit balance is too low"},
+		{"overloaded", "exit status 1", "overloaded_error"},
+		{"401 auth", "exit status 1", "401 Unauthorized"},
+		{"invalid api key", "exit status 1", "invalid api key provided"},
+		{"connection refused", "dial tcp: connection refused", ""},
+		{"dial tcp", "dial tcp 1.2.3.4:443: i/o timeout", ""},
+		{"tls handshake", "exit status 1", "TLS handshake timeout"},
+		{"http 5xx", "exit status 1", "HTTP 500 Internal Server Error"},
+		{"status 5xx", "exit status 1", "status 503 Service Unavailable"},
+	}
+
+	for _, tc := range failoverCases {
+		t.Run("failover/"+tc.name, func(t *testing.T) {
+			err := errors.New(tc.errMsg)
+			if !isFailoverError(err, tc.output, patterns) {
+				t.Errorf("expected failover for err=%q output=%q", tc.errMsg, tc.output)
+			}
+		})
+	}
+
+	nonFailoverCases := []struct {
+		name   string
+		errMsg string
+		output string
+	}{
+		{"nil error", "", ""},
+		{"generic exit", "exit status 1", "some unrelated error"},
+		{"context canceled", "context canceled", ""},
+		{"parse error", "parse stream: unexpected EOF", ""},
+		{"operator logic error", "exit status 1", "cannot find file foo.go"},
+	}
+
+	for _, tc := range nonFailoverCases {
+		t.Run("no-failover/"+tc.name, func(t *testing.T) {
+			var err error
+			if tc.errMsg != "" {
+				err = errors.New(tc.errMsg)
+			}
+			if isFailoverError(err, tc.output, patterns) {
+				t.Errorf("unexpected failover for err=%q output=%q", tc.errMsg, tc.output)
+			}
+		})
+	}
+}
+
+// TestBuildProviderList verifies provider list construction from credentials.
+func TestBuildProviderList(t *testing.T) {
+	t.Run("uses enabled providers in order", func(t *testing.T) {
+		creds := &config.Credentials{
+			ClaudeProviders: []config.ClaudeProvider{
+				{Name: "A", APIKey: "key-a", Enabled: true},
+				{Name: "B", APIKey: "key-b", Enabled: false},
+				{Name: "C", APIKey: "key-c", Enabled: true},
+			},
+		}
+		list := buildProviderList(creds)
+		if len(list) != 2 {
+			t.Fatalf("expected 2 providers, got %d", len(list))
+		}
+		if list[0].name != "A" || list[1].name != "C" {
+			t.Errorf("unexpected order: %v", list)
+		}
+	})
+
+	t.Run("falls back to legacy fields when no providers", func(t *testing.T) {
+		creds := &config.Credentials{
+			ClaudeAPIKey:  "sk-legacy",
+			ClaudeBaseURL: "https://legacy.example.com",
+		}
+		list := buildProviderList(creds)
+		if len(list) != 1 {
+			t.Fatalf("expected 1 provider, got %d", len(list))
+		}
+		if list[0].apiKey != "sk-legacy" {
+			t.Errorf("expected legacy apiKey, got %q", list[0].apiKey)
+		}
+		if list[0].baseURL != "https://legacy.example.com" {
+			t.Errorf("expected legacy baseURL, got %q", list[0].baseURL)
+		}
+	})
+
+	t.Run("returns default entry when nil creds", func(t *testing.T) {
+		list := buildProviderList(nil)
+		if len(list) != 1 {
+			t.Fatalf("expected 1 provider, got %d", len(list))
+		}
+	})
+}
+
+// TestScrubAPIKey verifies that API keys are redacted from error strings.
+func TestScrubAPIKey(t *testing.T) {
+	key := "sk-ant-secret123"
+	msg := "error: invalid key sk-ant-secret123 for request"
+	scrubbed := scrubAPIKey(msg, key)
+	if scrubbed == msg {
+		t.Error("expected key to be scrubbed from message")
+	}
+	if contains(scrubbed, key) {
+		t.Errorf("key still present in scrubbed message: %q", scrubbed)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/sortable": "8.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@tanstack/react-router": "^1.114.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: 8.0.0
+        version: 8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@18.3.1)
       '@tanstack/react-router':
         specifier: ^1.114.0
         version: 1.168.23(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -176,6 +185,28 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@8.0.0':
+    resolution: {integrity: sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.1.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -1467,6 +1498,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1696,6 +1730,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@8.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -3085,6 +3144,8 @@ snapshots:
   trough@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:

--- a/web/src/components/ProvidersSection.tsx
+++ b/web/src/components/ProvidersSection.tsx
@@ -1,0 +1,665 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import {
+  GripVertical,
+  Plus,
+  Trash2,
+  Pencil,
+  Eye,
+  EyeOff,
+  Loader2,
+  Check,
+  AlertCircle,
+  X,
+  FlaskConical,
+} from 'lucide-react'
+import { cn } from '../lib/utils'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ProviderView {
+  name: string
+  base_url?: string
+  api_key_set: boolean
+  api_key_hint?: string
+  model?: string
+  enabled: boolean
+  index: number
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+async function fetchProviders(): Promise<ProviderView[]> {
+  const r = await fetch('/api/providers', { cache: 'no-store' })
+  if (!r.ok) throw new Error(`HTTP ${r.status}`)
+  return r.json()
+}
+
+async function addProvider(body: {
+  name: string
+  base_url?: string
+  api_key?: string
+  model?: string
+  enabled: boolean
+}): Promise<ProviderView> {
+  const r = await fetch('/api/providers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const d = await r.json()
+  if (!r.ok) throw new Error(d.error || `HTTP ${r.status}`)
+  return d
+}
+
+async function updateProvider(
+  idx: number,
+  body: { name?: string; base_url?: string; api_key?: string; model?: string; enabled?: boolean },
+): Promise<ProviderView> {
+  const r = await fetch(`/api/providers/${idx}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  const d = await r.json()
+  if (!r.ok) throw new Error(d.error || `HTTP ${r.status}`)
+  return d
+}
+
+async function deleteProvider(idx: number): Promise<void> {
+  const r = await fetch(`/api/providers/${idx}`, { method: 'DELETE' })
+  if (!r.ok) {
+    const d = await r.json().catch(() => null)
+    throw new Error((d && d.error) || `HTTP ${r.status}`)
+  }
+}
+
+async function reorderProviders(order: string[]): Promise<ProviderView[]> {
+  const r = await fetch('/api/providers/reorder', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ order }),
+  })
+  const d = await r.json()
+  if (!r.ok) throw new Error(d.error || `HTTP ${r.status}`)
+  return d
+}
+
+async function testProvider(idx: number): Promise<{ status: string; reply?: string; error?: string }> {
+  const r = await fetch(`/api/providers/${idx}/test`, { method: 'POST' })
+  return r.json()
+}
+
+async function revealProviderKey(idx: number): Promise<string> {
+  try {
+    const r = await fetch(`/api/providers/${idx}/reveal`, { method: 'POST' })
+    if (!r.ok) return ''
+    const d = await r.json()
+    return typeof d.value === 'string' ? d.value : ''
+  } catch {
+    return ''
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sortable row
+// ---------------------------------------------------------------------------
+
+interface SortableRowProps {
+  provider: ProviderView
+  onEdit: (p: ProviderView) => void
+  onDelete: (p: ProviderView) => void
+  onToggle: (p: ProviderView) => void
+  onTest: (p: ProviderView) => void
+  testState: { busy: boolean; result: { ok: boolean; text: string } | null }
+}
+
+function SortableRow({ provider, onEdit, onDelete, onToggle, onTest, testState }: SortableRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: provider.name,
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  const maskedURL = provider.base_url
+    ? provider.base_url.length > 36
+      ? provider.base_url.slice(0, 36) + '…'
+      : provider.base_url
+    : '(api.anthropic.com)'
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'flex items-center gap-2 px-3 py-2 rounded border text-sm',
+        provider.enabled
+          ? 'bg-card border-border'
+          : 'bg-muted/40 border-border/50 text-muted-foreground',
+        isDragging && 'shadow-lg z-10',
+      )}
+    >
+      {/* Drag handle */}
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        className="text-muted-foreground/50 hover:text-muted-foreground cursor-grab active:cursor-grabbing shrink-0"
+        aria-label="Drag to reorder"
+      >
+        <GripVertical className="w-4 h-4" />
+      </button>
+
+      {/* Priority badge */}
+      <span className="text-[10px] font-mono text-muted-foreground w-5 shrink-0">
+        {provider.index}
+      </span>
+
+      {/* Name */}
+      <span className="font-medium w-32 shrink-0 truncate" title={provider.name}>
+        {provider.name}
+      </span>
+
+      {/* Base URL */}
+      <span className="text-muted-foreground font-mono text-xs flex-1 truncate" title={provider.base_url}>
+        {maskedURL}
+      </span>
+
+      {/* Model */}
+      <span className="text-muted-foreground text-xs w-20 shrink-0 truncate">
+        {provider.model || '(default)'}
+      </span>
+
+      {/* Key hint */}
+      <span className="text-muted-foreground font-mono text-xs w-16 shrink-0">
+        {provider.api_key_set ? `…${provider.api_key_hint ?? ''}` : '(none)'}
+      </span>
+
+      {/* Actions */}
+      <div className="flex items-center gap-1 shrink-0">
+        {/* Enable toggle */}
+        <button
+          type="button"
+          onClick={() => onToggle(provider)}
+          className={cn(
+            'text-xs px-1.5 py-0.5 rounded border',
+            provider.enabled
+              ? 'border-green-200 text-green-700 bg-green-50 hover:bg-green-100'
+              : 'border-border text-muted-foreground hover:bg-secondary/50',
+          )}
+          title={provider.enabled ? 'Disable provider' : 'Enable provider'}
+          aria-label={provider.enabled ? 'Disable provider' : 'Enable provider'}
+        >
+          {provider.enabled ? 'on' : 'off'}
+        </button>
+
+        {/* Test */}
+        <button
+          type="button"
+          onClick={() => onTest(provider)}
+          disabled={testState.busy}
+          className="text-muted-foreground hover:text-foreground disabled:opacity-50"
+          title="Test connectivity"
+          aria-label="Test provider connectivity"
+        >
+          {testState.busy
+            ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            : <FlaskConical className="w-3.5 h-3.5" />}
+        </button>
+
+        {/* Edit */}
+        <button
+          type="button"
+          onClick={() => onEdit(provider)}
+          className="text-muted-foreground hover:text-foreground"
+          title="Edit provider"
+          aria-label="Edit provider"
+        >
+          <Pencil className="w-3.5 h-3.5" />
+        </button>
+
+        {/* Delete */}
+        <button
+          type="button"
+          onClick={() => onDelete(provider)}
+          className="text-muted-foreground hover:text-red-600"
+          title="Delete provider"
+          aria-label="Delete provider"
+        >
+          <Trash2 className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Test result inline */}
+      {testState.result && (
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded border ml-1',
+            testState.result.ok
+              ? 'bg-green-50 border-green-200 text-green-700'
+              : 'bg-red-50 border-red-200 text-red-700',
+          )}
+        >
+          {testState.result.ok
+            ? <Check className="w-3 h-3" />
+            : <AlertCircle className="w-3 h-3" />}
+          {testState.result.text}
+        </span>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Add / Edit modal
+// ---------------------------------------------------------------------------
+
+interface ProviderModalProps {
+  initial?: ProviderView
+  onSave: (data: {
+    name: string
+    base_url: string
+    api_key: string
+    model: string
+    enabled: boolean
+  }) => Promise<void>
+  onClose: () => void
+}
+
+function ProviderModal({ initial, onSave, onClose }: ProviderModalProps) {
+  const [name, setName] = useState(initial?.name ?? '')
+  const [baseURL, setBaseURL] = useState(initial?.base_url ?? '')
+  const [apiKey, setApiKey] = useState('')
+  const [showKey, setShowKey] = useState(false)
+  const [model, setModel] = useState(initial?.model ?? '')
+  const [enabled, setEnabled] = useState(initial?.enabled ?? true)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const nameRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    nameRef.current?.focus()
+  }, [])
+
+  const handleReveal = async () => {
+    if (!showKey && apiKey === '' && initial?.api_key_set && initial.index !== undefined) {
+      const v = await revealProviderKey(initial.index)
+      if (v) setApiKey(v)
+    }
+    setShowKey(s => !s)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!name.trim()) { setErr('Name is required'); return }
+    setBusy(true); setErr(null)
+    try {
+      await onSave({ name: name.trim(), base_url: baseURL.trim(), api_key: apiKey, model: model.trim(), enabled })
+      onClose()
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={initial ? 'Edit provider' : 'Add provider'}
+    >
+      <div
+        className="bg-card border border-border rounded-lg shadow-lg w-full max-w-md p-5 space-y-4"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold">{initial ? 'Edit Provider' : 'Add Provider'}</h3>
+          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground" aria-label="Close">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <Field label="Name *">
+            <input
+              ref={nameRef}
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="e.g. Anthropic Official"
+              className="flex-1 text-sm px-2 py-1 border border-border rounded bg-background"
+              required
+            />
+          </Field>
+
+          <Field label="Base URL">
+            <input
+              type="url"
+              value={baseURL}
+              onChange={e => setBaseURL(e.target.value)}
+              placeholder="https://api.anthropic.com (default)"
+              className="flex-1 text-sm font-mono px-2 py-1 border border-border rounded bg-background"
+            />
+          </Field>
+
+          <Field label="API Key">
+            <div className="flex-1 flex gap-2 items-center">
+              <input
+                type={showKey ? 'text' : 'password'}
+                value={apiKey}
+                onChange={e => setApiKey(e.target.value)}
+                placeholder={initial?.api_key_set ? `configured · ${initial.api_key_hint ?? ''}` : 'sk-ant-…'}
+                className="flex-1 text-sm font-mono px-2 py-1 border border-border rounded bg-background"
+                autoComplete="off"
+              />
+              <button
+                type="button"
+                onClick={handleReveal}
+                className="text-muted-foreground hover:text-foreground"
+                title={showKey ? 'Hide' : 'Show saved value'}
+                aria-label={showKey ? 'Hide API key' : 'Show API key'}
+              >
+                {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
+            {initial?.api_key_set && apiKey === '' && (
+              <p className="text-[11px] text-muted-foreground">Leave blank to keep existing key.</p>
+            )}
+          </Field>
+
+          <Field label="Model">
+            <input
+              type="text"
+              value={model}
+              onChange={e => setModel(e.target.value)}
+              placeholder="(use global default)"
+              className="flex-1 text-sm font-mono px-2 py-1 border border-border rounded bg-background"
+            />
+          </Field>
+
+          <Field label="Enabled">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={e => setEnabled(e.target.checked)}
+              className="rounded border-border w-4 h-4"
+              aria-label="Provider enabled"
+            />
+          </Field>
+
+          {err && (
+            <p className="text-xs text-red-700 bg-red-50 border border-red-200 px-2 py-1.5 rounded">
+              {err}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-sm px-3 py-1 rounded border border-border hover:bg-secondary/50 text-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy}
+              className={cn(
+                'text-sm px-3 py-1 rounded border',
+                !busy
+                  ? 'bg-secondary hover:bg-secondary/70 border-border text-foreground'
+                  : 'bg-muted text-muted-foreground border-border cursor-not-allowed',
+              )}
+            >
+              {busy ? <Loader2 className="w-3 h-3 animate-spin inline mr-1" /> : null}
+              {initial ? 'Save' : 'Add'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-3">
+      <label className="text-xs text-muted-foreground w-20 shrink-0 pt-1.5">{label}</label>
+      <div className="flex-1 flex flex-col gap-1">{children}</div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main ProvidersSection
+// ---------------------------------------------------------------------------
+
+export function ProvidersSection() {
+  const [providers, setProviders] = useState<ProviderView[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadErr, setLoadErr] = useState<string | null>(null)
+  const [modal, setModal] = useState<{ mode: 'add' | 'edit'; provider?: ProviderView } | null>(null)
+  const [testStates, setTestStates] = useState<
+    Record<string, { busy: boolean; result: { ok: boolean; text: string } | null }>
+  >({})
+  const [saveErr, setSaveErr] = useState<string | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const load = useCallback(() => {
+    setLoadErr(null)
+    fetchProviders()
+      .then(ps => setProviders(ps))
+      .catch(e => setLoadErr(String(e.message || e)))
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => { load() }, [load])
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = providers.findIndex(p => p.name === active.id)
+    const newIndex = providers.findIndex(p => p.name === over.id)
+    const reordered = arrayMove(providers, oldIndex, newIndex).map((p, i) => ({ ...p, index: i }))
+    setProviders(reordered) // optimistic update
+
+    try {
+      const updated = await reorderProviders(reordered.map(p => p.name))
+      setProviders(updated)
+    } catch (e: unknown) {
+      setSaveErr(e instanceof Error ? e.message : String(e))
+      load() // revert on error
+    }
+  }
+
+  const handleToggle = async (p: ProviderView) => {
+    try {
+      const updated = await updateProvider(p.index, { enabled: !p.enabled })
+      setProviders(prev => prev.map(x => (x.name === p.name ? updated : x)))
+    } catch (e: unknown) {
+      setSaveErr(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  const handleDelete = async (p: ProviderView) => {
+    if (!window.confirm(`Delete provider "${p.name}"?`)) return
+    try {
+      await deleteProvider(p.index)
+      load()
+    } catch (e: unknown) {
+      setSaveErr(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  const handleTest = async (p: ProviderView) => {
+    setTestStates(prev => ({ ...prev, [p.name]: { busy: true, result: null } }))
+    try {
+      const d = await testProvider(p.index)
+      const ok = d.status === 'ok'
+      const text = ok
+        ? `OK${d.reply ? ' — ' + d.reply.slice(0, 60) : ''}`
+        : (d.error || 'failed').slice(0, 80)
+      setTestStates(prev => ({ ...prev, [p.name]: { busy: false, result: { ok, text } } }))
+    } catch (e: unknown) {
+      setTestStates(prev => ({
+        ...prev,
+        [p.name]: { busy: false, result: { ok: false, text: e instanceof Error ? e.message : String(e) } },
+      }))
+    }
+  }
+
+  const handleSaveAdd = async (data: {
+    name: string; base_url: string; api_key: string; model: string; enabled: boolean
+  }) => {
+    await addProvider({
+      name: data.name,
+      base_url: data.base_url || undefined,
+      api_key: data.api_key || undefined,
+      model: data.model || undefined,
+      enabled: data.enabled,
+    })
+    load()
+  }
+
+  const handleSaveEdit = (p: ProviderView) => async (data: {
+    name: string; base_url: string; api_key: string; model: string; enabled: boolean
+  }) => {
+    const body: Record<string, unknown> = {
+      name: data.name,
+      base_url: data.base_url,
+      model: data.model,
+      enabled: data.enabled,
+    }
+    // Only send api_key if the user typed something (non-empty = replace).
+    if (data.api_key !== '') {
+      body.api_key = data.api_key
+    }
+    await updateProvider(p.index, body as Parameters<typeof updateProvider>[1])
+    load()
+  }
+
+  return (
+    <section className="bg-card border border-border rounded-xl p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-foreground">Claude API Providers</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Ordered list of Claude API configurations. The runner tries providers top-to-bottom,
+            failing over on rate limits, auth errors, and network failures.
+            Drag to reorder — index 0 has highest priority.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setModal({ mode: 'add' })}
+          className="text-sm px-2.5 py-1 rounded border border-border hover:bg-secondary/50 text-foreground inline-flex items-center gap-1.5 shrink-0"
+          aria-label="Add provider"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          Add Provider
+        </button>
+      </div>
+
+      {loading && <p className="text-xs text-muted-foreground">Loading…</p>}
+      {loadErr && (
+        <div className="text-xs text-red-700 bg-red-50 border border-red-200 px-2 py-1.5 rounded">
+          Failed to load providers: {loadErr}
+        </div>
+      )}
+      {saveErr && (
+        <div className="text-xs text-red-700 bg-red-50 border border-red-200 px-2 py-1.5 rounded flex items-center justify-between">
+          <span>{saveErr}</span>
+          <button type="button" onClick={() => setSaveErr(null)} aria-label="Dismiss error">
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      )}
+
+      {!loading && providers.length === 0 && !loadErr && (
+        <p className="text-xs text-muted-foreground py-2">
+          No providers configured. Add one to enable multi-provider failover.
+        </p>
+      )}
+
+      {providers.length > 0 && (
+        <>
+          {/* Column headers */}
+          <div className="flex items-center gap-2 px-3 text-[10px] text-muted-foreground font-medium uppercase tracking-wide">
+            <span className="w-4 shrink-0" />
+            <span className="w-5 shrink-0">#</span>
+            <span className="w-32 shrink-0">Name</span>
+            <span className="flex-1">Base URL</span>
+            <span className="w-20 shrink-0">Model</span>
+            <span className="w-16 shrink-0">Key</span>
+            <span className="w-28 shrink-0">Actions</span>
+          </div>
+
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={providers.map(p => p.name)}
+              strategy={verticalListSortingStrategy}
+            >
+              <div className="space-y-1">
+                {providers.map(p => (
+                  <SortableRow
+                    key={p.name}
+                    provider={p}
+                    onEdit={p => setModal({ mode: 'edit', provider: p })}
+                    onDelete={handleDelete}
+                    onToggle={handleToggle}
+                    onTest={handleTest}
+                    testState={testStates[p.name] ?? { busy: false, result: null }}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </>
+      )}
+
+      {modal && (
+        <ProviderModal
+          initial={modal.mode === 'edit' ? modal.provider : undefined}
+          onSave={modal.mode === 'add' ? handleSaveAdd : handleSaveEdit(modal.provider!)}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </section>
+  )
+}

--- a/web/src/routes/_app.settings.tsx
+++ b/web/src/routes/_app.settings.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { Check, Loader2, AlertCircle, X, Eye, EyeOff, Folder, ChevronRight, Home, Copy, ExternalLink, RefreshCw, Upload, Download, LogOut } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { emitConfigChanged, useConfigChanged } from '../lib/configEvents'
+import { ProvidersSection } from '../components/ProvidersSection'
 
 interface SettingsView {
   claude: {
@@ -92,6 +93,7 @@ function SettingsPage() {
 
       {data && (
         <>
+          <ProvidersSection />
           <ClaudeSection view={data.claude} onSaved={refresh} />
           <TokensSection view={data.tokens} onSaved={refresh} />
           <GlobalSection view={data.global} onSaved={refresh} />


### PR DESCRIPTION
Fixes #128

## What changed

### Config layer
- New ClaudeProvider struct: Name, BaseURL, APIKey, Model, Enabled
- ClaudeProviders list added to Credentials; auto-migrates legacy claude_api_key + claude_base_url into ClaudeProviders[0] on first load (idempotent, persisted)
- DefaultFailoverPatterns: rate limit, 401, 5xx, network errors
- EffectiveFailoverPatterns() merges user-supplied patterns with defaults
- EnabledProviders() returns only enabled providers in list order

### Runner (internal/operator/claude.go)
- RunClaude iterates enabled providers in priority order
- Transient error matching failover pattern -> skip to next provider
- Genuine operator error (no pattern match) -> bail immediately
- All providers exhausted -> ErrRateLimit-wrapped error with per-provider failure summary (api_key scrubbed)
- Legacy single-provider path preserved as fallback

### Web API (internal/api/providers.go)
- GET /api/providers, POST /api/providers, PUT /api/providers/{index}, DELETE /api/providers/{index}
- PUT /api/providers/reorder (atomic single-write for drag-drop)
- POST /api/providers/{index}/test (lightweight probe)
- POST /api/providers/{index}/reveal (raw api_key)

### Web UI (web/src/components/ProvidersSection.tsx)
- Drag-to-reorder via @dnd-kit/sortable (keyboard accessible)
- Per-row: enable toggle, test button, edit, delete
- Add/Edit modal: password-typed api_key with reveal toggle
- Added at top of Settings page

### CLI (cmd/clawflow/commands/config_provider.go)
- clawflow config provider list/add/remove/enable/disable/move/test

### Tests
- internal/config/provider_test.go: migration idempotency, enabled-provider filtering, YAML round-trip, disk persistence
- internal/operator/failover_test.go: each default pattern triggers failover, unrelated errors do not, provider list construction, api_key scrubbing

## Testing
- go test ./internal/config/... ./internal/operator/... ./cmd/... -- all pass
- pnpm build in web/ -- clean TypeScript compile + Vite bundle

## Notes
- api_key stored plaintext in credentials.yaml (matches existing behavior); keyring integration is a separate follow-up
- Per-run cooldown only (cross-run cooldown out of scope for v1)
- Added: @dnd-kit/core@6.3.1, @dnd-kit/sortable@8.0.0, @dnd-kit/utilities@3.2.2