### PR TITLE
fix: analysis operators use persistent worktree instead of empty tempdir

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -1064,15 +1064,14 @@ func waitForCI(client vcs.Client, repo string, prNum int, timeoutSec int, prefix
 }
 
 // resolveWorkdir picks the cwd for the claude subprocess and returns a
-// cleanup callback. For operators that write code (implement) or target
-// PRs, the workdir must be a git worktree backed by the repo's local
-// clone — that way the operator's branch/commit/checkout commands don't
-// stomp on whatever the user has open in their primary clone. For
-// read-only operators, a tempdir is fine and gets RemoveAll'd on cleanup.
+// cleanup callback.
+//
+//   - implement / pr-target → per-issue mutable worktree (setupWorktree)
+//   - all other operators with local_path → persistent analysis worktree
+//     (ensureAnalysisWorktree) reset to origin/<base> before each run
+//   - all other operators without local_path → ephemeral tempdir + warning
 func resolveWorkdir(op *operator.Operator, repoCfg config.Repo, fullName string, issueNum int, startedAt time.Time) (worktreeResult, func(), error) {
-	// Pragmatic heuristic: "implement" and any pr-target operator need the
-	// repo. Everything else gets an ephemeral tempdir. A future schema field
-	// (e.g. operator.requires_workdir: true) can replace this.
+	// implement and pr-target operators need a mutable per-issue worktree.
 	needsRepo := op.Name == "implement" || op.Trigger.Target == "pr"
 	if needsRepo {
 		if repoCfg.LocalPath == "" {
@@ -1080,11 +1079,131 @@ func resolveWorkdir(op *operator.Operator, repoCfg config.Repo, fullName string,
 		}
 		return setupWorktree(repoCfg, fullName, issueNum, startedAt)
 	}
+
+	// Analysis operators need read access to the repo source so the LLM can
+	// grep/read actual code rather than guessing from issue text alone.
+	// Use a persistent analysis worktree that is always reset to origin/<base>
+	// before use so the operator sees the latest committed code.
+	if repoCfg.LocalPath != "" {
+		return ensureAnalysisWorktree(repoCfg, fullName)
+	}
+
+	// No local_path configured: fall back to an empty tempdir. Analysis quality
+	// will be limited since the operator cannot read source code.
+	fmt.Fprintf(os.Stderr, "  ⚠ no local_path configured for %s — operator %q will run without source code context (configure local_path for better analysis quality)\n", fullName, op.Name)
 	dir, err := os.MkdirTemp("", "clawflow-op-")
 	if err != nil {
 		return worktreeResult{}, func() {}, err
 	}
 	return worktreeResult{Path: dir}, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+// analysisWorktreeLocks serializes setup/refresh of analysis worktrees per
+// (slug, base) within a single process. Cross-process races are benign since
+// fetch+reset is idempotent.
+var analysisWorktreeLocks sync.Map // key "slug/base" → *sync.Mutex
+
+func getAnalysisWorktreeLock(slug, base string) *sync.Mutex {
+	key := slug + "/" + base
+	v, _ := analysisWorktreeLocks.LoadOrStore(key, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+// ensureAnalysisWorktree provisions or refreshes a persistent read-only
+// analysis worktree at ~/.clawflow/worktrees/<slug>/analysis-<base>.
+//
+// Unlike setupWorktree (which creates a per-issue ephemeral worktree for
+// implement), this worktree is long-lived and shared across all analysis
+// operators for the same repo+branch. It is always reset to origin/<base>
+// before use so the operator sees the latest committed code.
+//
+// Fetch failure blocks the operator — we refuse to run analysis on stale or
+// absent code rather than silently producing low-quality output.
+//
+// The returned cleanup is a no-op: the worktree persists for future runs.
+func ensureAnalysisWorktree(repoCfg config.Repo, fullName string) (worktreeResult, func(), error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return worktreeResult{}, func() {}, fmt.Errorf("home dir: %w", err)
+	}
+
+	base := repoCfg.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+	slug := strings.ReplaceAll(fullName, "/", "__")
+	localPath := repoCfg.LocalPath
+	wtPath := filepath.Join(home, ".clawflow", "worktrees", slug, "analysis-"+base)
+
+	// Serialize setup/refresh within this process so concurrent analysis
+	// operators on the same repo don't race on fetch+reset.
+	mu := getAnalysisWorktreeLock(slug, base)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Check whether the worktree already exists (has a .git pointer file).
+	_, statErr := os.Stat(filepath.Join(wtPath, ".git"))
+	worktreeExists := statErr == nil
+
+	if !worktreeExists {
+		// First time: fetch then create the worktree.
+		if err := os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
+			return worktreeResult{}, func() {}, fmt.Errorf("mkdir analysis worktree parent: %w", err)
+		}
+
+		fmt.Fprintf(os.Stderr, "  → analysis worktree: initializing at %s\n", wtPath)
+		fmt.Fprintf(os.Stderr, "  → analysis worktree: fetching origin/%s\n", base)
+		fetchCmd := exec.Command("git", "-C", localPath, "fetch", "origin", base)
+		fetchCmd.Stdout = os.Stderr
+		fetchCmd.Stderr = os.Stderr
+		if err := fetchCmd.Run(); err != nil {
+			return worktreeResult{}, func() {}, fmt.Errorf("git fetch origin/%s: %w — cannot initialize analysis worktree without network access", base, err)
+		}
+
+		addCmd := exec.Command("git", "-C", localPath, "worktree", "add", "--detach", wtPath, "origin/"+base)
+		addCmd.Stdout = os.Stderr
+		addCmd.Stderr = os.Stderr
+		if err := addCmd.Run(); err != nil {
+			// Fall back to the local base branch ref (e.g. brand-new clone
+			// that hasn't pushed yet and has no origin/<base> remote ref).
+			fmt.Fprintf(os.Stderr, "  ⚠ worktree add origin/%s failed, falling back to local %s\n", base, base)
+			addLocal := exec.Command("git", "-C", localPath, "worktree", "add", "--detach", wtPath, base)
+			addLocal.Stdout = os.Stderr
+			addLocal.Stderr = os.Stderr
+			if err2 := addLocal.Run(); err2 != nil {
+				return worktreeResult{}, func() {}, fmt.Errorf("git worktree add failed (origin/%s: %v; %s: %w)", base, err, base, err2)
+			}
+		}
+		fmt.Fprintf(os.Stderr, "  ✓ analysis worktree initialized (detached HEAD at origin/%s)\n", base)
+	} else {
+		// Existing worktree: fetch + reset to latest origin/<base>.
+		fmt.Fprintf(os.Stderr, "  → analysis worktree: refreshing to origin/%s\n", base)
+		fetchCmd := exec.Command("git", "-C", localPath, "fetch", "origin", base)
+		fetchCmd.Stdout = os.Stderr
+		fetchCmd.Stderr = os.Stderr
+		if err := fetchCmd.Run(); err != nil {
+			return worktreeResult{}, func() {}, fmt.Errorf("git fetch origin/%s: %w — analysis blocked to avoid stale-code evaluation", base, err)
+		}
+
+		resetCmd := exec.Command("git", "-C", wtPath, "reset", "--hard", "origin/"+base)
+		resetCmd.Stdout = os.Stderr
+		resetCmd.Stderr = os.Stderr
+		if err := resetCmd.Run(); err != nil {
+			return worktreeResult{}, func() {}, fmt.Errorf("git reset --hard origin/%s: %w", base, err)
+		}
+
+		cleanCmd := exec.Command("git", "-C", wtPath, "clean", "-fdx")
+		cleanCmd.Stdout = os.Stderr
+		cleanCmd.Stderr = os.Stderr
+		if err := cleanCmd.Run(); err != nil {
+			// Non-fatal: untracked files left behind won't affect analysis.
+			fmt.Fprintf(os.Stderr, "  ⚠ git clean -fdx (non-fatal): %v\n", err)
+		}
+		fmt.Fprintf(os.Stderr, "  ✓ analysis worktree refreshed (origin/%s)\n", base)
+	}
+
+	// No cleanup: the analysis worktree is persistent across runs.
+	return worktreeResult{Path: wtPath}, func() {}, nil
 }
 
 // worktreeResult holds the outcome of setupWorktree so the caller knows

--- a/skills/classify/SKILL.md
+++ b/skills/classify/SKILL.md
@@ -24,6 +24,10 @@ You are an issue triage classifier. Read the issue title and body and decide whe
 
 This operator only fires on issues that carry **no** classification label yet — its sole job is to route a fresh issue to the right downstream operator (`evaluate-bug`, `evaluate-feat`, or `reply-question`). It does not score, plan, or implement.
 
+## Source code context
+
+**Your working directory (`cwd`) is a snapshot of this repository's base branch at its latest commit.** If the issue references a specific file, function, or module, you can verify it exists with a quick `ls` or `grep` to improve classification accuracy.
+
 ## Output contract (MUST follow)
 
 Your stdout IS the issue comment. ClawFlow posts it verbatim, then applies the outcome label declared by the marker line at the end. Three hard rules:

--- a/skills/decompose/SKILL.md
+++ b/skills/decompose/SKILL.md
@@ -11,6 +11,10 @@ operator:
 
 You are a decomposition agent. Your job is to read a tracking issue and break it into concrete, independently-implementable sub-issues using the official GitHub sub-issue relationship.
 
+## Source code context
+
+**Your working directory (`cwd`) is a snapshot of this repository's base branch at its latest commit.** Use `ls`, `grep`, and file-reading tools to understand the existing code structure before decomposing — sub-issues grounded in actual modules and file paths are far easier to implement than abstract task descriptions.
+
 ## Output contract (MUST follow)
 
 Your stdout IS the issue comment. ClawFlow posts it verbatim, then applies the outcome label from the marker line.

--- a/skills/evaluate-bug/SKILL.md
+++ b/skills/evaluate-bug/SKILL.md
@@ -11,6 +11,14 @@ operator:
 
 You are a code-quality evaluator. Read the issue above and produce a structured assessment.
 
+## Source code context
+
+**Your working directory (`cwd`) is a snapshot of this repository's base branch at its latest commit.** You have full read access to the source code — use `ls`, `grep`, `Bash`, and file-reading tools to locate the relevant code before scoring. Evaluations that cite specific file paths, function names, and line numbers are far more useful than those based on issue text alone.
+
+If you cannot find the relevant code with a few targeted searches, say so explicitly — but always try first.
+
+**Root cause scores that do not reference any file path or symbol will be penalised.** A root cause like "the bug is in the validation logic" scores lower than "the bug is in `pkg/foo/bar.go:validateInput` which does X".
+
 ## Search history first (MUST do)
 
 Before scoring, run `clawflow issue search` to pull historical context for this repo. Every change in a clawflow project goes through an issue, so past issues are the project's decision archive — duplicates, prior root-cause analyses, and decisions about similar bugs all live there.

--- a/skills/evaluate-feat/SKILL.md
+++ b/skills/evaluate-feat/SKILL.md
@@ -12,6 +12,10 @@ operator:
 
 You are a feature-request evaluator. Read the issue above and produce a structured assessment.
 
+## Source code context
+
+**Your working directory (`cwd`) is a snapshot of this repository's base branch at its latest commit.** Use `ls`, `grep`, `Bash`, and file-reading tools to inspect the actual codebase before scoring scope and architectural fit. Evaluations that reference specific modules, interfaces, or files are significantly more useful than those based on issue text alone.
+
 ## Output contract (MUST follow)
 
 Your stdout IS the issue comment. ClawFlow captures everything you print to stdout, posts it as a comment, and reads the outcome marker from it to decide which label to apply.

--- a/skills/reply-comment/SKILL.md
+++ b/skills/reply-comment/SKILL.md
@@ -11,6 +11,10 @@ operator:
 
 Someone mentioned you in the issue above. Read the thread, find the latest comment that addresses you, and reply.
 
+## Source code context
+
+**Your working directory (`cwd`) is a snapshot of this repository's base branch at its latest commit.** If the question is about specific code, use `grep` or file-reading tools to look it up before answering — code-grounded replies are far more useful than guesses.
+
 ## Output contract (MUST follow)
 
 Your stdout IS the reply comment. ClawFlow posts it verbatim, then applies the outcome label declared by the marker line at the end. Three hard rules:

--- a/skills/reply-question/SKILL.md
+++ b/skills/reply-question/SKILL.md
@@ -19,6 +19,10 @@ Someone asked a technical question about the project. Your job is to provide a h
 
 This is NOT an evaluation task — do not score, assess priority, or estimate effort. Just answer the question.
 
+## Source code context
+
+**Your working directory (`cwd`) is a snapshot of this repository's base branch at its latest commit.** Use `ls`, `grep`, `Bash`, and file-reading tools to look up the actual implementation before answering — code-grounded answers are far more useful than guesses.
+
 ## Output contract (MUST follow)
 
 Your stdout IS the answer comment. ClawFlow posts it verbatim, then applies the outcome label. Three hard rules:

--- a/skills/track-progress/SKILL.md
+++ b/skills/track-progress/SKILL.md
@@ -11,6 +11,10 @@ operator:
 
 You are a progress-tracking agent. Your job is to check whether all sub-issues of a tracking issue are complete using GitHub's native sub-issue relationship, then report the current status.
 
+## Source code context
+
+**Your working directory (`cwd`) is a snapshot of this repository's base branch at its latest commit.** If you need to verify whether a sub-issue's implementation has actually landed in the codebase (e.g. checking for a function or file that should exist after a fix), you can use `grep` or file-reading tools to confirm.
+
 ## Output contract (MUST follow)
 
 Your stdout IS the issue comment. ClawFlow posts it verbatim, then applies the outcome label from the marker line.


### PR DESCRIPTION
Fixes #130

## What changed

** in **

Previously all non-implement/non-PR operators were routed to `os.MkdirTemp`, giving the LLM an empty directory. Now, when `local_path` is configured, analysis operators get a persistent worktree at `~/.clawflow/worktrees/<slug>/analysis-<base>` instead.

**New `ensureAnalysisWorktree` function**

- First use: `git fetch origin <base>` + `git worktree add --detach` — creates the long-lived worktree
- Subsequent uses: `git fetch origin <base>` + `git reset --hard origin/<base>` + `git clean -fdx` — always latest code
- A `sync.Map` mutex serializes concurrent analysis operators on the same repo within a process (cross-process races are benign since fetch+reset is idempotent)
- Fetch failure **blocks** the operator — we refuse to run analysis on stale/absent code rather than silently producing low-quality output
- No `local_path` configured → falls back to tempdir with a stderr warning

**Seven analysis SKILL.md files updated**

Added a `## Source code context` section to: `evaluate-bug`, `evaluate-feat`, `classify`, `decompose`, `reply-comment`, `reply-question`, `track-progress`. Each tells the LLM that `cwd` is the latest base branch snapshot and instructs it to grep/read source before drawing conclusions. `evaluate-bug` additionally notes that root cause scores without file paths or symbols will be penalised.

## What was tested

- `go build ./...` passes (with stub `web/dist` since frontend build is not available in this environment)
- `go test -race ./cmd/clawflow/commands/...` — PASS
- `go test -race ./internal/...` — PASS