### PR TITLE
fix: stop evaluate operator infinite retry on missing outcome marker

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -797,9 +797,18 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	// the caller so it can abort the remaining job queue.
 	isRateLimit := runErr != nil && errors.Is(runErr, operator.ErrRateLimit)
 
+	// Detect no-marker failures: claude produced output but omitted the
+	// outcome marker. operator.Run now returns ErrNoOutcomeMarker for this
+	// case so we can route it through the circuit breaker (status="failed")
+	// instead of silently recording it as "success" and letting the issue
+	// re-fire indefinitely (see issue #143).
+	isNoMarker := runErr != nil && errors.Is(runErr, operator.ErrNoOutcomeMarker)
+
 	if runErr != nil {
 		if isRateLimit {
 			fmt.Fprintf(os.Stderr, "%s ✗ claude rate limited (will retry next pass): %v\n", prefix, runErr)
+		} else if isNoMarker {
+			fmt.Fprintf(os.Stderr, "%s ✗ claude produced no outcome marker (will count toward circuit breaker): %v\n", prefix, runErr)
 		} else {
 			fmt.Fprintf(os.Stderr, "%s ✗ claude failed: %v\n", prefix, runErr)
 		}
@@ -823,11 +832,22 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		// and ConsecutiveFailures doesn't count this toward the circuit breaker.
 		rm.Status = "rate-limited"
 		rm.Error = runErr.Error()
+	case isNoMarker:
+		// No-marker runs are recorded as "no-marker" (distinct from generic
+		// "failed") so the dashboard can surface the specific cause. They DO
+		// count toward the circuit breaker — the issue stays unlabeled and
+		// will re-fire on every subsequent pass otherwise (issue #143).
+		rm.Status = "no-marker"
+		rm.Error = runErr.Error()
 	case runErr != nil:
 		rm.Status = "failed"
 		rm.Error = runErr.Error()
 	case output == "":
-		rm.Status = "skipped"
+		// Empty output: claude exited cleanly but produced nothing. Like
+		// no-marker, the issue stays unlabeled and will re-fire. Count toward
+		// the circuit breaker so a stuck issue eventually gets agent-failed
+		// instead of looping forever (issue #143).
+		rm.Status = "skipped-empty"
 	default:
 		rm.Status = "success"
 	}
@@ -835,7 +855,9 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	// Conditional cleanup: only remove the worktree on success/skip.
 	// On failure, preserve it so the next run can resume from the
 	// partial work instead of starting from scratch.
