### PR TITLE
fix(run): support per-issue base branch override via ClawFlow-Base-Branch marker

### DIFF
--- a/cmd/clawflow/commands/basebranch.go
+++ b/cmd/clawflow/commands/basebranch.go
@@ -1,0 +1,103 @@
+package commands
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/vcs"
+)
+
+// baseBranchMarkerRe matches a ClawFlow-Base-Branch: <value> line anywhere in text.
+// The value is captured as the first submatch group.
+var baseBranchMarkerRe = regexp.MustCompile(`(?m)^ClawFlow-Base-Branch:\s*(\S+)\s*$`)
+
+// validBranchNameRe restricts allowed characters to a conservative safe set.
+var validBranchNameRe = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// ParseBaseBranchOverride scans the issue body and comments for a
+//
+//	ClawFlow-Base-Branch: <branch>
+//
+// marker. Resolution order:
+//  1. Comments are sorted newest-first by CreatedAt (ISO 8601 lexicographic).
+//     The first (newest) comment containing the marker wins.
+//  2. If no comment contains the marker, the issue body is checked.
+//
+// Returns:
+//   - branch: the trimmed branch name (non-empty only when ok == true)
+//   - source: human-readable description of where the marker was found
+//   - ok: true if any marker was found (valid or invalid)
+//   - err: non-nil if a marker was found but the branch name fails validation
+//
+// When ok == false and err == nil, no marker was found; the caller should use
+// the repo-default base branch without modification.
+func ParseBaseBranchOverride(body string, comments []vcs.IssueComment) (branch, source string, ok bool, err error) {
+	// Sort comments newest-first so we pick the latest marker.
+	sorted := make([]vcs.IssueComment, len(comments))
+	copy(sorted, comments)
+	sort.Slice(sorted, func(i, j int) bool {
+		// ISO 8601 strings compare lexicographically correctly.
+		return sorted[i].CreatedAt > sorted[j].CreatedAt
+	})
+
+	for _, c := range sorted {
+		if val, found := extractBaseBranchMarker(c.Body); found {
+			src := fmt.Sprintf("comment by %s", c.Author)
+			if c.Author == "" {
+				src = "comment"
+			}
+			if valErr := validateBranchName(val); valErr != nil {
+				return "", src, true, fmt.Errorf("invalid ClawFlow-Base-Branch marker in %s: %w", src, valErr)
+			}
+			return val, src, true, nil
+		}
+	}
+
+	if val, found := extractBaseBranchMarker(body); found {
+		if valErr := validateBranchName(val); valErr != nil {
+			return "", "issue body", true, fmt.Errorf("invalid ClawFlow-Base-Branch marker in issue body: %w", valErr)
+		}
+		return val, "issue body", true, nil
+	}
+
+	return "", "", false, nil
+}
+
+// extractBaseBranchMarker returns the branch value from the first matching
+// ClawFlow-Base-Branch: <value> line in text, or ("", false) if none found.
+func extractBaseBranchMarker(text string) (string, bool) {
+	m := baseBranchMarkerRe.FindStringSubmatch(text)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+// validateBranchName checks that branch is a safe, non-empty git branch name
+// free of shell-injection and path-traversal sequences.
+func validateBranchName(branch string) error {
+	if branch == "" {
+		return fmt.Errorf("branch name must not be empty")
+	}
+	if len(branch) > 250 {
+		return fmt.Errorf("branch name too long (%d chars, max 250)", len(branch))
+	}
+	if !validBranchNameRe.MatchString(branch) {
+		return fmt.Errorf("branch name %q contains invalid characters (allowed: A-Za-z0-9._/-)", branch)
+	}
+	if strings.HasPrefix(branch, "-") {
+		return fmt.Errorf("branch name %q must not start with '-' (would be interpreted as a git flag)", branch)
+	}
+	if strings.HasPrefix(branch, "/") {
+		return fmt.Errorf("branch name %q must not start with '/'", branch)
+	}
+	if strings.HasPrefix(branch, ".") {
+		return fmt.Errorf("branch name %q must not start with '.'", branch)
+	}
+	if strings.Contains(branch, "..") {
+		return fmt.Errorf("branch name %q must not contain '..' (path traversal)", branch)
+	}
+	return nil
+}

--- a/cmd/clawflow/commands/basebranch_test.go
+++ b/cmd/clawflow/commands/basebranch_test.go
@@ -1,0 +1,220 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/vcs"
+)
+
+func TestParseBaseBranchOverride(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		comments    []vcs.IssueComment
+		wantBranch  string
+		wantSource  string
+		wantOK      bool
+		wantErrFrag string // non-empty → expect an error containing this string
+	}{
+		{
+			name:       "no marker anywhere",
+			body:       "This is a plain issue body with no marker.",
+			comments:   nil,
+			wantBranch: "",
+			wantOK:     false,
+		},
+		{
+			name:       "body-only marker",
+			body:       "Please implement on the feature branch.\n\nClawFlow-Base-Branch: feat/new-api",
+			comments:   nil,
+			wantBranch: "feat/new-api",
+			wantSource: "issue body",
+			wantOK:     true,
+		},
+		{
+			name: "comment marker wins over body marker",
+			body: "ClawFlow-Base-Branch: main",
+			comments: []vcs.IssueComment{
+				{Author: "alice", Body: "Let's use this branch.\nClawFlow-Base-Branch: feat/override", CreatedAt: "2024-01-02T10:00:00Z"},
+			},
+			wantBranch: "feat/override",
+			wantSource: "comment by alice",
+			wantOK:     true,
+		},
+		{
+			name: "latest comment marker wins (multiple comments with markers)",
+			body: "ClawFlow-Base-Branch: old-branch",
+			comments: []vcs.IssueComment{
+				{Author: "bob", Body: "ClawFlow-Base-Branch: second-branch", CreatedAt: "2024-01-02T09:00:00Z"},
+				{Author: "carol", Body: "ClawFlow-Base-Branch: latest-branch", CreatedAt: "2024-01-03T12:00:00Z"},
+				{Author: "dave", Body: "no marker here", CreatedAt: "2024-01-04T15:00:00Z"},
+			},
+			wantBranch: "latest-branch",
+			wantSource: "comment by carol",
+			wantOK:     true,
+		},
+		{
+			name: "only non-marker comments — falls back to body",
+			body: "ClawFlow-Base-Branch: codex/saas-worker-foundation",
+			comments: []vcs.IssueComment{
+				{Author: "alice", Body: "looks good", CreatedAt: "2024-01-02T10:00:00Z"},
+			},
+			wantBranch: "codex/saas-worker-foundation",
+			wantSource: "issue body",
+			wantOK:     true,
+		},
+		{
+			name:        "invalid marker in body — empty value",
+			body:        "ClawFlow-Base-Branch: ",
+			comments:    nil,
+			wantOK:      false, // regex won't match (requires \S+)
+			wantErrFrag: "",    // no error either — regex filters it
+		},
+		{
+			name:        "invalid marker — leading dash",
+			body:        "ClawFlow-Base-Branch: -foo",
+			comments:    nil,
+			wantOK:      true,
+			wantErrFrag: "must not start with '-'",
+		},
+		{
+			name:    "invalid marker — path traversal",
+			body:    "ClawFlow-Base-Branch: ../etc/passwd",
+			comments: nil,
+			// "../etc/passwd" starts with "." so the leading-dot check fires
+			// before the ".." check. Both are valid rejections.
+			wantOK:      true,
+			wantErrFrag: "must not start with '.'",
+		},
+		{
+			name:    "invalid marker — shell injection semicolon (no spaces)",
+			body:    "ClawFlow-Base-Branch: foo;bar",
+			comments: nil,
+			// "foo;bar" is captured as a single \S+ token; semicolon is not
+			// in the allowed character set so validation rejects it.
+			wantOK:      true,
+			wantErrFrag: "invalid characters",
+		},
+		{
+			name:    "shell injection with spaces — no marker match",
+			body:    "ClawFlow-Base-Branch: foo;rm -rf /",
+			comments: nil,
+			// The regex requires \S+\s*$ so trailing " -rf /" prevents a match.
+			// No marker is found — ok == false, no error.
+			wantOK:      false,
+			wantErrFrag: "",
+		},
+		{
+			name:        "invalid marker — leading slash",
+			body:        "ClawFlow-Base-Branch: /absolute/path",
+			comments:    nil,
+			wantOK:      true,
+			wantErrFrag: "must not start with '/'",
+		},
+		{
+			name:        "invalid marker — leading dot",
+			body:        "ClawFlow-Base-Branch: .hidden",
+			comments:    nil,
+			wantOK:      true,
+			wantErrFrag: "must not start with '.'",
+		},
+		{
+			name: "invalid marker in comment overrides valid body",
+			body: "ClawFlow-Base-Branch: valid-branch",
+			comments: []vcs.IssueComment{
+				{Author: "alice", Body: "ClawFlow-Base-Branch: -bad-branch", CreatedAt: "2024-01-02T10:00:00Z"},
+			},
+			wantOK:      true,
+			wantErrFrag: "must not start with '-'",
+		},
+		{
+			name:       "valid branch with dots and underscores via slash",
+			body:       "ClawFlow-Base-Branch: release/v1.2.3",
+			comments:   nil,
+			wantBranch: "release/v1.2.3",
+			wantSource: "issue body",
+			wantOK:     true,
+		},
+		{
+			name:       "valid branch — simple name no slash",
+			body:       "ClawFlow-Base-Branch: main",
+			comments:   nil,
+			wantBranch: "main",
+			wantSource: "issue body",
+			wantOK:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			branch, source, ok, err := ParseBaseBranchOverride(tc.body, tc.comments)
+
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+
+			if tc.wantErrFrag != "" {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tc.wantErrFrag)
+				} else if !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrFrag)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if tc.wantErrFrag == "" && ok {
+				if branch != tc.wantBranch {
+					t.Errorf("branch = %q, want %q", branch, tc.wantBranch)
+				}
+				if source != tc.wantSource {
+					t.Errorf("source = %q, want %q", source, tc.wantSource)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateBranchName(t *testing.T) {
+	valid := []string{
+		"main",
+		"feat/new-api",
+		"fix/issue-123",
+		"codex/saas-worker-foundation",
+		"release/v1.2.3",
+		"v0.1.0",
+		"my_branch",
+	}
+	for _, b := range valid {
+		if err := validateBranchName(b); err != nil {
+			t.Errorf("validateBranchName(%q) unexpected error: %v", b, err)
+		}
+	}
+
+	invalid := []struct {
+		name string
+		frag string
+	}{
+		{"", "empty"},
+		{"-foo", "'-'"},
+		{"/absolute", "'/'"},
+		{".hidden", "'.'"},
+		{"foo/../bar", "'..'"},
+		{"foo;bar", "invalid characters"},
+		{"foo bar", "invalid characters"},
+		{"foo\x00bar", "invalid characters"},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid:"+tc.name, func(t *testing.T) {
+			err := validateBranchName(tc.name)
+			if err == nil {
+				t.Errorf("validateBranchName(%q) expected error, got nil", tc.name)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.frag) {
+				t.Errorf("validateBranchName(%q) error %q does not contain %q", tc.name, err.Error(), tc.frag)
+			}
+		})
+	}
+}

