### PR TITLE
fix: Pilot detects SOP drift and self-repairs deployment.md

### DIFF
--- a/internal/chat/project_pilot.go
+++ b/internal/chat/project_pilot.go
@@ -275,12 +275,33 @@ signal:
 - ` + "`PATROL: clean — last 200 lines normal`" + `
 - ` + "`PATROL: 3 unique error patterns → filed bug api#42, api#43`" + `
 - ` + "`PATROL: SSH unreachable, skipped — see deployment.md`" + `
+- ` + "`PATROL: SOP drift — deployment.md commands returned no meaningful logs but project is active (recent runs/, web.pid exists) → updated deployment.md`" + `
 
 Errors observed but not yet tracked → file a bug (counts against the
 2-issue budget). Performance regressions or recurring nuisance log-spam
 → file as feature/improvement. This is the positive-feedback loop:
 production reality flows back into the backlog without anyone manually
 filing.
+
+**SOP drift detection:** After running the deployment.md log commands,
+if the returned signal is near-empty (e.g. only a handful of entries or
+no output at all) but the project shows signs of activity — any of:
+` + "`~/.clawflow/data/runs.json`" + ` has entries from the last 24h,
+` + "`~/.clawflow/data/web.pid`" + ` exists, or recent entries exist under
+` + "`~/.clawflow/data/pilot-runs/`" + ` — treat this as SOP drift. When drift is
+detected:
+1. Actively scan ` + "`~/.clawflow/logs/`" + ` and ` + "`~/.clawflow/data/`" + ` to find
+   the real log sources.
+2. Verify the corrected commands actually return meaningful data (run
+   them via Bash before committing to the update).
+3. Emit an updated ` + "`deployment.md`" + ` via the fenced block protocol below.
+4. Record the update in the ` + "`monitoring`" + ` duty's ` + "`actions`" + ` list, e.g.
+   ` + "`\"refreshed deployment.md — pointed log patrol at ~/.clawflow/logs/run.log\"`" + `.
+
+Be conservative: require at least one strong positive signal (e.g.
+` + "`runs.json`" + ` has entries from the last 24h) before emitting SOP-drift.
+A genuinely idle project with no recent runs should still write
+` + "`PATROL: clean`" + `, not trigger a false drift alarm.
 
 ## Hard rules
 
@@ -328,6 +349,29 @@ context.md in a fenced block:
 Emit the full file each time (the runner replaces, doesn't merge). Omit
 the block when nothing material changed. The runner only persists when
 the block is present and differs from the current file.
+
+## Updating the project's runtime SOP (deployment.md)
+
+When Play 3 reveals that deployment.md's log-retrieval commands don't
+match the project's actual log layout (SOP drift), output the complete
+updated deployment.md in a fenced block:
+
+    ` + "```deployment.md" + `
+    # Deployment
+    ... full document ...
+    ` + "```" + `
+
+Rules:
+- Only emit this block when you have **verified** the corrected commands
+  return real log data (run them via Bash first — don't speculate).
+- Emit the full file each time (the runner replaces, doesn't merge).
+- The runner only persists when the block is present and differs from
+  the current file, and only on a successful wake.
+- deployment.md is user-visible; only overwrite it when the new version
+  is a strict improvement (better log sources, corrected paths). Don't
+  rewrite for style.
+- Note the update in the ` + "`monitoring`" + ` duty's ` + "`actions`" + ` list (not
+  ` + "`doc_sync`" + ` — this is a Play 3 companion action).
 
 ## Output contract
 

--- a/internal/chat/project_test.go
+++ b/internal/chat/project_test.go
@@ -334,6 +334,52 @@ func TestBuildPilotContext_StandardPlays(t *testing.T) {
 	}
 }
 
+func TestBuildPilotContext_SOPDriftAndDeploymentUpdate(t *testing.T) {
+	repos := []PilotRepoDigest{}
+	prompt := BuildPilotContext("p", "", "## Logs\n\n```bash\ncat /tmp/old.log\n```", nil, repos)
+
+	// 4th PATROL output must be present
+	if !containsStr(prompt, "PATROL: SOP drift") {
+		t.Error("missing 4th PATROL output (SOP drift) in Play 3 contract")
+	}
+	if !containsStr(prompt, "web.pid") {
+		t.Error("missing web.pid activity signal in SOP drift detection rubric")
+	}
+	if !containsStr(prompt, "runs.json") {
+		t.Error("missing runs.json activity signal in SOP drift detection rubric")
+	}
+	if !containsStr(prompt, "pilot-runs/") {
+		t.Error("missing pilot-runs/ activity signal in SOP drift detection rubric")
+	}
+
+	// deployment.md update protocol section must be present
+	if !containsStr(prompt, "Updating the project's runtime SOP (deployment.md)") {
+		t.Error("missing 'Updating the project's runtime SOP (deployment.md)' section")
+	}
+	if !containsStr(prompt, "```deployment.md") {
+		t.Error("missing fenced deployment.md block in update protocol")
+	}
+	if !containsStr(prompt, "verified") {
+		t.Error("missing verification requirement in deployment.md update protocol")
+	}
+	// Must note that this is a monitoring duty action, not doc_sync
+	if !containsStr(prompt, "monitoring") {
+		t.Error("missing monitoring duty reference in deployment.md update protocol")
+	}
+}
+
+func TestBuildPilotContext_DeploymentUpdateProtocolAlwaysPresent(t *testing.T) {
+	// The deployment.md update protocol section should appear even when
+	// deployment.md is empty — Pilot may discover the file is missing and
+	// create it from scratch.
+	prompt := BuildPilotContext("p", "", "", nil, []PilotRepoDigest{})
+
+	if !containsStr(prompt, "Updating the project's runtime SOP (deployment.md)") {
+		t.Error("deployment.md update protocol section must be present even when deployment.md is empty")
+	}
+}
+
+
 func TestBuildProjectChatContext_AutomationModel(t *testing.T) {
 	repos := []ProjectChatRepo{{Name: "owner/repo-a", LocalPath: "/tmp/repo-a"}}
 	ctx := BuildProjectChatContext("my-proj", repos, "", "")

--- a/internal/pilot/schedule.go
+++ b/internal/pilot/schedule.go
@@ -369,6 +369,19 @@ func wake(ctx context.Context, p *project.Project, cfg *config.Config, creds *co
 				fmt.Fprintf(os.Stderr, "[pilot] %s: context.md updated by Pilot\n", p.Name)
 			}
 		}