-	if rm.Status == "success" || rm.Status == "skipped" {
+	// skipped-empty and no-marker have no partial work worth resuming,
+	// so clean up to avoid accumulating stale worktrees.
+	if rm.Status == "success" || rm.Status == "skipped-empty" || rm.Status == "no-marker" {
 		cleanup()
 	} else {
 		fmt.Fprintf(os.Stderr, "%s → preserving worktree for resume on next run: %s\n", prefix, workdir)
@@ -866,11 +888,17 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	case "success":
 		fmt.Printf("%s ✓ done\n", prefix)
 		return true, false
-	case "skipped":
-		return true, false
 	case "rate-limited":
 		// Signal the caller to abort the queue; do NOT call checkCircuitBreaker.
 		return false, true
+	case "no-marker":
+		fmt.Printf("%s ✗ no outcome marker (circuit breaker counting)\n", prefix)
+		checkCircuitBreaker(j, prefix)
+		return false, false
+	case "skipped-empty":
+		fmt.Printf("%s ✗ empty output (circuit breaker counting)\n", prefix)
+		checkCircuitBreaker(j, prefix)
+		return false, false
 	default:
 		checkCircuitBreaker(j, prefix)
 		return false, false

--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +11,14 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrNoOutcomeMarker is returned by Run when claude produced non-empty output
+// but the output contained no <!-- clawflow:outcome=… --> marker. This is
+// treated as a recoverable failure (not a permanent one) so the circuit
+// breaker upstream can count consecutive occurrences and eventually add
+// agent-failed to stop the retry loop. It is distinct from ErrRateLimit so
+// the caller can handle each case appropriately.
+var ErrNoOutcomeMarker = errors.New("operator produced no outcome marker")
 
 // outcomeRE matches a "<!-- clawflow:outcome=<label> --> " line. The runner
 // parses these from the operator's stdout to learn which terminal label to
@@ -132,15 +141,17 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 	//
 	// Posting this summary as a comment would accumulate duplicate meta-comments
 	// on every run (the trigger label is still present, so the operator fires
-	// again). Instead, log a warning and skip the comment post. The lock label
-	// will still be removed by the caller, so the issue is left in a clean state
-	// for the next run (which may succeed once the prompt hardening takes effect).
+	// again). Instead, return ErrNoOutcomeMarker so the caller records this as
+	// a failure and the circuit breaker can count consecutive occurrences.
+	// Without this, the issue stays unlabeled and re-fires on every subsequent
+	// pass until claude happens to produce a valid marker — potentially looping
+	// indefinitely (see issue #143).
 	if outcome == "" {
 		fmt.Fprintf(os.Stderr,
-			"  ⚠ operator %q stdout has no outcome marker — operator may have self-posted via a tool call; skipping comment post to prevent duplicate accumulation\n",
+			"  ⚠ operator %q stdout has no outcome marker — operator may have self-posted via a tool call; recording as failure to prevent infinite retry loop\n",
 			op.Name)
 		fmt.Fprintf(os.Stderr, "  ⚠ stdout was: %s\n", trimmed)
-		return trimmed, "", nil
+		return trimmed, "", ErrNoOutcomeMarker
 	}
 
 	// Write-back phase: post comment, apply outcome label, remove trigger labels.

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -102,8 +102,10 @@ func TestRun_HappyPath(t *testing.T) {
 			return "evaluation posted", nil
 		},
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// No outcome marker → Run now returns ErrNoOutcomeMarker so the circuit
+	// breaker upstream can count consecutive occurrences (issue #143).
+	if !errors.Is(err, ErrNoOutcomeMarker) {
+		t.Fatalf("expected ErrNoOutcomeMarker, got: %v", err)
 	}
 	if output != "evaluation posted" {
 		t.Errorf("Run returned output %q, want %q", output, "evaluation posted")
@@ -118,10 +120,7 @@ func TestRun_HappyPath(t *testing.T) {
 	if v.removeLabelCals != 0 {
 		t.Errorf("RemoveLabel called %d times, want 0", v.removeLabelCals)
 	}
-	// No outcome marker in the output → runner skips the comment post to
-	// prevent duplicate accumulation (the self-posting guard introduced in
-	// fix/issue-53). A real operator must include a marker; this test op
-	// intentionally omits one to verify the guard fires cleanly.
+	// No outcome marker → runner skips comment post (no VCS side-effects).
 	if len(v.comments) != 0 {
 		t.Fatalf("want 0 comments (no outcome marker → guard skips post), got %d", len(v.comments))
 	}
@@ -198,7 +197,9 @@ func TestRun_EventWriterReceivesRunFuncInput(t *testing.T) {
 			return "ok", nil
 		},
 	})
-	if err != nil {
+	// "ok" has no outcome marker → ErrNoOutcomeMarker (issue #143).
+	// The test only cares that EventWriter was wired through, not the outcome.
+	if err != nil && !errors.Is(err, ErrNoOutcomeMarker) {
 		t.Fatalf("unexpected: %v", err)
 	}
 	if captured != sink {
@@ -349,10 +350,11 @@ func TestRun_OutcomeMarker_None_NoPost(t *testing.T) {
 			return body, nil
 		},
 	})
-	if err != nil {
-		t.Fatalf("unexpected: %v", err)
+	// No marker → ErrNoOutcomeMarker so the circuit breaker can count it (issue #143).
+	if !errors.Is(err, ErrNoOutcomeMarker) {
+		t.Fatalf("expected ErrNoOutcomeMarker, got: %v", err)
 	}
-	// No marker → runner skips comment post (self-posting guard).
+	// No marker → runner skips comment post (no VCS side-effects).
 	if len(v.comments) != 0 {
 		t.Errorf("want 0 comments (no marker → guard skips post); got %v", v.comments)
 	}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -240,7 +240,8 @@ type RunMeta struct {
 	// would carry "0001-01-01T00:00:00Z" and the dashboard's duration math
 	// would render it as a giant negative offset.
 	EndedAt     *time.Time `json:"ended_at,omitempty"`
-	// Status is one of "running", "finalizing", "success", "failed", "skipped", "cancelled".
+	// Status is one of "running", "finalizing", "success", "failed", "skipped",
+	// "cancelled", "no-marker", "skipped-empty".
 	// "cancelled" is set only by /api/run/cancel after the runner process
 	// is killed — it lets the dashboard distinguish a user-initiated kill
 	// from an organic crash ("failed").
@@ -248,6 +249,9 @@ type RunMeta struct {
 	// successfully, before usage extraction and meta cleanup. If the process
 	// is killed in this window, the reconciler treats it as completed (not
 	// stale) and promotes it to "success" without re-queuing the issue.
+	// "no-marker" means claude produced output but omitted the outcome marker;
+	// the issue stays unlabeled and the circuit breaker counts this run.
+	// "skipped-empty" means claude produced empty output; same treatment.
 	Status  string `json:"status"`
 	PRUrl   string `json:"pr_url,omitempty"`
 	Error   string `json:"error,omitempty"`
@@ -1348,7 +1352,7 @@ func ConsecutiveFailures(repo string, issueNum int) int {
 	})
 	count := 0
 	for _, r := range runs {
-		if r.status != "failed" {
+		if r.status != "failed" && r.status != "no-marker" && r.status != "skipped-empty" {
 			break
 		}
 		count++

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -25,7 +25,7 @@ export interface Run {
   issue_title?: string
   started_at: string
   ended_at?: string
-  status: 'success' | 'failed' | 'skipped' | 'running' | 'cancelled'
+  status: 'success' | 'failed' | 'skipped' | 'running' | 'cancelled' | 'no-marker' | 'skipped-empty'
   summary?: string
   path: string
   pr_url?: string
@@ -613,6 +613,8 @@ export function StatusBadge({ status, runnerAlive }: { status: Run['status']; ru
           status === 'skipped' && 'bg-muted text-muted-foreground border-border',
           status === 'running' && 'bg-blue-100 text-blue-700 border-blue-200',
           status === 'cancelled' && 'bg-amber-50 text-amber-700 border-amber-200',
+          status === 'no-marker' && 'bg-orange-100 text-orange-700 border-orange-200',
+          status === 'skipped-empty' && 'bg-orange-50 text-orange-600 border-orange-200',
         )}
       >
         {status}

--- a/web/src/routes/_app.dashboard.tsx
+++ b/web/src/routes/_app.dashboard.tsx
@@ -31,7 +31,7 @@ interface Run {
   issue_state?: string
   started_at: string
   ended_at?: string
-  status: 'success' | 'failed' | 'skipped' | 'running' | 'cancelled'
+  status: 'success' | 'failed' | 'skipped' | 'running' | 'cancelled' | 'no-marker' | 'skipped-empty'
   summary?: string
   pr_url?: string
   error?: string
@@ -74,11 +74,13 @@ interface Pending {
 type StatusFilter = 'all' | 'success' | 'failed' | 'skipped' | 'running' | 'cancelled'
 
 const statusPill: Record<Run['status'], { label: string; cls: string; Icon: typeof CheckCircle2 }> = {
-  success:   { label: 'success',   cls: 'bg-green-100 text-green-700 border-green-200',   Icon: CheckCircle2 },
-  running:   { label: 'running',   cls: 'bg-blue-100 text-blue-700 border-blue-200',      Icon: Loader2 },
-  failed:    { label: 'failed',    cls: 'bg-red-100 text-red-700 border-red-200',         Icon: XCircle },
-  skipped:   { label: 'skipped',   cls: 'bg-muted text-muted-foreground border-border',   Icon: SkipForward },
-  cancelled: { label: 'cancelled', cls: 'bg-amber-50 text-amber-700 border-amber-200',    Icon: Square },
+  success:       { label: 'success',      cls: 'bg-green-100 text-green-700 border-green-200',   Icon: CheckCircle2 },
+  running:       { label: 'running',      cls: 'bg-blue-100 text-blue-700 border-blue-200',      Icon: Loader2 },
+  failed:        { label: 'failed',       cls: 'bg-red-100 text-red-700 border-red-200',         Icon: XCircle },
+  skipped:       { label: 'skipped',      cls: 'bg-muted text-muted-foreground border-border',   Icon: SkipForward },
+  cancelled:     { label: 'cancelled',    cls: 'bg-amber-50 text-amber-700 border-amber-200',    Icon: Square },
+  'no-marker':   { label: 'no marker',    cls: 'bg-orange-100 text-orange-700 border-orange-200', Icon: XCircle },
+  'skipped-empty': { label: 'empty',      cls: 'bg-orange-50 text-orange-600 border-orange-200', Icon: SkipForward },
 }
 
 function StatusChip({ status }: { status: Run['status'] }) {
@@ -287,7 +289,10 @@ function Dashboard() {
   const counts = useMemo(() => {
     const c = { total: runs.length, success: 0, failed: 0, skipped: 0, running: 0, cancelled: 0 }
     for (const r of runs) {
-      if (r.status in c) c[r.status]++
+      // no-marker and skipped-empty are label-state-machine failures: bucket
+      // them under "failed" for the stat cards so they surface as actionable.
+      const bucket = (r.status === 'no-marker' || r.status === 'skipped-empty') ? 'failed' : r.status
+      if (bucket in c) c[bucket as keyof typeof c]++
     }
     return c
   }, [runs])
@@ -308,7 +313,12 @@ function Dashboard() {
   const { filteredRunning, filteredHistory } = useMemo(() => {
     const q = query.trim().toLowerCase()
     const passesFilters = (r: Run) => {
-      if (statusFilter !== 'all' && r.status !== statusFilter) return false
+      if (statusFilter !== 'all') {
+        // "failed" filter also captures no-marker and skipped-empty since they
+        // are bucketed under failed in the stat cards (issue #143).
+        const effectiveStatus = (r.status === 'no-marker' || r.status === 'skipped-empty') ? 'failed' : r.status
+        if (effectiveStatus !== statusFilter) return false
+      }
       if (repoFilter !== 'all' && r.repo !== repoFilter) return false
       if (q && !(r.issue_title || '').toLowerCase().includes(q) && !String(r.issue_number).includes(q)) return false
       return true

--- a/web/src/routes/_app.runs.$slug.$issue.$ts.tsx
+++ b/web/src/routes/_app.runs.$slug.$issue.$ts.tsx
@@ -32,7 +32,7 @@ interface RunMeta {
   issue_title?: string
   started_at: string
   ended_at?: string
-  status: 'success' | 'failed' | 'skipped' | 'running' | 'cancelled'
+  status: 'success' | 'failed' | 'skipped' | 'running' | 'cancelled' | 'no-marker' | 'skipped-empty'
   summary?: string
   pr_url?: string
   error?: string
@@ -377,6 +377,50 @@ function ConclusionPanel({ meta }: { meta: RunMeta | null }) {
     )
   }
 
+  if (meta.status === 'no-marker') {
+    return (
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold mb-2" style={{ color: 'hsl(var(--error))' }}>
+          Conclusion · no outcome marker
+        </h2>
+        <div
+          className="rounded-lg p-4 text-sm whitespace-pre-wrap"
+          style={{
+            background: 'hsl(var(--bg-secondary))',
+            border: '1px solid hsl(var(--border))',
+            borderLeft: '3px solid hsl(var(--error))',
+            color: 'hsl(var(--text-high))',
+          }}
+        >
+          <p className="mb-2">The operator produced output but omitted the <code>{'<!-- clawflow:outcome=… -->'}</code> marker. No comment was posted and no label was applied to the issue.</p>
+          <p className="text-xs" style={{ color: 'hsl(var(--text-low))' }}>This run counts toward the circuit breaker. After {'{maxConsecutiveFailures}'} consecutive occurrences the issue will be labeled <code>agent-failed</code>.</p>
+          {meta.summary && <pre className="mt-3 text-xs overflow-auto">{meta.summary}</pre>}
+        </div>
+      </section>
+    )
+  }
+
+  if (meta.status === 'skipped-empty') {
+    return (
+      <section className="mb-6">
+        <h2 className="text-sm font-semibold mb-2" style={{ color: 'hsl(var(--text-high))' }}>
+          Conclusion · empty output
+        </h2>
+        <div
+          className="rounded-lg p-4 text-sm"
+          style={{
+            background: 'hsl(var(--bg-secondary))',
+            border: '1px solid hsl(var(--border))',
+            borderLeft: '3px solid hsl(var(--warning, var(--border)))',
+            color: 'hsl(var(--text-low))',
+          }}
+        >
+          Claude exited cleanly but produced no output. No comment was posted and no label was applied. This run counts toward the circuit breaker.
+        </div>
+      </section>
+    )
+  }
+
   if (meta.status === 'cancelled') {
     return (
       <section className="mb-6">
@@ -529,11 +573,13 @@ function msToShort(ms: number): string {
 
 function StatusBadge({ status }: { status: RunMeta['status'] }) {
   const cfg = {
-    success:   { cls: 'bg-green-100 text-green-700 border-green-200',  Icon: CheckCircle2 },
-    running:   { cls: 'bg-blue-100 text-blue-700 border-blue-200',     Icon: Loader2 },
-    failed:    { cls: 'bg-red-100 text-red-700 border-red-200',        Icon: XCircle },
-    skipped:   { cls: 'bg-muted text-muted-foreground border-border',  Icon: SkipForward },
-    cancelled: { cls: 'bg-amber-50 text-amber-700 border-amber-200',   Icon: Square },
+    success:         { cls: 'bg-green-100 text-green-700 border-green-200',    Icon: CheckCircle2 },
+    running:         { cls: 'bg-blue-100 text-blue-700 border-blue-200',       Icon: Loader2 },
+    failed:          { cls: 'bg-red-100 text-red-700 border-red-200',          Icon: XCircle },
+    skipped:         { cls: 'bg-muted text-muted-foreground border-border',    Icon: SkipForward },
+    cancelled:       { cls: 'bg-amber-50 text-amber-700 border-amber-200',     Icon: Square },
+    'no-marker':     { cls: 'bg-orange-100 text-orange-700 border-orange-200', Icon: XCircle },
+    'skipped-empty': { cls: 'bg-orange-50 text-orange-600 border-orange-200',  Icon: SkipForward },
   }[status] ?? { cls: 'bg-muted text-muted-foreground border-border', Icon: SkipForward }
   const Icon = cfg.Icon
   return (


### PR DESCRIPTION
Fixes #143

## What changed

When claude produces output but omits the `<!-- clawflow:outcome=… -->` marker, the runner previously returned `(output, "", nil)` — recording `status="success"` with no label applied. Since trigger labels were never removed, the operator re-fired on every cron pass, looping until claude happened to produce a valid marker.

### Root cause (from evaluation in #143)

Two failure modes, both leaving the issue unlabeled:
1. **No-marker run** (`output != ""`, `outcome == ""`): recorded as `status="success"`, circuit breaker never triggered
2. **Empty-output run** (`output == ""`): recorded as `status="skipped"`, circuit breaker never triggered

### Fix

- **`internal/operator/runner.go`**: introduce `ErrNoOutcomeMarker` sentinel; the no-marker guard now returns this error instead of `nil`
- **`cmd/clawflow/commands/run.go`**: detect `ErrNoOutcomeMarker` → `status="no-marker"`; empty output → `status="skipped-empty"`. Both route through `checkCircuitBreaker` so consecutive occurrences eventually add `agent-failed`
- **`internal/snapshot/snapshot.go`**: `ConsecutiveFailures` counts `"no-marker"` and `"skipped-empty"` alongside `"failed"`
- **`web/`**: new statuses added to type unions, `statusPill`/`StatusBadge`, `ConclusionPanel`, and `IssueList` badge styles; both bucketed under `"failed"` in stat cards and filter

## Testing

- `go test ./internal/operator/... ./internal/snapshot/...` — all pass
- Updated 3 runner tests that expected `err == nil` on no-marker output; they now assert `errors.Is(err, ErrNoOutcomeMarker)`