### PR TITLE
feat(cloud): add cloud config REST endpoints

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -133,6 +133,89 @@ func (c *Client) FinishRun(ctx context.Context, runID string, req FinishRunReque
 	return c.post(ctx, "/api/worker/runs/"+url.PathEscape(runID)+"/finish", req, nil)
 }
 
+// ---- Cloud config client methods ----
+
+// GetCloudConfig returns the aggregated cloud configuration summary.
+func (c *Client) GetCloudConfig(ctx context.Context) (*CloudConfigSummary, error) {
+	var resp CloudConfigSummary
+	if err := c.get(ctx, "/api/cloud/config", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateProject creates a new cloud project.
+func (c *Client) CreateProject(ctx context.Context, req CreateProjectRequest) (*Project, error) {
+	var resp Project
+	if err := c.post(ctx, "/api/cloud/projects", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateRepo registers a new repository in the cloud config.
+func (c *Client) CreateRepo(ctx context.Context, req CreateRepoRequest) (*Repo, error) {
+	var resp Repo
+	if err := c.post(ctx, "/api/cloud/repos", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateRepo applies a partial update to a cloud repository.
+func (c *Client) UpdateRepo(ctx context.Context, id string, req UpdateRepoRequest) (*Repo, error) {
+	var resp Repo
+	if err := c.patch(ctx, "/api/cloud/repos/"+url.PathEscape(id), req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CreateBinding creates a new machine binding.
+func (c *Client) CreateBinding(ctx context.Context, req CreateBindingRequest) (*Binding, error) {
+	var resp Binding
+	if err := c.post(ctx, "/api/cloud/bindings", req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// UpdateBinding applies a partial update to an existing machine binding.
+func (c *Client) UpdateBinding(ctx context.Context, id string, req UpdateBindingRequest) (*Binding, error) {
+	var resp Binding
+	if err := c.patch(ctx, "/api/cloud/bindings/"+url.PathEscape(id), req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ListMachines returns all registered machines.
+func (c *Client) ListMachines(ctx context.Context) (*ListMachinesResponse, error) {
+	var resp ListMachinesResponse
+	if err := c.get(ctx, "/api/cloud/machines", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ListJobs returns current job queue state.
+func (c *Client) ListJobs(ctx context.Context) (*ListJobsResponse, error) {
+	var resp ListJobsResponse
+	if err := c.get(ctx, "/api/cloud/jobs", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// ListRuns returns recent run records.
+func (c *Client) ListRuns(ctx context.Context) (*ListRunsResponse, error) {
+	var resp ListRunsResponse
+	if err := c.get(ctx, "/api/cloud/runs", &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (c *Client) post(ctx context.Context, path string, in any, out any) error {
 	var body bytes.Buffer
 	if in != nil {
@@ -141,6 +224,57 @@ func (c *Client) post(ctx context.Context, path string, in any, out any) error {
 		}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, &body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("cloud API %s: HTTP %d", path, resp.StatusCode)
+	}
+	if out == nil || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("cloud API %s: HTTP %d", path, resp.StatusCode)
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (c *Client) patch(ctx context.Context, path string, in any, out any) error {
+	var body bytes.Buffer
+	if in != nil {
+		if err := json.NewEncoder(&body).Encode(in); err != nil {
+			return err
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.baseURL+path, &body)
 	if err != nil {
 		return err
 	}

--- a/internal/cloud/cloud_config_test.go
+++ b/internal/cloud/cloud_config_test.go
@@ -1,0 +1,578 @@
+package cloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// authReq builds an authenticated HTTP request.
+func authReq(t *testing.T, method, rawURL string, body []byte) *http.Request {
+	t.Helper()
+	var r *http.Request
+	var err error
+	if body != nil {
+		r, err = http.NewRequest(method, rawURL, bytes.NewReader(body))
+	} else {
+		r, err = http.NewRequest(method, rawURL, nil)
+	}
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	if body != nil {
+		r.Header.Set("Content-Type", "application/json")
+	}
+	r.Header.Set("Authorization", "Bearer test-token")
+	return r
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// TestCloudConfigAuthRequired verifies that all cloud config endpoints reject
+// requests without a valid Authorization: Bearer header.
+func TestCloudConfigAuthRequired(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	cases := []struct{ method, path string }{
+		{http.MethodGet, "/api/cloud/config"},
+		{http.MethodPost, "/api/cloud/projects"},
+		{http.MethodPost, "/api/cloud/repos"},
+		{http.MethodPost, "/api/cloud/bindings"},
+		{http.MethodGet, "/api/cloud/machines"},
+		{http.MethodGet, "/api/cloud/jobs"},
+		{http.MethodGet, "/api/cloud/runs"},
+	}
+	for _, c := range cases {
+		req, _ := http.NewRequest(c.method, srv.URL+c.path, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", c.method, c.path, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("%s %s: want 401, got %d", c.method, c.path, resp.StatusCode)
+		}
+	}
+}
+
+// TestCloudConfigGetSummaryEmpty verifies the initial empty summary shape.
+func TestCloudConfigGetSummaryEmpty(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	req := authReq(t, http.MethodGet, srv.URL+"/api/cloud/config", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var summary CloudConfigSummary
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Slices must not be nil so JSON round-trips cleanly.
+	if summary.Projects == nil || summary.Repos == nil || summary.Machines == nil || summary.Bindings == nil {
+		t.Fatalf("nil slices in summary: %+v", summary)
+	}
+	if summary.Counts.Projects != 0 || summary.Counts.Repos != 0 ||
+		summary.Counts.Machines != 0 || summary.Counts.Bindings != 0 {
+		t.Errorf("non-zero initial counts: %+v", summary.Counts)
+	}
+}
+
+// TestCloudConfigCreateProject verifies happy-path project creation.
+func TestCloudConfigCreateProject(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	body := mustMarshal(t, CreateProjectRequest{Name: "my-project", Description: "test desc"})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/projects", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create project: status = %d", resp.StatusCode)
+	}
+	var p Project
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.ID == "" || p.Name != "my-project" || p.Description != "test desc" {
+		t.Errorf("project = %+v", p)
+	}
+	if p.CreatedAt.IsZero() || p.UpdatedAt.IsZero() {
+		t.Errorf("zero timestamps: created=%v updated=%v", p.CreatedAt, p.UpdatedAt)
+	}
+}
+
+// TestCloudConfigCreateProjectMissingName verifies validation failure.
+func TestCloudConfigCreateProjectMissingName(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	body := mustMarshal(t, CreateProjectRequest{})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/projects", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestCloudConfigCreateRepo verifies happy-path repo creation.
+func TestCloudConfigCreateRepo(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	body := mustMarshal(t, CreateRepoRequest{Name: "owner/repo", Platform: "github"})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/repos", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create repo: status = %d", resp.StatusCode)
+	}
+	var r Repo
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if r.ID == "" || r.Name != "owner/repo" || r.Platform != "github" {
+		t.Errorf("repo = %+v", r)
+	}
+}
+
+// TestCloudConfigCreateRepoDefaultsPlatform verifies platform defaults to "github".
+func TestCloudConfigCreateRepoDefaultsPlatform(t *testing.T) {
+	store := NewMemoryStore()
+	repo, err := store.CreateRepo(CreateRepoRequest{Name: "owner/repo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repo.Platform != "github" {
+		t.Errorf("platform = %q, want github", repo.Platform)
+	}
+}
+
+// TestCloudConfigCreateRepoMissingName verifies validation failure.
+func TestCloudConfigCreateRepoMissingName(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	body := mustMarshal(t, CreateRepoRequest{})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/repos", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestCloudConfigCreateRepoUnknownProject verifies that referencing a
+// non-existent project_id returns 400.
+func TestCloudConfigCreateRepoUnknownProject(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	body := mustMarshal(t, CreateRepoRequest{Name: "owner/repo", ProjectID: "nonexistent"})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/repos", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestCloudConfigUpdateRepo verifies PATCH /api/cloud/repos/{id}.
+func TestCloudConfigUpdateRepo(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	repo, err := store.CreateRepo(CreateRepoRequest{Name: "owner/repo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newBranch := "develop"
+	body := mustMarshal(t, UpdateRepoRequest{BaseBranch: &newBranch})
+	req := authReq(t, http.MethodPatch, srv.URL+"/api/cloud/repos/"+repo.ID, body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update repo: status = %d", resp.StatusCode)
+	}
+	var updated Repo
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if updated.BaseBranch != "develop" {
+		t.Errorf("base_branch = %q, want %q", updated.BaseBranch, "develop")
+	}
+}
+
+// TestCloudConfigUpdateRepoNotFound verifies 404 for unknown repo ID.
+func TestCloudConfigUpdateRepoNotFound(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	newBranch := "develop"
+	body := mustMarshal(t, UpdateRepoRequest{BaseBranch: &newBranch})
+	req := authReq(t, http.MethodPatch, srv.URL+"/api/cloud/repos/nonexistent", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestCloudConfigCreateBinding verifies POST /api/cloud/bindings.
+func TestCloudConfigCreateBinding(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	reg, err := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := store.CreateRepo(CreateRepoRequest{Name: "owner/repo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := mustMarshal(t, CreateBindingRequest{MachineID: reg.MachineID, RepoID: repo.ID})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/bindings", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create binding: status = %d", resp.StatusCode)
+	}
+	var b Binding
+	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if b.ID == "" || b.MachineID != reg.MachineID || b.RepoID != repo.ID {
+		t.Errorf("binding = %+v", b)
+	}
+}
+
+// TestCloudConfigCreateBindingMissingMachineID verifies validation failure.
+func TestCloudConfigCreateBindingMissingMachineID(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	body := mustMarshal(t, CreateBindingRequest{RepoID: "some-repo"})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/bindings", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestCloudConfigCreateBindingMissingRepoOrProject verifies that at least one
+// of repo_id or project_id must be supplied.
+func TestCloudConfigCreateBindingMissingRepoOrProject(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	reg, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
+	body := mustMarshal(t, CreateBindingRequest{MachineID: reg.MachineID})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/bindings", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestCloudConfigCreateBindingUnknownMachine verifies that referencing a
+// non-existent machine_id returns 400.
+func TestCloudConfigCreateBindingUnknownMachine(t *testing.T) {
+	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	defer srv.Close()
+
+	body := mustMarshal(t, CreateBindingRequest{MachineID: "nonexistent", RepoID: "some-repo"})
+	req := authReq(t, http.MethodPost, srv.URL+"/api/cloud/bindings", body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+}
+
+// TestCloudConfigUpdateBinding verifies PATCH /api/cloud/bindings/{id}.
+func TestCloudConfigUpdateBinding(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	reg1, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host1"})
+	reg2, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host2"})
+	repo, _ := store.CreateRepo(CreateRepoRequest{Name: "owner/repo"})
+
+	binding, err := store.CreateBinding(CreateBindingRequest{MachineID: reg1.MachineID, RepoID: repo.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := mustMarshal(t, UpdateBindingRequest{MachineID: reg2.MachineID})
+	req := authReq(t, http.MethodPatch, srv.URL+"/api/cloud/bindings/"+binding.ID, body)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update binding: status = %d", resp.StatusCode)
+	}
+	var updated Binding
+	if err := json.NewDecoder(resp.Body).Decode(&updated); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if updated.MachineID != reg2.MachineID {
+		t.Errorf("machine_id = %q, want %q", updated.MachineID, reg2.MachineID)
+	}
+}
+
+// TestCloudConfigListMachines verifies GET /api/cloud/machines.
+func TestCloudConfigListMachines(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	reg, err := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := authReq(t, http.MethodGet, srv.URL+"/api/cloud/machines", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list machines: status = %d", resp.StatusCode)
+	}
+	var list ListMachinesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list.Machines) != 1 || list.Machines[0].ID != reg.MachineID {
+		t.Errorf("machines = %+v, want machine %s", list.Machines, reg.MachineID)
+	}
+}
+
+// TestCloudConfigListJobs verifies GET /api/cloud/jobs.
+func TestCloudConfigListJobs(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	_, err := store.EnqueueJob(JobSpec{
+		Repo:     "o/r",
+		Operator: "evaluate-bug",
+		Target:   "issue",
+		Number:   1,
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := authReq(t, http.MethodGet, srv.URL+"/api/cloud/jobs", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list jobs: status = %d", resp.StatusCode)
+	}
+	var list ListJobsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list.Jobs) != 1 {
+		t.Errorf("jobs count = %d, want 1", len(list.Jobs))
+	}
+}
+
+// TestCloudConfigListRuns verifies GET /api/cloud/runs.
+func TestCloudConfigListRuns(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	reg, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
+	_, _ = store.EnqueueJob(JobSpec{
+		Repo:     "o/r",
+		Operator: "evaluate-bug",
+		Target:   "issue",
+		Number:   1,
+	}, "")
+	_, _ = store.Lease(LeaseRequest{MachineID: reg.MachineID, WorkerID: reg.WorkerID}, DefaultLeaseDuration)
+
+	req := authReq(t, http.MethodGet, srv.URL+"/api/cloud/runs", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list runs: status = %d", resp.StatusCode)
+	}
+	var list ListRunsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list.Runs) != 1 {
+		t.Errorf("runs count = %d, want 1", len(list.Runs))
+	}
+}
+
+// TestCloudConfigSummaryReflectsCreates verifies GET /api/cloud/config counts
+// update as resources are created.
+func TestCloudConfigSummaryReflectsCreates(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	store.CreateProject(CreateProjectRequest{Name: "p1"})  //nolint:errcheck
+	store.CreateRepo(CreateRepoRequest{Name: "owner/repo"}) //nolint:errcheck
+
+	req := authReq(t, http.MethodGet, srv.URL+"/api/cloud/config", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var summary CloudConfigSummary
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if summary.Counts.Projects != 1 || summary.Counts.Repos != 1 {
+		t.Errorf("counts = %+v, want projects=1 repos=1", summary.Counts)
+	}
+	if len(summary.Projects) != 1 || summary.Projects[0].Name != "p1" {
+		t.Errorf("projects slice = %+v", summary.Projects)
+	}
+}
+
+// TestCloudConfigClientRoundTrip verifies that the typed Client can talk to
+// the server and decode the JSON shapes correctly.
+func TestCloudConfigClientRoundTrip(t *testing.T) {
+	store := NewMemoryStore()
+	srv := httptest.NewServer(NewServer(store))
+	defer srv.Close()
+
+	client, err := NewClient(Config{BaseURL: srv.URL, AccessToken: "test-token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create project via client.
+	proj, err := client.CreateProject(t.Context(), CreateProjectRequest{Name: "rt-project"})
+	if err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if proj.ID == "" || proj.Name != "rt-project" {
+		t.Errorf("project = %+v", proj)
+	}
+
+	// Create repo via client.
+	repo, err := client.CreateRepo(t.Context(), CreateRepoRequest{Name: "owner/rt-repo", ProjectID: proj.ID})
+	if err != nil {
+		t.Fatalf("CreateRepo: %v", err)
+	}
+	if repo.ProjectID != proj.ID {
+		t.Errorf("repo.project_id = %q, want %q", repo.ProjectID, proj.ID)
+	}
+
+	// Update repo via client.
+	branch := "main"
+	updated, err := client.UpdateRepo(t.Context(), repo.ID, UpdateRepoRequest{BaseBranch: &branch})
+	if err != nil {
+		t.Fatalf("UpdateRepo: %v", err)
+	}
+	if updated.BaseBranch != "main" {
+		t.Errorf("base_branch = %q, want main", updated.BaseBranch)
+	}
+
+	// Register machine directly and bind via client.
+	reg, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "rt-host"})
+	binding, err := client.CreateBinding(t.Context(), CreateBindingRequest{
+		MachineID: reg.MachineID,
+		RepoID:    repo.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateBinding: %v", err)
+	}
+	if binding.RepoID != repo.ID {
+		t.Errorf("binding.repo_id = %q, want %q", binding.RepoID, repo.ID)
+	}
+
+	// Verify summary counts.
+	summary, err := client.GetCloudConfig(t.Context())
+	if err != nil {
+		t.Fatalf("GetCloudConfig: %v", err)
+	}
+	if summary.Counts.Projects != 1 || summary.Counts.Repos != 1 ||
+		summary.Counts.Machines != 1 || summary.Counts.Bindings != 1 {
+		t.Errorf("summary counts = %+v", summary.Counts)
+	}
+
+	// List machines via client.
+	machines, err := client.ListMachines(t.Context())
+	if err != nil {
+		t.Fatalf("ListMachines: %v", err)
+	}
+	if len(machines.Machines) != 1 {
+		t.Errorf("machines count = %d, want 1", len(machines.Machines))
+	}
+}

--- a/internal/cloud/server.go
+++ b/internal/cloud/server.go
@@ -10,17 +10,36 @@ import (
 // NewServer returns an HTTP handler for the worker protocol. The handler is a
 // dev/reference server around MemoryStore; production can keep these routes and
 // replace the store implementation.
+//
+// Worker routes (/api/worker/*, /api/cloud/dev/jobs) are unauthenticated for
+// backward compatibility. Cloud config routes (/api/cloud/config, /api/cloud/repos,
+// etc.) require a non-empty Authorization: Bearer <token> header.
+// TODO(rbac): validate tokens against workspace credentials in a follow-up issue.
 func NewServer(store *MemoryStore) http.Handler {
 	if store == nil {
 		store = NewMemoryStore()
 	}
 	s := &server{store: store}
 	mux := http.NewServeMux()
+
+	// Worker protocol — no auth (backward compatible).
 	mux.HandleFunc("/api/worker/register", s.handleRegister)
 	mux.HandleFunc("/api/worker/heartbeat", s.handleHeartbeat)
 	mux.HandleFunc("/api/worker/lease", s.handleLease)
 	mux.HandleFunc("/api/worker/runs/", s.handleRun)
 	mux.HandleFunc("/api/cloud/dev/jobs", s.handleDevJobs)
+
+	// Cloud config — bearer auth required.
+	mux.HandleFunc("/api/cloud/config", s.withAuth(s.handleCloudConfig))
+	mux.HandleFunc("/api/cloud/projects", s.withAuth(s.handleCloudProjects))
+	mux.HandleFunc("/api/cloud/repos", s.withAuth(s.handleCloudRepos))
+	mux.HandleFunc("/api/cloud/repos/", s.withAuth(s.handleCloudRepoByID))
+	mux.HandleFunc("/api/cloud/bindings", s.withAuth(s.handleCloudBindings))
+	mux.HandleFunc("/api/cloud/bindings/", s.withAuth(s.handleCloudBindingByID))
+	mux.HandleFunc("/api/cloud/machines", s.withAuth(s.handleCloudMachines))
+	mux.HandleFunc("/api/cloud/jobs", s.withAuth(s.handleCloudJobs))
+	mux.HandleFunc("/api/cloud/runs", s.withAuth(s.handleCloudRuns))
+
 	return mux
 }
 
@@ -160,4 +179,173 @@ func writeCloudError(w http.ResponseWriter, status int, msg string) {
 		"error": msg,
 		"time":  time.Now().UTC().Format(time.RFC3339),
 	})
+}
+
+// ---- Cloud config auth middleware ----
+
+// withAuth wraps a handler to require a non-empty Authorization: Bearer <token>
+// header. It accepts any non-empty token for now.
+// TODO(rbac): validate token against registered workers or user credentials.
+func (s *server) withAuth(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		const prefix = "Bearer "
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, prefix) || strings.TrimSpace(strings.TrimPrefix(auth, prefix)) == "" {
+			writeCloudError(w, http.StatusUnauthorized, "missing or invalid bearer token")
+			return
+		}
+		h(w, r)
+	}
+}
+
+// ---- Cloud config handlers ----
+
+// handleCloudConfig returns an aggregated summary of all cloud config resources.
+// GET /api/cloud/config
+func (s *server) handleCloudConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeCloudJSON(w, http.StatusOK, s.store.Summary())
+}
+
+// handleCloudProjects handles project creation.
+// POST /api/cloud/projects
+func (s *server) handleCloudProjects(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req CreateProjectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeCloudError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	p, err := s.store.CreateProject(req)
+	if err != nil {
+		writeCloudError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeCloudJSON(w, http.StatusCreated, p)
+}
+
+// handleCloudRepos handles repo creation.
+// POST /api/cloud/repos
+func (s *server) handleCloudRepos(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req CreateRepoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeCloudError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	repo, err := s.store.CreateRepo(req)
+	if err != nil {
+		writeCloudError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeCloudJSON(w, http.StatusCreated, repo)
+}
+
+// handleCloudRepoByID handles partial updates to a repo.
+// PATCH /api/cloud/repos/{id}
+func (s *server) handleCloudRepoByID(w http.ResponseWriter, r *http.Request) {
+	id := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/cloud/repos/"), "/")
+	if id == "" {
+		writeCloudError(w, http.StatusNotFound, "repo id required")
+		return
+	}
+	if r.Method != http.MethodPatch {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req UpdateRepoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeCloudError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	repo, err := s.store.UpdateRepo(id, req)
+	if err != nil {
+		writeCloudError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeCloudJSON(w, http.StatusOK, repo)
+}
+
+// handleCloudBindings handles binding creation.
+// POST /api/cloud/bindings
+func (s *server) handleCloudBindings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req CreateBindingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeCloudError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	b, err := s.store.CreateBinding(req)
+	if err != nil {
+		writeCloudError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeCloudJSON(w, http.StatusCreated, b)
+}
+
+// handleCloudBindingByID handles partial updates to a binding.
+// PATCH /api/cloud/bindings/{id}
+func (s *server) handleCloudBindingByID(w http.ResponseWriter, r *http.Request) {
+	id := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/cloud/bindings/"), "/")
+	if id == "" {
+		writeCloudError(w, http.StatusNotFound, "binding id required")
+		return
+	}
+	if r.Method != http.MethodPatch {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req UpdateBindingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeCloudError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	b, err := s.store.UpdateBinding(id, req)
+	if err != nil {
+		writeCloudError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeCloudJSON(w, http.StatusOK, b)
+}
+
+// handleCloudMachines returns all registered machines.
+// GET /api/cloud/machines
+func (s *server) handleCloudMachines(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeCloudJSON(w, http.StatusOK, ListMachinesResponse{Machines: s.store.ListMachines()})
+}
+
+// handleCloudJobs returns all job records.
+// GET /api/cloud/jobs
+func (s *server) handleCloudJobs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeCloudJSON(w, http.StatusOK, ListJobsResponse{Jobs: s.store.ListJobs()})
+}
+
+// handleCloudRuns returns all run records.
+// GET /api/cloud/runs
+func (s *server) handleCloudRuns(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeCloudJSON(w, http.StatusOK, ListRunsResponse{Runs: s.store.ListRuns()})
 }

--- a/internal/cloud/store.go
+++ b/internal/cloud/store.go
@@ -80,6 +80,11 @@ type MemoryStore struct {
 	Jobs     map[string]*JobRecord
 	Runs     map[string]*RunRecord
 
+	// Cloud config resources.
+	Projects map[string]*Project
+	Repos    map[string]*Repo
+	Bindings map[string]*Binding
+
 	dedupe map[string]string
 }
 
@@ -89,6 +94,9 @@ func NewMemoryStore() *MemoryStore {
 		Workers:  make(map[string]*Worker),
 		Jobs:     make(map[string]*JobRecord),
 		Runs:     make(map[string]*RunRecord),
+		Projects: make(map[string]*Project),
+		Repos:    make(map[string]*Repo),
+		Bindings: make(map[string]*Binding),
 		dedupe:   make(map[string]string),
 	}
 }
@@ -297,6 +305,267 @@ func cloneJob(job *JobRecord) *JobRecord {
 		}
 	}
 	return &cp
+}
+
+// ---- Cloud config store methods ----
+
+// CreateProject creates a new cloud project. Name is required.
+func (s *MemoryStore) CreateProject(req CreateProjectRequest) (*Project, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := &Project{
+		ID:          newID("proj"),
+		Name:        req.Name,
+		Description: req.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	s.Projects[p.ID] = p
+	cp := *p
+	return &cp, nil
+}
+
+// GetProject returns a copy of the project with the given ID, or nil.
+func (s *MemoryStore) GetProject(id string) *Project {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.Projects[id]
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	return &cp
+}
+
+// CreateRepo registers a new repository. Name is required.
+// If project_id is supplied it must reference an existing project.
+func (s *MemoryStore) CreateRepo(req CreateRepoRequest) (*Repo, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if req.ProjectID != "" {
+		if _, ok := s.Projects[req.ProjectID]; !ok {
+			return nil, fmt.Errorf("project %q not found", req.ProjectID)
+		}
+	}
+	platform := req.Platform
+	if platform == "" {
+		platform = "github"
+	}
+	r := &Repo{
+		ID:         newID("repo"),
+		Name:       req.Name,
+		Platform:   platform,
+		ProjectID:  req.ProjectID,
+		BaseBranch: req.BaseBranch,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	s.Repos[r.ID] = r
+	cp := *r
+	return &cp, nil
+}
+
+// GetRepo returns a copy of the repo with the given ID, or nil.
+func (s *MemoryStore) GetRepo(id string) *Repo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r := s.Repos[id]
+	if r == nil {
+		return nil
+	}
+	cp := *r
+	return &cp
+}
+
+// UpdateRepo applies a partial update to the named repo.
+// Only non-nil fields are modified. Setting project_id to "" unlinks the repo.
+func (s *MemoryStore) UpdateRepo(id string, req UpdateRepoRequest) (*Repo, error) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.Repos[id]
+	if !ok {
+		return nil, fmt.Errorf("repo %q not found", id)
+	}
+	if req.ProjectID != nil {
+		if *req.ProjectID != "" {
+			if _, ok := s.Projects[*req.ProjectID]; !ok {
+				return nil, fmt.Errorf("project %q not found", *req.ProjectID)
+			}
+		}
+		r.ProjectID = *req.ProjectID
+	}
+	if req.BaseBranch != nil {
+		r.BaseBranch = *req.BaseBranch
+	}
+	r.UpdatedAt = now
+	cp := *r
+	return &cp, nil
+}
+
+// CreateBinding creates a binding that assigns a repo or project to a machine.
+// machine_id is required; exactly one of repo_id or project_id must be set.
+// All referenced IDs must exist.
+func (s *MemoryStore) CreateBinding(req CreateBindingRequest) (*Binding, error) {
+	if req.MachineID == "" {
+		return nil, fmt.Errorf("machine_id is required")
+	}
+	if req.RepoID == "" && req.ProjectID == "" {
+		return nil, fmt.Errorf("one of repo_id or project_id is required")
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.Machines[req.MachineID]; !ok {
+		return nil, fmt.Errorf("machine %q not found", req.MachineID)
+	}
+	if req.RepoID != "" {
+		if _, ok := s.Repos[req.RepoID]; !ok {
+			return nil, fmt.Errorf("repo %q not found", req.RepoID)
+		}
+	}
+	if req.ProjectID != "" {
+		if _, ok := s.Projects[req.ProjectID]; !ok {
+			return nil, fmt.Errorf("project %q not found", req.ProjectID)
+		}
+	}
+	b := &Binding{
+		ID:        newID("binding"),
+		MachineID: req.MachineID,
+		RepoID:    req.RepoID,
+		ProjectID: req.ProjectID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	s.Bindings[b.ID] = b
+	cp := *b
+	return &cp, nil
+}
+
+// GetBinding returns a copy of the binding with the given ID, or nil.
+func (s *MemoryStore) GetBinding(id string) *Binding {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b := s.Bindings[id]
+	if b == nil {
+		return nil
+	}
+	cp := *b
+	return &cp
+}
+
+// UpdateBinding applies a partial update to the named binding.
+// Non-empty fields are validated and applied.
+func (s *MemoryStore) UpdateBinding(id string, req UpdateBindingRequest) (*Binding, error) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.Bindings[id]
+	if !ok {
+		return nil, fmt.Errorf("binding %q not found", id)
+	}
+	if req.MachineID != "" {
+		if _, ok := s.Machines[req.MachineID]; !ok {
+			return nil, fmt.Errorf("machine %q not found", req.MachineID)
+		}
+		b.MachineID = req.MachineID
+	}
+	if req.RepoID != "" {
+		if _, ok := s.Repos[req.RepoID]; !ok {
+			return nil, fmt.Errorf("repo %q not found", req.RepoID)
+		}
+		b.RepoID = req.RepoID
+	}
+	if req.ProjectID != "" {
+		if _, ok := s.Projects[req.ProjectID]; !ok {
+			return nil, fmt.Errorf("project %q not found", req.ProjectID)
+		}
+		b.ProjectID = req.ProjectID
+	}
+	b.UpdatedAt = now
+	cp := *b
+	return &cp, nil
+}
+
+// ListMachines returns copies of all registered machines.
+func (s *MemoryStore) ListMachines() []*Machine {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*Machine, 0, len(s.Machines))
+	for _, m := range s.Machines {
+		cp := *m
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// ListJobs returns copies of all job records.
+func (s *MemoryStore) ListJobs() []*JobRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*JobRecord, 0, len(s.Jobs))
+	for _, j := range s.Jobs {
+		out = append(out, cloneJob(j))
+	}
+	return out
+}
+
+// ListRuns returns copies of all run records.
+func (s *MemoryStore) ListRuns() []*RunRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*RunRecord, 0, len(s.Runs))
+	for _, r := range s.Runs {
+		cp := *r
+		cp.Events = append([]RunEvent(nil), r.Events...)
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// Summary returns an aggregated snapshot of all cloud config resources.
+func (s *MemoryStore) Summary() CloudConfigSummary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sum := CloudConfigSummary{
+		Projects: make([]*Project, 0, len(s.Projects)),
+		Repos:    make([]*Repo, 0, len(s.Repos)),
+		Machines: make([]*Machine, 0, len(s.Machines)),
+		Bindings: make([]*Binding, 0, len(s.Bindings)),
+	}
+	for _, p := range s.Projects {
+		cp := *p
+		sum.Projects = append(sum.Projects, &cp)
+	}
+	for _, r := range s.Repos {
+		cp := *r
+		sum.Repos = append(sum.Repos, &cp)
+	}
+	for _, m := range s.Machines {
+		cp := *m
+		sum.Machines = append(sum.Machines, &cp)
+	}
+	for _, b := range s.Bindings {
+		cp := *b
+		sum.Bindings = append(sum.Bindings, &cp)
+	}
+	sum.Counts = ConfigCounts{
+		Projects: len(s.Projects),
+		Repos:    len(s.Repos),
+		Machines: len(s.Machines),
+		Bindings: len(s.Bindings),
+		Jobs:     len(s.Jobs),
+		Runs:     len(s.Runs),
+	}
+	return sum
 }
 
 func newID(prefix string) string {

--- a/internal/cloud/types.go
+++ b/internal/cloud/types.go
@@ -6,6 +6,116 @@ import "time"
 // "github", "gitlab", or "codex".
 type Capability string
 
+// ---- Cloud config domain types ----
+
+// Project is a top-level configuration unit that groups repos and automation
+// settings. A repo may belong to at most one project; project_id is optional.
+type Project struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// Repo is a repository registered with the cloud config. It may optionally
+// belong to a Project (project_id). Deleting a project does not cascade in
+// this iteration — repos become orphans with project_id still set.
+type Repo struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`            // "owner/repo" slug
+	Platform   string    `json:"platform"`         // "github" | "gitlab"
+	ProjectID  string    `json:"project_id,omitempty"`
+	BaseBranch string    `json:"base_branch,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// Binding links a repo or project to a specific registered machine. The
+// binding is keyed by an opaque ID; update semantics are PATCH /bindings/{id}.
+type Binding struct {
+	ID        string    `json:"id"`
+	MachineID string    `json:"machine_id"`
+	RepoID    string    `json:"repo_id,omitempty"`
+	ProjectID string    `json:"project_id,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ---- Cloud config request/response DTOs ----
+
+// CreateProjectRequest is the body for POST /api/cloud/projects.
+type CreateProjectRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// CreateRepoRequest is the body for POST /api/cloud/repos.
+type CreateRepoRequest struct {
+	Name       string `json:"name"`
+	Platform   string `json:"platform,omitempty"`
+	ProjectID  string `json:"project_id,omitempty"`
+	BaseBranch string `json:"base_branch,omitempty"`
+}
+
+// UpdateRepoRequest is the body for PATCH /api/cloud/repos/{id}.
+// Pointer fields are omitted when nil, allowing partial updates.
+// Setting project_id to "" unlinks the repo from its project.
+type UpdateRepoRequest struct {
+	ProjectID  *string `json:"project_id,omitempty"`
+	BaseBranch *string `json:"base_branch,omitempty"`
+}
+
+// CreateBindingRequest is the body for POST /api/cloud/bindings.
+// Exactly one of repo_id or project_id must be supplied.
+type CreateBindingRequest struct {
+	MachineID string `json:"machine_id"`
+	RepoID    string `json:"repo_id,omitempty"`
+	ProjectID string `json:"project_id,omitempty"`
+}
+
+// UpdateBindingRequest is the body for PATCH /api/cloud/bindings/{id}.
+// Only non-empty fields are applied.
+type UpdateBindingRequest struct {
+	MachineID string `json:"machine_id,omitempty"`
+	RepoID    string `json:"repo_id,omitempty"`
+	ProjectID string `json:"project_id,omitempty"`
+}
+
+// ListMachinesResponse is the response for GET /api/cloud/machines.
+type ListMachinesResponse struct {
+	Machines []*Machine `json:"machines"`
+}
+
+// ListJobsResponse is the response for GET /api/cloud/jobs.
+type ListJobsResponse struct {
+	Jobs []*JobRecord `json:"jobs"`
+}
+
+// ListRunsResponse is the response for GET /api/cloud/runs.
+type ListRunsResponse struct {
+	Runs []*RunRecord `json:"runs"`
+}
+
+// ConfigCounts holds aggregate counts for all cloud resources.
+type ConfigCounts struct {
+	Projects int `json:"projects"`
+	Repos    int `json:"repos"`
+	Machines int `json:"machines"`
+	Bindings int `json:"bindings"`
+	Jobs     int `json:"jobs"`
+	Runs     int `json:"runs"`
+}
+
+// CloudConfigSummary is the response for GET /api/cloud/config.
+type CloudConfigSummary struct {
+	Projects []*Project  `json:"projects"`
+	Repos    []*Repo     `json:"repos"`
+	Machines []*Machine  `json:"machines"`
+	Bindings []*Binding  `json:"bindings"`
+	Counts   ConfigCounts `json:"counts"`
+}
+
 type RegisterWorkerRequest struct {
 	Hostname     string       `json:"hostname"`
 	DisplayName  string       `json:"display_name,omitempty"`


### PR DESCRIPTION
Fixes #153

## What changed

Adds the first cloud config CRUD surface on top of the `codex/saas-worker-foundation` (`MemoryStore` + server) introduced in #151.

### New endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/cloud/config` | Aggregated summary (projects, repos, machines, bindings, counts) |
| `POST` | `/api/cloud/projects` | Create a project |
| `POST` | `/api/cloud/repos` | Register a repo (defaults platform to `github`) |
| `PATCH` | `/api/cloud/repos/{id}` | Update `project_id` / `base_branch` |
| `POST` | `/api/cloud/bindings` | Bind a repo or project to a machine |
| `PATCH` | `/api/cloud/bindings/{id}` | Reassign machine / swap target |
| `GET` | `/api/cloud/machines` | List registered machines |
| `GET` | `/api/cloud/jobs` | List job queue state |
| `GET` | `/api/cloud/runs` | List run records |

All cloud config routes require `Authorization: Bearer <token>` (any non-empty token accepted; `TODO(rbac)` comment marks the follow-up). Existing `/api/worker/*` and `/api/cloud/dev/jobs` routes are unchanged.

### Files changed

- `internal/cloud/types.go` — `Project`, `Repo`, `Binding` domain types + all request/response DTOs + `CloudConfigSummary`
- `internal/cloud/store.go` — `MemoryStore` extended with `Projects`/`Repos`/`Bindings` maps; `CreateProject`, `CreateRepo`, `UpdateRepo`, `CreateBinding`, `UpdateBinding`, `ListMachines`, `ListJobs`, `ListRuns`, `Summary` methods
- `internal/cloud/server.go` — `withAuth` middleware + 9 new handlers; `NewServer` mux updated
- `internal/cloud/client.go` — `GetCloudConfig`, `CreateProject`, `CreateRepo`, `UpdateRepo`, `CreateBinding`, `UpdateBinding`, `ListMachines`, `ListJobs`, `ListRuns`; `get`/`patch` transport helpers
- `internal/cloud/cloud_config_test.go` — 23 new tests: happy-path CRUD, JSON shape, validation failures (missing name, unknown IDs), auth failure, client round-trip

### Design decisions

- **`project_id` is optional** for repos; deleting a project does not cascade (orphan repos keep their `project_id`).
- **Binding POST requires machine_id + at least one of repo_id/project_id**; all referenced IDs must exist.
- **`UpdateRepoRequest` uses pointer fields** so `project_id: ""` explicitly unlinks a repo from its project.
- **Auth is any-bearer-for-now** with a `TODO(rbac)` comment; worker tokens already in use serve as access tokens until #RBAC follow-up.

### Test results

```
ok  github.com/zhoushoujianwork/clawflow/internal/cloud   1.575s
```
(29 tests pass — 23 new + 6 pre-existing; `web/dist` embed error is pre-existing on this branch and unrelated.)