--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -709,7 +709,33 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		fmt.Fprintf(os.Stderr, "%s ⚠ snapshot runs index (running): %v\n", prefix, err)
 	}
 
-	wtResult, cleanup, err := resolveWorkdir(j.op, j.repoCfg, j.repo, j.sub.Number, startedAt)
+	// Fetch comments before resolveWorkdir so we can parse the
+	// ClawFlow-Base-Branch: marker and plumb the override into worktree
+	// setup. Using ListIssueCommentsDetail gives us CreatedAt for correct
+	// newest-first ordering and avoids a second round-trip at line 736.
+	detailComments, _ := j.client.ListIssueCommentsDetail(j.repo, j.sub.Number)
+
+	// Parse optional per-issue base-branch override.
+	overrideBranch, overrideSource, hasOverride, overrideErr := ParseBaseBranchOverride(j.sub.Body, detailComments)
+	if overrideErr != nil {
+		// Hard-fail: the marker exists but is invalid. Surface the error
+		// the same way as workdir failures (meta.json + circuit breaker)
+		// so the dashboard and PM patrol can see it without posting a
+		// VCS comment (operator contract: runner owns VCS side-effects).
+		fmt.Fprintf(os.Stderr, "%s ✗ base-branch marker invalid: %v\n", prefix, overrideErr)
+		runningMeta.Status = "failed"
+		runningMeta.Error = overrideErr.Error()
+		now := time.Now().UTC()
+		runningMeta.EndedAt = &now
+		_ = snapshot.WriteRunMeta(runDir, runningMeta)
+		checkCircuitBreaker(j, prefix)
+		return false, false
+	}
+	if hasOverride {
+		fmt.Fprintf(os.Stderr, "%s → base-branch override: %q (from %s)\n", prefix, overrideBranch, overrideSource)
+	}
+
+	wtResult, cleanup, err := resolveWorkdir(j.op, j.repoCfg, j.repo, j.sub.Number, startedAt, overrideBranch)
 	if err != nil {
 		// Failure path: do NOT post a comment to the issue. The full
 		// error is captured in events.jsonl and the run row on the
@@ -733,7 +759,11 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		fmt.Fprintf(os.Stderr, "%s ✓ workdir ready: %s\n", prefix, workdir)
 	}
 
