### PR TITLE
fix: raise issue chat mode picker z-index from z-20 to z-50

### DIFF
--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -480,7 +480,7 @@ function IssueRow({
           </button>
           {showModePicker && (
             <div
-              className="absolute right-0 top-6 z-20 bg-card border border-border rounded-lg shadow-lg py-1 min-w-[160px]"
+              className="absolute right-0 top-6 z-50 bg-card border border-border rounded-lg shadow-lg py-1 min-w-[160px]"
               role="menu"
             >
               <button


### PR DESCRIPTION
Fixes #144\n\nThe Issue mode / Edit mode picker popup in IssueList was using `z-20`, while every other overlay in the dashboard (SyncPopover, repo context menu, ChatDrawer, sticky nav) uses `z-50`. This caused the popup to render beneath adjacent row elements (labels, runs counter, icon buttons).\n\nOne-line change: `z-20` → `z-50` on the mode picker div in `web/src/components/IssueList.tsx:483`.\n\nVerified: `npm run build` passes with no errors.