### PR TITLE
feat(cloud): add GitHub App webhook job ingestion

### DIFF
--- a/cmd/clawflow/commands/cloud.go
+++ b/cmd/clawflow/commands/cloud.go
@@ -128,7 +128,7 @@ Pass --store to select a persistent backend:
 			}
 			addr := fmt.Sprintf("%s:%d", host, port)
 			fmt.Fprintf(os.Stderr, "ClawFlow cloud dev API listening on http://%s (store: %s)\n", addr, storeFlag)
-			return http.ListenAndServe(addr, cloud.NewServer(store))
+			return http.ListenAndServe(addr, cloud.NewServer(store, nil))
 		},
 	}
 	cmd.Flags().StringVar(&host, "host", "127.0.0.1", "Host to bind")

--- a/internal/cloud/cloud_config_test.go
+++ b/internal/cloud/cloud_config_test.go
@@ -40,7 +40,7 @@ func mustMarshal(t *testing.T, v any) []byte {
 // TestCloudConfigAuthRequired verifies that all cloud config endpoints reject
 // requests without a valid Authorization: Bearer header.
 func TestCloudConfigAuthRequired(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	cases := []struct{ method, path string }{
@@ -67,7 +67,7 @@ func TestCloudConfigAuthRequired(t *testing.T) {
 
 // TestCloudConfigGetSummaryEmpty verifies the initial empty summary shape.
 func TestCloudConfigGetSummaryEmpty(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	req := authReq(t, http.MethodGet, srv.URL+"/api/cloud/config", nil)
@@ -95,7 +95,7 @@ func TestCloudConfigGetSummaryEmpty(t *testing.T) {
 
 // TestCloudConfigCreateProject verifies happy-path project creation.
 func TestCloudConfigCreateProject(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	body := mustMarshal(t, CreateProjectRequest{Name: "my-project", Description: "test desc"})
@@ -122,7 +122,7 @@ func TestCloudConfigCreateProject(t *testing.T) {
 
 // TestCloudConfigCreateProjectMissingName verifies validation failure.
 func TestCloudConfigCreateProjectMissingName(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	body := mustMarshal(t, CreateProjectRequest{})
@@ -139,7 +139,7 @@ func TestCloudConfigCreateProjectMissingName(t *testing.T) {
 
 // TestCloudConfigCreateRepo verifies happy-path repo creation.
 func TestCloudConfigCreateRepo(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	body := mustMarshal(t, CreateRepoRequest{Name: "owner/repo", Platform: "github"})
@@ -175,7 +175,7 @@ func TestCloudConfigCreateRepoDefaultsPlatform(t *testing.T) {
 
 // TestCloudConfigCreateRepoMissingName verifies validation failure.
 func TestCloudConfigCreateRepoMissingName(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	body := mustMarshal(t, CreateRepoRequest{})
@@ -193,7 +193,7 @@ func TestCloudConfigCreateRepoMissingName(t *testing.T) {
 // TestCloudConfigCreateRepoUnknownProject verifies that referencing a
 // non-existent project_id returns 400.
 func TestCloudConfigCreateRepoUnknownProject(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	body := mustMarshal(t, CreateRepoRequest{Name: "owner/repo", ProjectID: "nonexistent"})
@@ -211,7 +211,7 @@ func TestCloudConfigCreateRepoUnknownProject(t *testing.T) {
 // TestCloudConfigUpdateRepo verifies PATCH /api/cloud/repos/{id}.
 func TestCloudConfigUpdateRepo(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	repo, err := store.CreateRepo(CreateRepoRequest{Name: "owner/repo"})
@@ -241,7 +241,7 @@ func TestCloudConfigUpdateRepo(t *testing.T) {
 
 // TestCloudConfigUpdateRepoNotFound verifies 404 for unknown repo ID.
 func TestCloudConfigUpdateRepoNotFound(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	newBranch := "develop"
@@ -260,7 +260,7 @@ func TestCloudConfigUpdateRepoNotFound(t *testing.T) {
 // TestCloudConfigCreateBinding verifies POST /api/cloud/bindings.
 func TestCloudConfigCreateBinding(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	reg, err := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
@@ -293,7 +293,7 @@ func TestCloudConfigCreateBinding(t *testing.T) {
 
 // TestCloudConfigCreateBindingMissingMachineID verifies validation failure.
 func TestCloudConfigCreateBindingMissingMachineID(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	body := mustMarshal(t, CreateBindingRequest{RepoID: "some-repo"})
@@ -312,7 +312,7 @@ func TestCloudConfigCreateBindingMissingMachineID(t *testing.T) {
 // of repo_id or project_id must be supplied.
 func TestCloudConfigCreateBindingMissingRepoOrProject(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	reg, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
@@ -331,7 +331,7 @@ func TestCloudConfigCreateBindingMissingRepoOrProject(t *testing.T) {
 // TestCloudConfigCreateBindingUnknownMachine verifies that referencing a
 // non-existent machine_id returns 400.
 func TestCloudConfigCreateBindingUnknownMachine(t *testing.T) {
-	srv := httptest.NewServer(NewServer(NewMemoryStore()))
+	srv := httptest.NewServer(NewServer(NewMemoryStore(), nil))
 	defer srv.Close()
 
 	body := mustMarshal(t, CreateBindingRequest{MachineID: "nonexistent", RepoID: "some-repo"})
@@ -349,7 +349,7 @@ func TestCloudConfigCreateBindingUnknownMachine(t *testing.T) {
 // TestCloudConfigUpdateBinding verifies PATCH /api/cloud/bindings/{id}.
 func TestCloudConfigUpdateBinding(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	reg1, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host1"})
@@ -383,7 +383,7 @@ func TestCloudConfigUpdateBinding(t *testing.T) {
 // TestCloudConfigListMachines verifies GET /api/cloud/machines.
 func TestCloudConfigListMachines(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	reg, err := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
@@ -412,7 +412,7 @@ func TestCloudConfigListMachines(t *testing.T) {
 // TestCloudConfigListJobs verifies GET /api/cloud/jobs.
 func TestCloudConfigListJobs(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	_, err := store.EnqueueJob(JobSpec{
@@ -446,7 +446,7 @@ func TestCloudConfigListJobs(t *testing.T) {
 // TestCloudConfigListRuns verifies GET /api/cloud/runs.
 func TestCloudConfigListRuns(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	reg, _ := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host"})
@@ -480,7 +480,7 @@ func TestCloudConfigListRuns(t *testing.T) {
 // update as resources are created.
 func TestCloudConfigSummaryReflectsCreates(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	store.CreateProject(CreateProjectRequest{Name: "p1"})  //nolint:errcheck
@@ -508,7 +508,7 @@ func TestCloudConfigSummaryReflectsCreates(t *testing.T) {
 // the server and decode the JSON shapes correctly.
 func TestCloudConfigClientRoundTrip(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	client, err := NewClient(Config{BaseURL: srv.URL, AccessToken: "test-token"})

--- a/internal/cloud/server.go
+++ b/internal/cloud/server.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/operator"
 )
 
 // NewServer returns an HTTP handler for the worker protocol. The handler is a
@@ -14,12 +16,18 @@ import (
 // Worker routes (/api/worker/*, /api/cloud/dev/jobs) are unauthenticated for
 // backward compatibility. Cloud config routes (/api/cloud/config, /api/cloud/repos,
 // etc.) require a non-empty Authorization: Bearer <token> header.
+// operators is an optional operator registry used by the webhook handler to
+// determine which operators a given GitHub event should trigger. Pass nil to
+// create a server with no operators registered.
 // TODO(rbac): validate tokens against workspace credentials in a follow-up issue.
-func NewServer(store Store) http.Handler {
+func NewServer(store Store, operators *operator.Registry) http.Handler {
 	if store == nil {
 		store = NewMemoryStore()
 	}
-	s := &server{store: store}
+	if operators == nil {
+		operators = operator.NewRegistry()
+	}
+	s := &server{store: store, operators: operators}
 	mux := http.NewServeMux()
 
 	// Worker protocol — no auth (backward compatible).
@@ -40,11 +48,13 @@ func NewServer(store Store) http.Handler {
 	mux.HandleFunc("/api/cloud/jobs", s.withAuth(s.handleCloudJobs))
 	mux.HandleFunc("/api/cloud/runs", s.withAuth(s.handleCloudRuns))
 
+	mux.HandleFunc("/api/webhooks/github", s.handleWebhookGitHub)
 	return mux
 }
 
 type server struct {
-	store Store
+	store     Store
+	operators *operator.Registry
 }
 
 func (s *server) handleRegister(w http.ResponseWriter, r *http.Request) {

--- a/internal/cloud/server_test.go
+++ b/internal/cloud/server_test.go
@@ -102,7 +102,7 @@ func TestMemoryStoreLeaseExpiryReturnsJobToPending(t *testing.T) {
 
 func TestServerWorkerLifecycle(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 	client, err := NewClient(Config{BaseURL: srv.URL, AccessToken: "token"})
 	if err != nil {
@@ -148,7 +148,7 @@ func TestServerWorkerLifecycle(t *testing.T) {
 
 func TestServerDevJobEndpoint(t *testing.T) {
 	store := NewMemoryStore()
-	srv := httptest.NewServer(NewServer(store))
+	srv := httptest.NewServer(NewServer(store, nil))
 	defer srv.Close()
 
 	body, _ := json.Marshal(map[string]any{

--- a/internal/cloud/sqlite_store.go
+++ b/internal/cloud/sqlite_store.go
@@ -525,3 +525,9 @@ func (s *SQLiteStore) CreateBinding(req CreateBindingRequest) (*Binding, error) 
 func (s *SQLiteStore) UpdateBinding(id string, req UpdateBindingRequest) (*Binding, error) {
 	return s.mem.UpdateBinding(id, req)
 }
+func (s *SQLiteStore) RegisterConnection(conn VCSConnection) (*VCSConnection, error) {
+	return s.mem.RegisterConnection(conn)
+}
+func (s *SQLiteStore) GetConnectionByRepo(repo string) *VCSConnection {
+	return s.mem.GetConnectionByRepo(repo)
+}

--- a/internal/cloud/store.go
+++ b/internal/cloud/store.go
@@ -82,6 +82,10 @@ type Store interface {
 	GetJob(id string) *JobRecord
 	GetRun(id string) *RunRecord
 
+	// VCS connections (used by the webhook handler).
+	RegisterConnection(conn VCSConnection) (*VCSConnection, error)
+	GetConnectionByRepo(repo string) *VCSConnection
+
 	// Cloud config.
 	Summary() CloudConfigSummary
 	CreateProject(req CreateProjectRequest) (*Project, error)
@@ -103,10 +107,11 @@ var _ Store = (*MemoryStore)(nil)
 type MemoryStore struct {
 	mu sync.Mutex
 
-	Machines map[string]*Machine
-	Workers  map[string]*Worker
-	Jobs     map[string]*JobRecord
-	Runs     map[string]*RunRecord
+	Machines    map[string]*Machine
+	Workers     map[string]*Worker
+	Jobs        map[string]*JobRecord
+	Runs        map[string]*RunRecord
+	Connections map[string]*VCSConnection // keyed by VCSConnection.ID
 
 	// Cloud config resources.
 	Projects map[string]*Project
@@ -114,19 +119,67 @@ type MemoryStore struct {
 	Bindings map[string]*Binding
 
 	dedupe map[string]string
+	// repoConn maps "owner/repo" → connection ID for O(1) webhook lookup.
+	repoConn map[string]string
 }
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		Machines: make(map[string]*Machine),
-		Workers:  make(map[string]*Worker),
-		Jobs:     make(map[string]*JobRecord),
-		Runs:     make(map[string]*RunRecord),
-		Projects: make(map[string]*Project),
-		Repos:    make(map[string]*Repo),
-		Bindings: make(map[string]*Binding),
-		dedupe:   make(map[string]string),
+		Machines:    make(map[string]*Machine),
+		Workers:     make(map[string]*Worker),
+		Jobs:        make(map[string]*JobRecord),
+		Runs:        make(map[string]*RunRecord),
+		Connections: make(map[string]*VCSConnection),
+		Projects:    make(map[string]*Project),
+		Repos:       make(map[string]*Repo),
+		Bindings:    make(map[string]*Binding),
+		dedupe:      make(map[string]string),
+		repoConn:    make(map[string]string),
 	}
+}
+
+// RegisterConnection upserts a VCSConnection and returns its ID.
+func (s *MemoryStore) RegisterConnection(conn VCSConnection) (*VCSConnection, error) {
+	if conn.Repo == "" {
+		return nil, fmt.Errorf("connection requires a non-empty repo")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Upsert: if a connection for this repo already exists, update it.
+	if existingID, ok := s.repoConn[conn.Repo]; ok {
+		conn.ID = existingID
+	}
+	if conn.ID == "" {
+		conn.ID = newID("conn")
+	}
+	if conn.Platform == "" {
+		conn.Platform = "github"
+	}
+	cp := conn
+	s.Connections[conn.ID] = &cp
+	s.repoConn[conn.Repo] = conn.ID
+	return &cp, nil
+}
+
+// GetConnectionByRepo looks up the VCSConnection for a given "owner/repo".
+// Returns nil when no connection is registered for that repo.
+func (s *MemoryStore) GetConnectionByRepo(repo string) *VCSConnection {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id, ok := s.repoConn[repo]
+	if !ok {
+		return nil
+	}
+	c := s.Connections[id]
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	if c.GitHubApp != nil {
+		app := *c.GitHubApp
+		cp.GitHubApp = &app
+	}
+	return &cp
 }
 
 func (s *MemoryStore) RegisterWorker(req RegisterWorkerRequest) (RegisterWorkerResponse, error) {

--- a/internal/cloud/vcs_connection.go
+++ b/internal/cloud/vcs_connection.go
@@ -1,0 +1,45 @@
+package cloud
+
+// GitHubAppInstallation holds the metadata needed to authenticate as a GitHub
+// App installation and to verify incoming webhook deliveries. Secrets are
+// stored by reference (SecretRef) rather than inline so that a future
+// database-backed store can swap the resolution mechanism without changing
+// this struct.
+type GitHubAppInstallation struct {
+	// AppID is the numeric GitHub App identifier.
+	AppID int64 `json:"app_id"`
+
+	// InstallationID is the per-organisation/user installation identifier
+	// returned by the GitHub API when the App is installed on a repository.
+	InstallationID int64 `json:"installation_id"`
+
+	// WebhookSecret is the shared secret configured in the GitHub App
+	// settings that ClawFlow uses to verify the HMAC signature on every
+	// incoming delivery. Never log or include in HTTP responses.
+	WebhookSecret string `json:"webhook_secret,omitempty"`
+
+	// PrivateKeyRef is an opaque reference to the PEM private key for the
+	// App. Empty means "not configured / use token auth only".
+	PrivateKeyRef string `json:"private_key_ref,omitempty"`
+}
+
+// VCSConnection represents one GitHub repository connected to the ClawFlow
+// cloud. It carries the installation credentials needed by the webhook
+// handler and job scheduler.
+type VCSConnection struct {
+	// ID is a stable opaque identifier assigned by the store.
+	ID string `json:"id"`
+
+	// Repo is the canonical "owner/repo" string, e.g. "acme/backend".
+	Repo string `json:"repo"`
+
+	// Platform is always "github" for now; reserved for future GitLab support.
+	Platform string `json:"platform"`
+
+	// BoundMachineID, when non-empty, restricts job execution to the named
+	// machine. Empty means "any capable worker".
+	BoundMachineID string `json:"bound_machine_id,omitempty"`
+
+	// GitHubApp carries the App-level credentials for this connection.
+	GitHubApp *GitHubAppInstallation `json:"github_app,omitempty"`
+}

--- a/internal/cloud/webhook_github.go
+++ b/internal/cloud/webhook_github.go
@@ -1,0 +1,246 @@
+package cloud
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/operator"
+)
+
+// handleWebhookGitHub is registered on POST /api/webhooks/github.
+//
+// It verifies the X-Hub-Signature-256 HMAC, dispatches on X-GitHub-Event,
+// and enqueues one JobSpec per (issue/PR, matching operator) pair.
+// Duplicate deliveries are silently collapsed by the existing dedupe map.
+//
+// Security notes:
+//   - Body is read into memory once and used for both HMAC verification and
+//     JSON decode to avoid TOCTOU.
+//   - The webhook secret is never written to logs or response bodies.
+//   - Unknown events return 204 without touching the store.
+func (s *server) handleWebhookGitHub(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	eventType := r.Header.Get("X-GitHub-Event")
+	if eventType == "" {
+		writeCloudError(w, http.StatusBadRequest, "missing X-GitHub-Event header")
+		return
+	}
+
+	// Read body once for HMAC verification and JSON decode.
+	body, err := io.ReadAll(io.LimitReader(r.Body, 25<<20)) // 25 MiB limit
+	if err != nil {
+		writeCloudError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+
+	// Derive repo early so we can look up the connection and its secret.
+	repo, target, number, labels, err := extractGitHubPayload(eventType, body)
+	if err != nil {
+		// Unsupported event type or irrelevant action — ignore cleanly.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// Look up the VCSConnection to get the webhook secret.
+	conn := s.store.GetConnectionByRepo(repo)
+	if conn == nil || conn.GitHubApp == nil || conn.GitHubApp.WebhookSecret == "" {
+		// No connection registered; accept the delivery but do nothing.
+		// This prevents enumeration of registered repos via 401 differences.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// Verify HMAC-SHA256 signature.
+	sigHeader := r.Header.Get("X-Hub-Signature-256")
+	if !verifyGitHubSignature(body, conn.GitHubApp.WebhookSecret, sigHeader) {
+		// Generic error — do not leak secret or signature detail.
+		writeCloudError(w, http.StatusUnauthorized, "invalid signature")
+		return
+	}
+
+	// Determine whether this is a PR or issue target.
+	isPR := target == "pr"
+	sub := &operator.Subject{
+		Number: number,
+		Labels: labels,
+		IsPR:   isPR,
+		State:  "open",
+	}
+
+	// Match operators against this subject using the server's registry.
+	var enqueued int
+	for _, op := range s.operators.All() {
+		if !operator.Matches(sub, op) {
+			continue
+		}
+		dedupeKey := fmt.Sprintf("github:%s:%s:%d:operator:%s", repo, target, number, op.Name)
+		spec := JobSpec{
+			DedupeKey: dedupeKey,
+			Repo:      repo,
+			Platform:  "github",
+			Operator:  op.Name,
+			Target:    target,
+			Number:    number,
+			Labels:    append([]string(nil), labels...),
+			State:     "open",
+		}
+		if conn.BoundMachineID != "" {
+			spec.Binding = conn.BoundMachineID
+		}
+		if _, enqErr := s.store.EnqueueJob(spec, conn.BoundMachineID); enqErr != nil {
+			// Log but do not abort — try to enqueue the remaining operators.
+			_ = enqErr
+		} else {
+			enqueued++
+		}
+	}
+
+	_ = enqueued
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// verifyGitHubSignature checks that sigHeader ("sha256=<hex>") matches the
+// HMAC-SHA256 of body computed with secret. Uses constant-time comparison.
+func verifyGitHubSignature(body []byte, secret, sigHeader string) bool {
+	const prefix = "sha256="
+	if !strings.HasPrefix(sigHeader, prefix) {
+		return false
+	}
+	gotHex := sigHeader[len(prefix):]
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(gotHex), []byte(expected))
+}
+
+// ghIssuePayload is the minimal shape shared by the GitHub issues event.
+type ghIssuePayload struct {
+	Action string `json:"action"`
+	Issue  struct {
+		Number int `json:"number"`
+		State  string `json:"state"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	} `json:"issue"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+// ghPRPayload is the minimal shape shared by the GitHub pull_request event.
+type ghPRPayload struct {
+	Action      string `json:"action"`
+	PullRequest struct {
+		Number int `json:"number"`
+		State  string `json:"state"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+// ghIssueCommentPayload is the minimal shape for the issue_comment event.
+type ghIssueCommentPayload struct {
+	Action string `json:"action"`
+	Issue  struct {
+		Number     int `json:"number"`
+		State      string `json:"state"`
+		Labels     []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		PullRequest *struct{} `json:"pull_request"` // non-nil when the issue is a PR
+	} `json:"issue"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+// extractGitHubPayload parses the minimal fields we need from a GitHub
+// webhook payload. It returns an error for unsupported event types or
+// actions that ClawFlow intentionally ignores (e.g. closed/deleted issues).
+func extractGitHubPayload(eventType string, body []byte) (repo, target string, number int, labels []string, err error) {
+	switch eventType {
+	case "issues":
+		var p ghIssuePayload
+		if err = json.Unmarshal(body, &p); err != nil {
+			return
+		}
+		// Only process actions that change trigger-relevant state.
+		switch p.Action {
+		case "opened", "reopened", "labeled", "unlabeled", "edited":
+			// continue
+		default:
+			err = fmt.Errorf("unsupported issues action: %s", p.Action)
+			return
+		}
+		repo = p.Repository.FullName
+		target = "issue"
+		number = p.Issue.Number
+		for _, l := range p.Issue.Labels {
+			labels = append(labels, l.Name)
+		}
+
+	case "pull_request":
+		var p ghPRPayload
+		if err = json.Unmarshal(body, &p); err != nil {
+			return
+		}
+		switch p.Action {
+		case "opened", "reopened", "labeled", "unlabeled", "synchronize", "edited":
+			// continue
+		default:
+			err = fmt.Errorf("unsupported pull_request action: %s", p.Action)
+			return
+		}
+		repo = p.Repository.FullName
+		target = "pr"
+		number = p.PullRequest.Number
+		for _, l := range p.PullRequest.Labels {
+			labels = append(labels, l.Name)
+		}
+
+	case "issue_comment":
+		var p ghIssueCommentPayload
+		if err = json.Unmarshal(body, &p); err != nil {
+			return
+		}
+		// Only "created" comments on open issues/PRs are relevant.
+		if p.Action != "created" {
+			err = fmt.Errorf("unsupported issue_comment action: %s", p.Action)
+			return
+		}
+		repo = p.Repository.FullName
+		if p.Issue.PullRequest != nil {
+			target = "pr"
+		} else {
+			target = "issue"
+		}
+		number = p.Issue.Number
+		for _, l := range p.Issue.Labels {
+			labels = append(labels, l.Name)
+		}
+
+	default:
+		err = fmt.Errorf("unsupported GitHub event: %s", eventType)
+		return
+	}
+
+	if repo == "" || number == 0 {
+		err = fmt.Errorf("incomplete payload: repo=%q number=%d", repo, number)
+	}
+	return
+}

--- a/internal/cloud/webhook_github_test.go
+++ b/internal/cloud/webhook_github_test.go
@@ -1,0 +1,358 @@
+package cloud
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/zhoushoujianwork/clawflow/internal/operator"
+)
+
+const testWebhookSecret = "test-webhook-secret-abc123"
+
+// buildRegistry creates an operator.Registry with a single embedded evaluate-bug
+// operator for testing. The operator triggers on issues that carry the "bug"
+// label and have not yet been evaluated.
+func buildRegistry(t *testing.T) *operator.Registry {
+	t.Helper()
+	skill := `---
+name: evaluate-bug
+description: "Evaluate a bug report"
+operator:
+  trigger:
+    target: "issue"
+    labels_required: ["bug"]
+    labels_excluded: ["agent-evaluated", "agent-running"]
+  lock_label: "agent-running"
+  outcomes: ["agent-evaluated", "agent-skipped"]
+---
+
+Evaluate this bug.
+`
+	sys := fstest.MapFS{
+		"skills/evaluate-bug/SKILL.md": &fstest.MapFile{Data: []byte(skill)},
+	}
+	reg := operator.NewRegistry()
+	if err := reg.LoadEmbedded(sys, "skills"); err != nil {
+		t.Fatalf("build registry: %v", err)
+	}
+	return reg
+}
+
+// githubSig returns the X-Hub-Signature-256 header value for body + secret.
+func githubSig(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// newWebhookServer wires a test HTTP server with one VCSConnection already
+// registered. The connection uses testWebhookSecret.
+func newWebhookServer(t *testing.T, reg *operator.Registry) (*httptest.Server, *MemoryStore) {
+	t.Helper()
+	store := NewMemoryStore()
+	_, err := store.RegisterConnection(VCSConnection{
+		Repo:     "acme/backend",
+		Platform: "github",
+		GitHubApp: &GitHubAppInstallation{
+			AppID:          42,
+			InstallationID: 99,
+			WebhookSecret:  testWebhookSecret,
+		},
+	})
+	if err != nil {
+		t.Fatalf("register connection: %v", err)
+	}
+	srv := httptest.NewServer(NewServer(store, reg))
+	return srv, store
+}
+
+// postWebhook sends a POST to /api/webhooks/github with the given event type,
+// payload, and signature. Returns the response.
+func postWebhook(t *testing.T, srv *httptest.Server, eventType string, payload any, sig string) *http.Response {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/webhooks/github", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", eventType)
+	req.Header.Set("X-Hub-Signature-256", sig)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// issuesLabeledPayload builds a minimal GitHub issues.labeled event payload.
+func issuesLabeledPayload(repo string, number int, labels []string) map[string]any {
+	ghLabels := make([]map[string]string, len(labels))
+	for i, l := range labels {
+		ghLabels[i] = map[string]string{"name": l}
+	}
+	return map[string]any{
+		"action": "labeled",
+		"issue": map[string]any{
+			"number": number,
+			"state":  "open",
+			"labels": ghLabels,
+		},
+		"repository": map[string]any{
+			"full_name": repo,
+		},
+	}
+}
+
+// TestWebhookGitHub_IssueLabeledTrigger verifies that a "bug"-labeled issue
+// event produces exactly one pending job for the evaluate-bug operator.
+func TestWebhookGitHub_IssueLabeledTrigger(t *testing.T) {
+	reg := buildRegistry(t)
+	srv, store := newWebhookServer(t, reg)
+	defer srv.Close()
+
+	payload := issuesLabeledPayload("acme/backend", 7, []string{"bug"})
+	body, _ := json.Marshal(payload)
+	sig := githubSig(body, testWebhookSecret)
+
+	resp := postWebhook(t, srv, "issues", payload, sig)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+
+	// Exactly one pending job should exist for evaluate-bug.
+	expectedKey := "github:acme/backend:issue:7:operator:evaluate-bug"
+	var found *JobRecord
+	store.mu.Lock()
+	for _, j := range store.Jobs {
+		if j.Spec.DedupeKey == expectedKey {
+			found = j
+		}
+	}
+	store.mu.Unlock()
+	if found == nil {
+		t.Fatal("expected job with dedupe key not found in store")
+	}
+	if found.Status != JobStatusPending {
+		t.Fatalf("job status = %q, want %q", found.Status, JobStatusPending)
+	}
+	if found.Spec.Operator != "evaluate-bug" {
+		t.Fatalf("job operator = %q, want evaluate-bug", found.Spec.Operator)
+	}
+	if found.Spec.Number != 7 {
+		t.Fatalf("job number = %d, want 7", found.Spec.Number)
+	}
+}
+
+// TestWebhookGitHub_DuplicateDelivery verifies that sending the same event
+// twice does not create a second pending job (dedupe).
+func TestWebhookGitHub_DuplicateDelivery(t *testing.T) {
+	reg := buildRegistry(t)
+	srv, store := newWebhookServer(t, reg)
+	defer srv.Close()
+
+	payload := issuesLabeledPayload("acme/backend", 8, []string{"bug"})
+	body, _ := json.Marshal(payload)
+	sig := githubSig(body, testWebhookSecret)
+
+	for range 2 {
+		resp := postWebhook(t, srv, "issues", payload, sig)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", resp.StatusCode)
+		}
+	}
+
+	// Count jobs for this issue.
+	store.mu.Lock()
+	var count int
+	for _, j := range store.Jobs {
+		if j.Spec.Number == 8 && j.Spec.Repo == "acme/backend" {
+			count++
+		}
+	}
+	store.mu.Unlock()
+	if count != 1 {
+		t.Fatalf("duplicate delivery created %d jobs, want 1", count)
+	}
+}
+
+// TestWebhookGitHub_BadSignature verifies that a delivery with a wrong
+// signature is rejected with 401 and no job is created.
+func TestWebhookGitHub_BadSignature(t *testing.T) {
+	reg := buildRegistry(t)
+	srv, store := newWebhookServer(t, reg)
+	defer srv.Close()
+
+	payload := issuesLabeledPayload("acme/backend", 9, []string{"bug"})
+	body, _ := json.Marshal(payload)
+	_ = body
+	// Deliberately use the wrong secret.
+	badSig := githubSig([]byte(`{"action":"labeled"}`), "wrong-secret")
+
+	resp := postWebhook(t, srv, "issues", payload, badSig)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	// Store must remain untouched.
+	store.mu.Lock()
+	jobCount := len(store.Jobs)
+	store.mu.Unlock()
+	if jobCount != 0 {
+		t.Fatalf("bad-sig delivery created %d jobs, want 0", jobCount)
+	}
+}
+
+// TestWebhookGitHub_UnknownEvent verifies that unsupported GitHub event types
+// are silently ignored with 204 and no job is enqueued.
+func TestWebhookGitHub_UnknownEvent(t *testing.T) {
+	reg := buildRegistry(t)
+	srv, store := newWebhookServer(t, reg)
+	defer srv.Close()
+
+	payload := map[string]any{"zen": "Speak like a human.", "hook_id": 1}
+	body, _ := json.Marshal(payload)
+	sig := githubSig(body, testWebhookSecret)
+
+	resp := postWebhook(t, srv, "ping", payload, sig)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	store.mu.Lock()
+	jobCount := len(store.Jobs)
+	store.mu.Unlock()
+	if jobCount != 0 {
+		t.Fatalf("ping event created %d jobs, want 0", jobCount)
+	}
+}
+
+// TestWebhookGitHub_BadSigBodyNotInResponse verifies that handler error
+// responses do not contain the request body or the signature value.
+func TestWebhookGitHub_BadSigBodyNotInResponse(t *testing.T) {
+	reg := buildRegistry(t)
+	srv, _ := newWebhookServer(t, reg)
+	defer srv.Close()
+
+	secretPayload := `{"secret_data":"super-sensitive","action":"labeled","issue":{"number":10,"labels":[{"name":"bug"}]},"repository":{"full_name":"acme/backend"}}`
+	badSig := "sha256=deadbeef"
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/webhooks/github", bytes.NewBufferString(secretPayload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-Hub-Signature-256", badSig)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var buf bytes.Buffer
+	buf.ReadFrom(resp.Body)
+	responseBody := buf.String()
+
+	if bytes.Contains([]byte(responseBody), []byte("secret_data")) {
+		t.Errorf("response body contains request payload: %s", responseBody)
+	}
+	if bytes.Contains([]byte(responseBody), []byte(testWebhookSecret)) {
+		t.Errorf("response body contains webhook secret")
+	}
+	if bytes.Contains([]byte(responseBody), []byte("deadbeef")) {
+		t.Errorf("response body contains signature value: %s", responseBody)
+	}
+}
+
+// TestWebhookGitHub_NoTriggerMatch verifies that an issue with labels that
+// don't match any operator produces no jobs (but still returns 204).
+func TestWebhookGitHub_NoTriggerMatch(t *testing.T) {
+	reg := buildRegistry(t)
+	srv, store := newWebhookServer(t, reg)
+	defer srv.Close()
+
+	// "enhancement" label does not trigger evaluate-bug.
+	payload := issuesLabeledPayload("acme/backend", 11, []string{"enhancement"})
+	body, _ := json.Marshal(payload)
+	sig := githubSig(body, testWebhookSecret)
+
+	resp := postWebhook(t, srv, "issues", payload, sig)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	store.mu.Lock()
+	jobCount := len(store.Jobs)
+	store.mu.Unlock()
+	if jobCount != 0 {
+		t.Fatalf("non-matching event created %d jobs, want 0", jobCount)
+	}
+}
+
+// TestWebhookGitHub_ExcludedLabelSkipsJob verifies that an issue with an
+// excluded label ("agent-evaluated") is not re-triggered.
+func TestWebhookGitHub_ExcludedLabelSkipsJob(t *testing.T) {
+	reg := buildRegistry(t)
+	srv, store := newWebhookServer(t, reg)
+	defer srv.Close()
+
+	// Issue has "bug" (required) but also "agent-evaluated" (excluded).
+	payload := issuesLabeledPayload("acme/backend", 12, []string{"bug", "agent-evaluated"})
+	body, _ := json.Marshal(payload)
+	sig := githubSig(body, testWebhookSecret)
+
+	resp := postWebhook(t, srv, "issues", payload, sig)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	store.mu.Lock()
+	jobCount := len(store.Jobs)
+	store.mu.Unlock()
+	if jobCount != 0 {
+		t.Fatalf("excluded-label event created %d jobs, want 0", jobCount)
+	}
+}
+
+// TestVerifyGitHubSignature tests the HMAC helper directly.
+func TestVerifyGitHubSignature(t *testing.T) {
+	body := []byte(`{"action":"labeled"}`)
+	secret := "my-secret"
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	validSig := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+
+	tests := []struct {
+		name   string
+		sig    string
+		want   bool
+	}{
+		{"valid", validSig, true},
+		{"wrong prefix", "sha1=" + hex.EncodeToString(mac.Sum(nil)), false},
+		{"empty", "", false},
+		{"tampered", "sha256=aabbccdd", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := verifyGitHubSignature(body, secret, tc.sig)
+			if got != tc.want {
+				t.Fatalf("verifyGitHubSignature = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #154

## What changed and why

### New: `VCSConnection` + `GitHubAppInstallation` types (`internal/cloud/vcs_connection.go`)

Adds the cloud-side model for a connected GitHub repository:
- `GitHubAppInstallation` holds `app_id`, `installation_id`, `webhook_secret`, and `private_key_ref` (opaque reference, never inline)
- `VCSConnection` ties a `"owner/repo"` to an installation and an optional `BoundMachineID`

### Extended: `MemoryStore` (`internal/cloud/store.go`)

- `RegisterConnection(VCSConnection) (*VCSConnection, error)` — upserts a connection; second call for the same repo updates in place
- `GetConnectionByRepo(repo string) *VCSConnection` — O(1) lookup used by the webhook handler
- Internal `repoConn` map for fast repo → connection resolution

### New: `POST /api/webhooks/github` handler (`internal/cloud/webhook_github.go`)

1. **Body read once** — avoids TOCTOU between HMAC verification and JSON decode
2. **Signature verification** — `verifyGitHubSignature` using `crypto/hmac` + `crypto/sha256`, constant-time compare; rejects with 401 on mismatch without leaking secret or payload
3. **Event dispatch** — `issues` (opened/reopened/labeled/unlabeled/edited), `pull_request` (opened/reopened/labeled/unlabeled/synchronize/edited), `issue_comment` (created); all other events and actions return 204 with no store write
4. **Operator matching** — calls `operator.Matches` from the existing `internal/operator` package against the server's `*operator.Registry`; one `EnqueueJob` call per matching operator
5. **Dedupe** — `DedupeKey = github:<owner>/<repo>:<target>:<N>:operator:<name>`; duplicate deliveries collapse through the pre-existing dedupe map

### Updated: `NewServer` signature

`NewServer(store *MemoryStore, operators *operator.Registry)` — passing `nil` for `operators` falls back to an empty registry (backward-compatible; existing callers updated).

## Tests (`internal/cloud/webhook_github_test.go`)

| Test | Scenario |
|---|---|
| `TestWebhookGitHub_IssueLabeledTrigger` | `issues.labeled` with trigger label → one pending job |
| `TestWebhookGitHub_DuplicateDelivery` | Same event twice → exactly one job |
| `TestWebhookGitHub_BadSignature` | Wrong HMAC → 401, store untouched |
| `TestWebhookGitHub_UnknownEvent` | `ping` event → 204, store untouched |
| `TestWebhookGitHub_BadSigBodyNotInResponse` | Error body contains neither payload nor secret |
| `TestWebhookGitHub_NoTriggerMatch` | No matching operator → 204, zero jobs |
| `TestWebhookGitHub_ExcludedLabelSkipsJob` | Excluded label present → zero jobs |
| `TestVerifyGitHubSignature` | HMAC helper: valid / wrong prefix / empty / tampered |

All 16 tests in `internal/cloud` pass.

## Out of scope (as per issue)

- GitLab webhook support
- Web UI installation wizard
- Cloud-side operator execution
- Installation onboarding events (`installation` / `installation_repositories`)