+		// On success, look for an updated deployment.md in the output and
+		// persist it. Symmetric to context.md: Pilot may rewrite the runtime
+		// SOP when Play 3 detects that the existing log commands don't match
+		// the project's actual log layout (SOP drift). Only honour writes on
+		// a successful wake — a failed wake's view of the environment may be
+		// inconsistent.
+		if updated := chat.ExtractFencedBlock(output, "deployment.md"); updated != "" && strings.TrimSpace(updated) != strings.TrimSpace(deploymentMD) {
+			if werr := project.WriteDeployment(p.Name, updated); werr != nil {
+				fmt.Fprintf(os.Stderr, "[pilot] %s: write deployment.md: %v\n", p.Name, werr)
+			} else {
+				fmt.Fprintf(os.Stderr, "[pilot] %s: deployment.md updated by Pilot\n", p.Name)
+			}
+		}
 	}
 
 	if u, uerr := snapshot.ExtractUsage(filepath.Join(runDir, "events.jsonl")); uerr == nil {

--- a/internal/pilot/schedule_writeback_test.go
+++ b/internal/pilot/schedule_writeback_test.go
@@ -1,0 +1,103 @@
+package pilot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/chat"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
+)
+
+// TestDeploymentMDWriteBack verifies that ExtractFencedBlock correctly
+// extracts a deployment.md block from Pilot output, and that the
+// extracted content differs from the original (triggering a write).
+// This mirrors the logic in wake() without invoking claude.
+func TestDeploymentMDWriteBack(t *testing.T) {
+	// Simulate Pilot output containing an updated deployment.md block.
+	pilotOutput := `
+I detected SOP drift — the existing log commands returned no output but
+~/.clawflow/data/runs.json has recent entries. I verified the corrected
+commands return real data.
+
+` + "```deployment.md" + `
+# Deployment
+
+## Method 1: Structured logs (preferred)
+
+` + "```bash" + `
+tail -n 200 ~/.clawflow/logs/run.log
+` + "```" + `
+` + "```" + `
+
+PATROL: SOP drift — deployment.md commands returned no meaningful logs but project is active → updated deployment.md
+PILOT-RESULT: 1 action — refreshed deployment.md, pointed log patrol at ~/.clawflow/logs/run.log
+`
+
+	oldDeployment := "## Logs\n\n```bash\ncat /tmp/old.log\n```"
+
+	extracted := chat.ExtractFencedBlock(pilotOutput, "deployment.md")
+	if extracted == "" {
+		t.Fatal("ExtractFencedBlock returned empty for deployment.md block in Pilot output")
+	}
+	if strings.TrimSpace(extracted) == strings.TrimSpace(oldDeployment) {
+		t.Error("extracted deployment.md should differ from old content — write-back would be skipped")
+	}
+	if !strings.Contains(extracted, "run.log") {
+		t.Error("extracted deployment.md should reference run.log")
+	}
+}
+
+// TestDeploymentMDWriteBack_NoChange verifies that when the Pilot emits
+// a deployment.md block identical to the current file, the write-back
+// is skipped (strings.TrimSpace comparison).
+func TestDeploymentMDWriteBack_NoChange(t *testing.T) {
+	existing := "# Deployment\n\nSSH then journalctl."
+	pilotOutput := "```deployment.md\n# Deployment\n\nSSH then journalctl.\n```"
+
+	extracted := chat.ExtractFencedBlock(pilotOutput, "deployment.md")
+	if strings.TrimSpace(extracted) != strings.TrimSpace(existing) {
+		t.Errorf("expected identical content to skip write-back, got %q vs %q", extracted, existing)
+	}
+}
+
+// TestDeploymentMDWriteBack_NoBlock verifies that when the Pilot output
+// contains no deployment.md block, ExtractFencedBlock returns "" and
+// no write-back occurs.
+func TestDeploymentMDWriteBack_NoBlock(t *testing.T) {
+	pilotOutput := "PATROL: clean — last 200 lines normal\nPILOT-RESULT: no-action — backlog coherent"
+
+	extracted := chat.ExtractFencedBlock(pilotOutput, "deployment.md")
+	if extracted != "" {
+		t.Errorf("expected empty extraction when no deployment.md block present, got %q", extracted)
+	}
+}
+
+// TestDeploymentMDWriteBack_RoundTrip verifies the full write/read cycle
+// using the real project.WriteDeployment / project.ReadDeployment functions.
+func TestDeploymentMDWriteBack_RoundTrip(t *testing.T) {
+	// Use a temp dir as HOME so we don't pollute ~/.clawflow.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	projName := "writeback-test"
+	// Ensure the project directory exists.
+	projDir := filepath.Join(tmpHome, ".clawflow", "projects", projName)
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+
+	newContent := "# Deployment\n\n## Logs\n\ntail -n 200 ~/.clawflow/logs/run.log"
+
+	if err := project.WriteDeployment(projName, newContent); err != nil {
+		t.Fatalf("WriteDeployment: %v", err)
+	}
+	got, err := project.ReadDeployment(projName)
+	if err != nil {
+		t.Fatalf("ReadDeployment: %v", err)
+	}
+	if got != newContent {
+		t.Errorf("ReadDeployment = %q, want %q", got, newContent)
+	}
+}