-	comments, _ := j.client.ListIssueComments(j.repo, j.sub.Number)
+	// Extract comment bodies from the already-fetched detail slice.
+	comments := make([]string, len(detailComments))
+	for i, c := range detailComments {
+		comments[i] = c.Body
+	}
 
 	eventsFile, eventsErr := os.Create(filepath.Join(runDir, "events.jsonl"))
 	if eventsErr != nil {
@@ -1118,14 +1148,14 @@ func waitForCI(client vcs.Client, repo string, prNum int, timeoutSec int, prefix
 //   - all other operators with local_path → persistent analysis worktree
 //     (ensureAnalysisWorktree) reset to origin/<base> before each run
 //   - all other operators without local_path → ephemeral tempdir + warning
-func resolveWorkdir(op *operator.Operator, repoCfg config.Repo, fullName string, issueNum int, startedAt time.Time) (worktreeResult, func(), error) {
+func resolveWorkdir(op *operator.Operator, repoCfg config.Repo, fullName string, issueNum int, startedAt time.Time, overrideBranch string) (worktreeResult, func(), error) {
 	// implement and pr-target operators need a mutable per-issue worktree.
 	needsRepo := op.Name == "implement" || op.Trigger.Target == "pr"
 	if needsRepo {
 		if repoCfg.LocalPath == "" {
 			return worktreeResult{}, func() {}, fmt.Errorf("operator %q needs repo local_path but it's empty in config", op.Name)
 		}
-		return setupWorktree(repoCfg, fullName, issueNum, startedAt)
+		return setupWorktree(repoCfg, fullName, issueNum, startedAt, overrideBranch)
 	}
 
 	// Analysis operators need read access to the repo source so the LLM can
@@ -1342,7 +1372,16 @@ func findExistingWorktree(parent string, issueNum int, localPath, base string) (
 //
 // Cleanup removes the worktree (force) but leaves any branches the operator
 // created alone — pushed branches stay locally for the user to inspect/delete.
-func setupWorktree(repoCfg config.Repo, fullName string, issueNum int, startedAt time.Time) (worktreeResult, func(), error) {
+//
+// overrideBranch, when non-empty, replaces repoCfg.BaseBranch for this single
+// run only — it is the integration point for the ClawFlow-Base-Branch: marker
+// (see ParseBaseBranchOverride in basebranch.go) and is never persisted.
+//
+// NOTE: this override intentionally does NOT propagate to ensureAnalysisWorktree.
+// Analysis worktrees are long-lived and shared across all issues for the same
+// (repo, branch) pair; a per-issue override would either pollute that shared
+// worktree or require a separate per-issue analysis worktree (out of scope).
+func setupWorktree(repoCfg config.Repo, fullName string, issueNum int, startedAt time.Time, overrideBranch string) (worktreeResult, func(), error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return worktreeResult{}, func() {}, fmt.Errorf("home dir: %w", err)
@@ -1353,7 +1392,12 @@ func setupWorktree(repoCfg config.Repo, fullName string, issueNum int, startedAt
 		return worktreeResult{}, func() {}, fmt.Errorf("mkdir worktree parent: %w", err)
 	}
 
-	base := repoCfg.BaseBranch
+	// Resolve base branch: per-issue override takes highest priority,
+	// then the repo config value, then the hardcoded "main" default.
+	base := overrideBranch
+	if base == "" {
+		base = repoCfg.BaseBranch
+	}
 	if base == "" {
 		base = "main"
 	}


### PR DESCRIPTION
Fixes #151

## What changed

### New: `cmd/clawflow/commands/basebranch.go`

- `ParseBaseBranchOverride(body string, comments []vcs.IssueComment) (branch, source string, ok bool, err error)`  
  Scans the issue body and comments for a `ClawFlow-Base-Branch: <branch>` marker. Latest comment wins (sorted by `CreatedAt` newest-first); falls back to the body marker; returns `ok=false` when no marker exists.
- `validateBranchName` rejects: empty, >250 chars, non-`[A-Za-z0-9._/-]` characters, leading `-`/`.`/`/`, and `..` sequences — blocks git-flag injection and path traversal.

### Modified: `cmd/clawflow/commands/run.go`

- `resolveWorkdir` and `setupWorktree` gain an `overrideBranch string` parameter.
- Inside `setupWorktree` the base branch resolution order is now: override → `repoCfg.BaseBranch` → `"main"`.
- `runOneOperator` fetches `ListIssueCommentsDetail` **before** `resolveWorkdir` (single round-trip), parses the override, and hard-fails the run on an invalid marker (recorded in `meta.json`; no VCS comment posted — follows runner contract).
- `ensureAnalysisWorktree` is intentionally unchanged — analysis worktrees are long-lived and shared per `(repo, branch)`; a per-issue override there would cause cache collisions.

### New: `cmd/clawflow/commands/basebranch_test.go`

Unit tests covering:
- Body-only marker
- Latest-comment-wins (multiple comment markers)
- Comment marker overrides body marker
- Non-marker comments → body fallback
- Invalid markers: leading `-`, leading `.`, leading `/`, `..`, invalid chars, spaced shell injection (no marker match)