### PR DESCRIPTION
Fixes #134\n\n## What changed\n\n### Play 3 — 4th patrol output (project_pilot.go)\n\nAdds `PATROL: SOP drift — deployment.md commands returned no meaningful logs but project is active → updated deployment.md` as a legal Play 3 outcome. Includes a conservative drift-detection rubric: Pilot must see at least one strong activity signal (`runs.json` entries from last 24h, `web.pid` present, or recent `pilot-runs/` entries) before emitting drift — a genuinely idle project still writes `PATROL: clean`.\n\n### deployment.md self-maintenance protocol (project_pilot.go)\n\nNew section symmetric to the existing `context.md` update protocol. Pilot may emit a fenced ```deployment.md block only after verifying the corrected commands return real log data via Bash. Rules: full file each time (runner replaces), only on successful wake, note the update in `monitoring` duty actions (not `doc_sync`).\n\n### Runner write-back (schedule.go)\n\nAfter the context.md write-back block, calls `chat.ExtractFencedBlock(output, "deployment.md")` and on mismatch calls `project.WriteDeployment`. Gated on `meta.Status == "success"` — same guard as context.md. Logs `[pilot] <proj>: deployment.md updated by Pilot`.\n\n### Tests\n\n- `TestBuildPilotContext_SOPDriftAndDeploymentUpdate` — asserts 4th PATROL line, activity signals, and new protocol section are present in the prompt\n- `TestBuildPilotContext_DeploymentUpdateProtocolAlwaysPresent` — protocol section present even when deployment.md is empty\n- `TestDeploymentMDWriteBack` — extraction detects changed content\n- `TestDeploymentMDWriteBack_NoChange` — identical content skips write-back\n- `TestDeploymentMDWriteBack_NoBlock` — no block → empty extraction\n- `TestDeploymentMDWriteBack_RoundTrip` — full WriteDeployment/ReadDeployment cycle\n\n## Tested\n\n`go test ./internal/chat/... ./internal/pilot/... ./internal/project/...` — all pass.