### PR TITLE
feat(web): add SaaS worker cloud views

### DIFF
--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -309,6 +309,16 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/sync/push", api.HandleSyncPush)
 			mux.HandleFunc("/api/sync/pull", api.HandleSyncPull)
 			mux.HandleFunc("/api/login", api.HandleLogin)
+			// Cloud proxy — forwards /api/cloud/* to the configured cloud
+			// server using the stored access token. The browser stays
+			// same-origin and never sees the token.
+			mux.HandleFunc("/api/cloud/status", api.HandleCloudStatus)
+			mux.HandleFunc("/api/cloud/config", api.HandleCloudConfig)
+			mux.HandleFunc("/api/cloud/machines", api.HandleCloudMachines)
+			mux.HandleFunc("/api/cloud/bindings", api.HandleCloudBindings)
+			mux.HandleFunc("/api/cloud/bindings/", api.HandleCloudBindingByID)
+			mux.HandleFunc("/api/cloud/jobs", api.HandleCloudJobs)
+			mux.HandleFunc("/api/cloud/runs", api.HandleCloudRuns)
 			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 				// SPA fallback: if the requested path maps to a real
 				// asset inside the embedded bundle (assets/, favicon.svg,

--- a/internal/api/cloud.go
+++ b/internal/api/cloud.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/cloud"
+)
+
+// cloudProxy is a reusable reverse-proxy that forwards a request to the
+// configured ClawFlow cloud server and streams the response back to the
+// browser. It adds the stored access token so the browser never sees it.
+// If the cloud is not configured (no URL or no token), it responds 503.
+func cloudProxy(w http.ResponseWriter, r *http.Request, upstreamPath string) {
+	cfg, err := cloud.LoadConfig()
+	if err != nil || cfg.BaseURL == "" || cfg.AccessToken == "" {
+		http.Error(w, `{"error":"cloud not configured"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	targetURL := strings.TrimRight(cfg.BaseURL, "/") + upstreamPath
+	if r.URL.RawQuery != "" {
+		targetURL += "?" + r.URL.RawQuery
+	}
+
+	var bodyReader io.Reader
+	if r.ContentLength != 0 && r.Body != nil {
+		bodyReader = r.Body
+		defer r.Body.Close()
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, bodyReader)
+	if err != nil {
+		http.Error(w, `{"error":"proxy error"}`, http.StatusInternalServerError)
+		return
+	}
+	// Forward content-type for POST/PATCH
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	req.Header.Set("Authorization", "Bearer "+cfg.AccessToken)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		http.Error(w, `{"error":"cloud unreachable"}`, http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response headers (Content-Type in particular)
+	for k, vals := range resp.Header {
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// HandleCloudStatus returns whether the cloud is configured so the UI can
+// conditionally show or hide the Cloud nav entry.
+func HandleCloudStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cfg, err := cloud.LoadConfig()
+	configured := err == nil && cfg.AccessToken != ""
+	writeJSON(w, http.StatusOK, map[string]any{
+		"configured": configured,
+		"url":        cfg.BaseURL,
+	})
+}
+
+// HandleCloudMachines proxies GET /api/cloud/machines to the cloud server.
+func HandleCloudMachines(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cloudProxy(w, r, "/api/cloud/machines")
+}
+
+// HandleCloudBindings proxies GET and POST /api/cloud/bindings.
+func HandleCloudBindings(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodPost:
+		cloudProxy(w, r, "/api/cloud/bindings")
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// HandleCloudBindingByID proxies PATCH /api/cloud/bindings/{id}.
+func HandleCloudBindingByID(w http.ResponseWriter, r *http.Request) {
+	// Extract the binding ID from the URL path
+	// Path is /api/cloud/bindings/{id}
+	path := r.URL.Path
+	id := strings.TrimPrefix(path, "/api/cloud/bindings/")
+	if id == "" {
+		http.Error(w, "missing binding id", http.StatusBadRequest)
+		return
+	}
+	switch r.Method {
+	case http.MethodPatch, http.MethodGet:
+		cloudProxy(w, r, "/api/cloud/bindings/"+id)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// HandleCloudJobs proxies GET /api/cloud/jobs to the cloud server.
+func HandleCloudJobs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cloudProxy(w, r, "/api/cloud/jobs")
+}
+
+// HandleCloudRuns proxies GET /api/cloud/runs to the cloud server.
+func HandleCloudRuns(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cloudProxy(w, r, "/api/cloud/runs")
+}
+
+// HandleCloudConfig proxies GET /api/cloud/config to the cloud server.
+func HandleCloudConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cloudProxy(w, r, "/api/cloud/config")
+}

--- a/web/src/lib/cloudApi.ts
+++ b/web/src/lib/cloudApi.ts
@@ -1,0 +1,177 @@
+// cloudApi.ts — typed fetch helpers for the ClawFlow cloud proxy.
+// The browser calls /api/cloud/* which the Go web server proxies to the
+// configured cloud URL using the stored access token — the token is never
+// exposed to JavaScript.
+
+// ---- Domain types (mirror internal/cloud/types.go) ----
+
+export interface Machine {
+  id: string
+  hostname: string
+  display_name?: string
+  version?: string
+  capabilities?: string[]
+  last_seen_at: string // ISO 8601
+}
+
+export interface Worker {
+  id: string
+  machine_id: string
+  status: string
+  capacity: number
+  active_runs?: string[]
+  last_seen_at: string
+}
+
+export interface Binding {
+  id: string
+  machine_id: string
+  repo_id?: string
+  project_id?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Project {
+  id: string
+  name: string
+  description?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface Repo {
+  id: string
+  name: string
+  platform: string
+  project_id?: string
+  base_branch?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface JobSpec {
+  job_id: string
+  run_id?: string
+  repo: string
+  platform: string
+  operator: string
+  target: string
+  number: number
+  title?: string
+  labels?: string[]
+}
+
+export interface JobRecord {
+  spec: JobSpec
+  status: 'pending' | 'leased' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'expired'
+  bound_machine_id?: string
+  lease_worker_id?: string
+  lease_expires_at?: string
+  attempt_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface RunRecord {
+  id: string
+  job_id: string
+  status: 'running' | 'succeeded' | 'failed' | 'cancelled'
+  outcome?: string
+  summary?: string
+  error?: string
+  started_at: string
+  ended_at?: string
+}
+
+export interface CloudStatus {
+  configured: boolean
+  url: string
+}
+
+export interface CloudConfigSummary {
+  projects: Project[]
+  repos: Repo[]
+  machines: Machine[]
+  bindings: Binding[]
+  counts: {
+    projects: number
+    repos: number
+    machines: number
+    bindings: number
+    jobs: number
+    runs: number
+  }
+}
+
+// ---- Update request types ----
+
+export interface UpdateBindingRequest {
+  machine_id?: string
+  repo_id?: string
+  project_id?: string
+}
+
+// ---- Fetch helpers ----
+
+async function cloudFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, init)
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`${res.status} ${res.statusText}: ${text}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export function fetchCloudStatus(): Promise<CloudStatus> {
+  return cloudFetch<CloudStatus>('/api/cloud/status')
+}
+
+export function fetchCloudConfig(): Promise<CloudConfigSummary> {
+  return cloudFetch<CloudConfigSummary>('/api/cloud/config')
+}
+
+export function fetchMachines(): Promise<{ machines: Machine[] }> {
+  return cloudFetch<{ machines: Machine[] }>('/api/cloud/machines')
+}
+
+export function fetchBindings(): Promise<{ bindings: Binding[] }> {
+  return cloudFetch<{ bindings: Binding[] }>('/api/cloud/bindings')
+}
+
+export function updateBinding(id: string, body: UpdateBindingRequest): Promise<Binding> {
+  return cloudFetch<Binding>(`/api/cloud/bindings/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+export function fetchJobs(): Promise<{ jobs: JobRecord[] }> {
+  return cloudFetch<{ jobs: JobRecord[] }>('/api/cloud/jobs')
+}
+
+export function fetchRuns(): Promise<{ runs: RunRecord[] }> {
+  return cloudFetch<{ runs: RunRecord[] }>('/api/cloud/runs')
+}
+
+// ---- Helpers ----
+
+export function timeAgo(iso: string | undefined): string {
+  if (!iso) return '—'
+  const t = new Date(iso).getTime()
+  if (!isFinite(t)) return '—'
+  const diff = Math.floor((Date.now() - t) / 1000)
+  if (diff < 0) return 'just now'
+  if (diff < 60) return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}min ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+/** Returns true when the machine has sent a heartbeat in the last 5 minutes. */
+export function isMachineOnline(m: Machine): boolean {
+  if (!m.last_seen_at) return false
+  const age = Date.now() - new Date(m.last_seen_at).getTime()
+  return age < 5 * 60 * 1000
+}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -16,11 +16,15 @@ import { Route as AppSettingsRouteImport } from './routes/_app.settings'
 import { Route as AppProjectsRouteImport } from './routes/_app.projects'
 import { Route as AppOperatorsRouteImport } from './routes/_app.operators'
 import { Route as AppDashboardRouteImport } from './routes/_app.dashboard'
+import { Route as AppCloudRouteImport } from './routes/_app.cloud'
 import { Route as AppReposIndexRouteImport } from './routes/_app.repos.index'
 import { Route as AppProjectsIndexRouteImport } from './routes/_app.projects.index'
 import { Route as AppReposAddRouteImport } from './routes/_app.repos.add'
 import { Route as AppReposRepoNameRouteImport } from './routes/_app.repos.$repoName'
 import { Route as AppProjectsNameRouteImport } from './routes/_app.projects.$name'
+import { Route as AppCloudMachinesRouteImport } from './routes/_app.cloud.machines'
+import { Route as AppCloudJobsRouteImport } from './routes/_app.cloud.jobs'
+import { Route as AppCloudBindingsRouteImport } from './routes/_app.cloud.bindings'
 import { Route as AppProjectsNamePilotRunsRouteImport } from './routes/_app.projects.$name_.pilot-runs'
 import { Route as AppRunsSlugIssueTsRouteImport } from './routes/_app.runs.$slug.$issue.$ts'
 
@@ -58,6 +62,11 @@ const AppDashboardRoute = AppDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => AppRoute,
 } as any)
+const AppCloudRoute = AppCloudRouteImport.update({
+  id: '/cloud',
+  path: '/cloud',
+  getParentRoute: () => AppRoute,
+} as any)
 const AppReposIndexRoute = AppReposIndexRouteImport.update({
   id: '/repos/',
   path: '/repos/',
@@ -83,6 +92,21 @@ const AppProjectsNameRoute = AppProjectsNameRouteImport.update({
   path: '/$name',
   getParentRoute: () => AppProjectsRoute,
 } as any)
+const AppCloudMachinesRoute = AppCloudMachinesRouteImport.update({
+  id: '/machines',
+  path: '/machines',
+  getParentRoute: () => AppCloudRoute,
+} as any)
+const AppCloudJobsRoute = AppCloudJobsRouteImport.update({
+  id: '/jobs',
+  path: '/jobs',
+  getParentRoute: () => AppCloudRoute,
+} as any)
+const AppCloudBindingsRoute = AppCloudBindingsRouteImport.update({
+  id: '/bindings',
+  path: '/bindings',
+  getParentRoute: () => AppCloudRoute,
+} as any)
 const AppProjectsNamePilotRunsRoute =
   AppProjectsNamePilotRunsRouteImport.update({
     id: '/$name_/pilot-runs',
@@ -97,11 +121,15 @@ const AppRunsSlugIssueTsRoute = AppRunsSlugIssueTsRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/cloud': typeof AppCloudRouteWithChildren
   '/dashboard': typeof AppDashboardRoute
   '/operators': typeof AppOperatorsRoute
   '/projects': typeof AppProjectsRouteWithChildren
   '/settings': typeof AppSettingsRoute
   '/usage': typeof AppUsageRoute
+  '/cloud/bindings': typeof AppCloudBindingsRoute
+  '/cloud/jobs': typeof AppCloudJobsRoute
+  '/cloud/machines': typeof AppCloudMachinesRoute
   '/projects/$name': typeof AppProjectsNameRoute
   '/repos/$repoName': typeof AppReposRepoNameRoute
   '/repos/add': typeof AppReposAddRoute
@@ -112,10 +140,14 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/cloud': typeof AppCloudRouteWithChildren
   '/dashboard': typeof AppDashboardRoute
   '/operators': typeof AppOperatorsRoute
   '/settings': typeof AppSettingsRoute
   '/usage': typeof AppUsageRoute
+  '/cloud/bindings': typeof AppCloudBindingsRoute
+  '/cloud/jobs': typeof AppCloudJobsRoute
+  '/cloud/machines': typeof AppCloudMachinesRoute
   '/projects/$name': typeof AppProjectsNameRoute
   '/repos/$repoName': typeof AppReposRepoNameRoute
   '/repos/add': typeof AppReposAddRoute
@@ -128,11 +160,15 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_app': typeof AppRouteWithChildren
+  '/_app/cloud': typeof AppCloudRouteWithChildren
   '/_app/dashboard': typeof AppDashboardRoute
   '/_app/operators': typeof AppOperatorsRoute
   '/_app/projects': typeof AppProjectsRouteWithChildren
   '/_app/settings': typeof AppSettingsRoute
   '/_app/usage': typeof AppUsageRoute
+  '/_app/cloud/bindings': typeof AppCloudBindingsRoute
+  '/_app/cloud/jobs': typeof AppCloudJobsRoute
+  '/_app/cloud/machines': typeof AppCloudMachinesRoute
   '/_app/projects/$name': typeof AppProjectsNameRoute
   '/_app/repos/$repoName': typeof AppReposRepoNameRoute
   '/_app/repos/add': typeof AppReposAddRoute
@@ -145,11 +181,15 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/cloud'
     | '/dashboard'
     | '/operators'
     | '/projects'
     | '/settings'
     | '/usage'
+    | '/cloud/bindings'
+    | '/cloud/jobs'
+    | '/cloud/machines'
     | '/projects/$name'
     | '/repos/$repoName'
     | '/repos/add'
@@ -160,10 +200,14 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/cloud'
     | '/dashboard'
     | '/operators'
     | '/settings'
     | '/usage'
+    | '/cloud/bindings'
+    | '/cloud/jobs'
+    | '/cloud/machines'
     | '/projects/$name'
     | '/repos/$repoName'
     | '/repos/add'
@@ -175,11 +219,15 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_app'
+    | '/_app/cloud'
     | '/_app/dashboard'
     | '/_app/operators'
     | '/_app/projects'
     | '/_app/settings'
     | '/_app/usage'
+    | '/_app/cloud/bindings'
+    | '/_app/cloud/jobs'
+    | '/_app/cloud/machines'
     | '/_app/projects/$name'
     | '/_app/repos/$repoName'
     | '/_app/repos/add'
@@ -245,6 +293,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppDashboardRouteImport
       parentRoute: typeof AppRoute
     }
+    '/_app/cloud': {
+      id: '/_app/cloud'
+      path: '/cloud'
+      fullPath: '/cloud'
+      preLoaderRoute: typeof AppCloudRouteImport
+      parentRoute: typeof AppRoute
+    }
     '/_app/repos/': {
       id: '/_app/repos/'
       path: '/repos'
@@ -280,6 +335,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppProjectsNameRouteImport
       parentRoute: typeof AppProjectsRoute
     }
+    '/_app/cloud/machines': {
+      id: '/_app/cloud/machines'
+      path: '/machines'
+      fullPath: '/cloud/machines'
+      preLoaderRoute: typeof AppCloudMachinesRouteImport
+      parentRoute: typeof AppCloudRoute
+    }
+    '/_app/cloud/jobs': {
+      id: '/_app/cloud/jobs'
+      path: '/jobs'
+      fullPath: '/cloud/jobs'
+      preLoaderRoute: typeof AppCloudJobsRouteImport
+      parentRoute: typeof AppCloudRoute
+    }
+    '/_app/cloud/bindings': {
+      id: '/_app/cloud/bindings'
+      path: '/bindings'
+      fullPath: '/cloud/bindings'
+      preLoaderRoute: typeof AppCloudBindingsRouteImport
+      parentRoute: typeof AppCloudRoute
+    }
     '/_app/projects/$name_/pilot-runs': {
       id: '/_app/projects/$name_/pilot-runs'
       path: '/$name/pilot-runs'
@@ -296,6 +372,22 @@ declare module '@tanstack/react-router' {
     }
   }
 }
+
+interface AppCloudRouteChildren {
+  AppCloudBindingsRoute: typeof AppCloudBindingsRoute
+  AppCloudJobsRoute: typeof AppCloudJobsRoute
+  AppCloudMachinesRoute: typeof AppCloudMachinesRoute
+}
+
+const AppCloudRouteChildren: AppCloudRouteChildren = {
+  AppCloudBindingsRoute: AppCloudBindingsRoute,
+  AppCloudJobsRoute: AppCloudJobsRoute,
+  AppCloudMachinesRoute: AppCloudMachinesRoute,
+}
+
+const AppCloudRouteWithChildren = AppCloudRoute._addFileChildren(
+  AppCloudRouteChildren,
+)
 
 interface AppProjectsRouteChildren {
   AppProjectsNameRoute: typeof AppProjectsNameRoute
@@ -314,6 +406,7 @@ const AppProjectsRouteWithChildren = AppProjectsRoute._addFileChildren(
 )
 
 interface AppRouteChildren {
+  AppCloudRoute: typeof AppCloudRouteWithChildren
   AppDashboardRoute: typeof AppDashboardRoute
   AppOperatorsRoute: typeof AppOperatorsRoute
   AppProjectsRoute: typeof AppProjectsRouteWithChildren
@@ -326,6 +419,7 @@ interface AppRouteChildren {
 }
 
 const AppRouteChildren: AppRouteChildren = {
+  AppCloudRoute: AppCloudRouteWithChildren,
   AppDashboardRoute: AppDashboardRoute,
   AppOperatorsRoute: AppOperatorsRoute,
   AppProjectsRoute: AppProjectsRouteWithChildren,

--- a/web/src/routes/_app.cloud.bindings.tsx
+++ b/web/src/routes/_app.cloud.bindings.tsx
@@ -1,0 +1,223 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useRef, useState } from 'react'
+import { Link2, RefreshCw, Check, X } from 'lucide-react'
+import {
+  fetchBindings,
+  fetchMachines,
+  updateBinding,
+  timeAgo,
+  type Binding,
+  type Machine,
+} from '../lib/cloudApi'
+
+export const Route = createFileRoute('/_app/cloud/bindings')({
+  component: BindingsPage,
+})
+
+interface EditState {
+  id: string
+  machine_id: string
+  saving: boolean
+}
+
+function BindingsPage() {
+  const [bindings, setBindings] = useState<Binding[]>([])
+  const [machines, setMachines] = useState<Machine[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [edit, setEdit] = useState<EditState | null>(null)
+  const selectRef = useRef<HTMLSelectElement>(null)
+
+  const load = () => {
+    setLoading(true)
+    setError(null)
+    Promise.all([fetchBindings(), fetchMachines()])
+      .then(([b, m]) => {
+        setBindings(b.bindings ?? [])
+        setMachines(m.machines ?? [])
+      })
+      .catch(e => setError(String(e)))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(load, [])
+
+  const machineLabel = (id: string) => {
+    const m = machines.find(m => m.id === id)
+    return m ? (m.display_name || m.hostname) : id
+  }
+
+  const startEdit = (b: Binding) => {
+    setEdit({ id: b.id, machine_id: b.machine_id, saving: false })
+    // Focus the select on next frame
+    requestAnimationFrame(() => selectRef.current?.focus())
+  }
+
+  const cancelEdit = () => setEdit(null)
+
+  const saveEdit = async () => {
+    if (!edit) return
+    setEdit(e => e ? { ...e, saving: true } : e)
+    try {
+      const updated = await updateBinding(edit.id, { machine_id: edit.machine_id })
+      setBindings(bs => bs.map(b => (b.id === updated.id ? updated : b)))
+      setEdit(null)
+    } catch (e) {
+      setError(String(e))
+      setEdit(e => e ? { ...e, saving: false } : e)
+    }
+  }
+
+  return (
+    <div className="px-6 py-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-base font-semibold" style={{ color: 'hsl(var(--text-high))' }}>
+          Bindings
+        </h1>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-sm border transition-colors disabled:opacity-50"
+          style={{ borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+        >
+          <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div
+          className="mb-4 px-4 py-3 rounded-md text-sm border"
+          style={{ background: 'hsl(var(--bg-panel))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-high))' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!loading && bindings.length === 0 && !error && (
+        <EmptyBindings />
+      )}
+
+      {bindings.length > 0 && (
+        <div
+          className="rounded-lg border overflow-hidden"
+          style={{ borderColor: 'hsl(var(--border))' }}
+        >
+          <table className="w-full text-sm">
+            <thead>
+              <tr
+                className="text-xs font-medium border-b"
+                style={{ background: 'hsl(var(--bg-panel))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+              >
+                <th className="text-left px-4 py-2">Repo / Project</th>
+                <th className="text-left px-4 py-2">Machine</th>
+                <th className="text-left px-4 py-2">Updated</th>
+                <th className="text-left px-4 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {bindings.map((b, i) => {
+                const isEditing = edit?.id === b.id
+                return (
+                  <tr
+                    key={b.id}
+                    className="border-b last:border-b-0"
+                    style={{ borderColor: 'hsl(var(--border))', background: i % 2 === 0 ? 'transparent' : 'hsl(var(--bg-panel) / 0.4)' }}
+                  >
+                    <td className="px-4 py-2.5 font-mono text-xs" style={{ color: 'hsl(var(--text-high))' }}>
+                      {b.repo_id || b.project_id || '—'}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      {isEditing ? (
+                        <select
+                          ref={selectRef}
+                          value={edit.machine_id}
+                          onChange={e => setEdit(ev => ev ? { ...ev, machine_id: e.target.value } : ev)}
+                          disabled={edit.saving}
+                          className="text-xs px-2 py-1 rounded border"
+                          style={{
+                            background: 'hsl(var(--bg-primary))',
+                            borderColor: 'hsl(var(--brand))',
+                            color: 'hsl(var(--text-high))',
+                          }}
+                        >
+                          {machines.map(m => (
+                            <option key={m.id} value={m.id}>
+                              {m.display_name || m.hostname}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span className="text-sm" style={{ color: 'hsl(var(--text-mid, var(--text-low)))' }}>
+                          {machineLabel(b.machine_id)}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2.5 text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+                      {timeAgo(b.updated_at)}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      {isEditing ? (
+                        <div className="flex items-center gap-1.5">
+                          <button
+                            onClick={saveEdit}
+                            disabled={edit.saving}
+                            className="p-1 rounded transition-colors disabled:opacity-50"
+                            style={{ color: 'hsl(142 76% 36%)' }}
+                            title="Save"
+                          >
+                            <Check size={14} />
+                          </button>
+                          <button
+                            onClick={cancelEdit}
+                            disabled={edit.saving}
+                            className="p-1 rounded transition-colors disabled:opacity-50"
+                            style={{ color: 'hsl(var(--text-low))' }}
+                            title="Cancel"
+                          >
+                            <X size={14} />
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => startEdit(b)}
+                          className="text-xs px-2 py-1 rounded border transition-colors"
+                          style={{ borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+                        >
+                          Rebind
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EmptyBindings() {
+  return (
+    <div
+      className="rounded-lg border px-6 py-12 text-center"
+      style={{ borderColor: 'hsl(var(--border))', background: 'hsl(var(--bg-panel))' }}
+    >
+      <Link2 size={32} className="mx-auto mb-3 opacity-30" style={{ color: 'hsl(var(--text-low))' }} />
+      <p className="text-sm font-medium mb-1" style={{ color: 'hsl(var(--text-high))' }}>
+        No bindings yet
+      </p>
+      <p className="text-xs mb-4" style={{ color: 'hsl(var(--text-low))' }}>
+        Bind a repo or project to a machine to route jobs to it.
+      </p>
+      <div
+        className="inline-block text-left rounded-md px-3 py-2 font-mono text-xs border"
+        style={{ background: 'hsl(var(--bg-primary))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+      >
+        clawflow cloud bind --repo owner/repo --machine &lt;id&gt;
+      </div>
+    </div>
+  )
+}

--- a/web/src/routes/_app.cloud.jobs.tsx
+++ b/web/src/routes/_app.cloud.jobs.tsx
@@ -1,0 +1,256 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { Layers, RefreshCw, ChevronDown, ChevronUp } from 'lucide-react'
+import { fetchJobs, fetchRuns, timeAgo, type JobRecord, type RunRecord } from '../lib/cloudApi'
+
+export const Route = createFileRoute('/_app/cloud/jobs')({
+  component: JobsPage,
+})
+
+type JobStatus = JobRecord['status'] | 'all'
+
+const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }> = {
+  pending:   { bg: 'hsl(38 92% 50% / 0.12)', text: 'hsl(38 92% 44%)', border: 'hsl(38 92% 50% / 0.3)' },
+  leased:    { bg: 'hsl(210 100% 56% / 0.12)', text: 'hsl(210 100% 48%)', border: 'hsl(210 100% 56% / 0.3)' },
+  running:   { bg: 'hsl(262 80% 60% / 0.12)', text: 'hsl(262 80% 52%)', border: 'hsl(262 80% 60% / 0.3)' },
+  succeeded: { bg: 'hsl(142 76% 36% / 0.12)', text: 'hsl(142 76% 32%)', border: 'hsl(142 76% 36% / 0.3)' },
+  failed:    { bg: 'hsl(0 84% 60% / 0.12)', text: 'hsl(0 84% 54%)', border: 'hsl(0 84% 60% / 0.3)' },
+  cancelled: { bg: 'hsl(var(--bg-panel))', text: 'hsl(var(--text-low))', border: 'hsl(var(--border))' },
+  expired:   { bg: 'hsl(var(--bg-panel))', text: 'hsl(var(--text-low))', border: 'hsl(var(--border))' },
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors = STATUS_COLORS[status] ?? STATUS_COLORS.cancelled
+  return (
+    <span
+      className="inline-flex items-center text-xs px-2 py-0.5 rounded-full font-medium"
+      style={{ background: colors.bg, color: colors.text, border: `1px solid ${colors.border}` }}
+    >
+      {status}
+    </span>
+  )
+}
+
+function JobsPage() {
+  const [jobs, setJobs] = useState<JobRecord[]>([])
+  const [runs, setRuns] = useState<RunRecord[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filter, setFilter] = useState<JobStatus>('all')
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const load = () => {
+    setLoading(true)
+    setError(null)
+    Promise.all([fetchJobs(), fetchRuns()])
+      .then(([j, r]) => {
+        setJobs(j.jobs ?? [])
+        setRuns(r.runs ?? [])
+      })
+      .catch(e => setError(String(e)))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(load, [])
+
+  const allStatuses: JobStatus[] = ['all', 'pending', 'leased', 'running', 'succeeded', 'failed', 'cancelled', 'expired']
+  const filtered = filter === 'all' ? jobs : jobs.filter(j => j.status === filter)
+  const runsForJob = (jobId: string) => runs.filter(r => r.job_id === jobId)
+  const toggleExpand = (id: string) =>
+    setExpanded(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+
+  return (
+    <div className="px-6 py-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-base font-semibold" style={{ color: 'hsl(var(--text-high))' }}>
+          Jobs &amp; Runs
+        </h1>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-sm border transition-colors disabled:opacity-50"
+          style={{ borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+        >
+          <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Status filter chips */}
+      <div className="flex flex-wrap gap-1.5 mb-4">
+        {allStatuses.map(s => {
+          const active = filter === s
+          const colors = s !== 'all' ? (STATUS_COLORS[s] ?? STATUS_COLORS.cancelled) : null
+          return (
+            <button
+              key={s}
+              onClick={() => setFilter(s)}
+              className="text-xs px-2.5 py-1 rounded-full transition-colors border font-medium"
+              style={{
+                background: active ? (colors?.bg ?? 'hsl(var(--brand) / 0.1)') : 'transparent',
+                color: active ? (colors?.text ?? 'hsl(var(--brand))') : 'hsl(var(--text-low))',
+                borderColor: active ? (colors?.border ?? 'hsl(var(--brand) / 0.4)') : 'hsl(var(--border))',
+              }}
+            >
+              {s}
+              {s !== 'all' && (
+                <span className="ml-1 opacity-70">
+                  {jobs.filter(j => j.status === s).length}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {error && (
+        <div
+          className="mb-4 px-4 py-3 rounded-md text-sm border"
+          style={{ background: 'hsl(var(--bg-panel))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-high))' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!loading && filtered.length === 0 && !error && (
+        filter === 'all' ? <EmptyJobs /> : (
+          <div className="text-center py-12 text-sm" style={{ color: 'hsl(var(--text-low))' }}>
+            No {filter} jobs
+          </div>
+        )
+      )}
+
+      {filtered.length > 0 && (
+        <div className="space-y-2">
+          {filtered.map(job => {
+            const isOpen = expanded.has(job.spec.job_id)
+            const jobRuns = runsForJob(job.spec.job_id)
+            return (
+              <div
+                key={job.spec.job_id}
+                className="rounded-lg border overflow-hidden"
+                style={{ borderColor: 'hsl(var(--border))' }}
+              >
+                {/* Job row */}
+                <button
+                  className="w-full text-left px-4 py-3 flex items-center gap-3 transition-colors hover:bg-[hsl(var(--bg-panel)/0.5)]"
+                  onClick={() => toggleExpand(job.spec.job_id)}
+                >
+                  <StatusBadge status={job.status} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+                        {job.spec.repo}
+                      </span>
+                      <span className="text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+                        #{job.spec.number}
+                      </span>
+                      <span
+                        className="text-xs px-1.5 py-0.5 rounded"
+                        style={{ background: 'hsl(var(--bg-panel))', color: 'hsl(var(--text-low))', border: '1px solid hsl(var(--border))' }}
+                      >
+                        {job.spec.operator}
+                      </span>
+                    </div>
+                    {job.spec.title && (
+                      <p className="text-sm truncate mt-0.5" style={{ color: 'hsl(var(--text-high))' }}>
+                        {job.spec.title}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    <span className="text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+                      {timeAgo(job.updated_at)}
+                    </span>
+                    {jobRuns.length > 0 && (
+                      <span className="text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+                        {jobRuns.length} run{jobRuns.length !== 1 ? 's' : ''}
+                      </span>
+                    )}
+                    {isOpen ? <ChevronUp size={14} style={{ color: 'hsl(var(--text-low))' }} /> : <ChevronDown size={14} style={{ color: 'hsl(var(--text-low))' }} />}
+                  </div>
+                </button>
+
+                {/* Run details drawer */}
+                {isOpen && (
+                  <div
+                    className="border-t px-4 py-3"
+                    style={{ borderColor: 'hsl(var(--border))', background: 'hsl(var(--bg-panel) / 0.5)' }}
+                  >
+                    <div className="grid grid-cols-3 gap-3 text-xs mb-3">
+                      <div>
+                        <p className="font-medium mb-0.5" style={{ color: 'hsl(var(--text-low))' }}>Job ID</p>
+                        <p className="font-mono" style={{ color: 'hsl(var(--text-high))' }}>{job.spec.job_id}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium mb-0.5" style={{ color: 'hsl(var(--text-low))' }}>Attempts</p>
+                        <p style={{ color: 'hsl(var(--text-high))' }}>{job.attempt_count}</p>
+                      </div>
+                      <div>
+                        <p className="font-medium mb-0.5" style={{ color: 'hsl(var(--text-low))' }}>Created</p>
+                        <p style={{ color: 'hsl(var(--text-high))' }}>{timeAgo(job.created_at)}</p>
+                      </div>
+                      {job.bound_machine_id && (
+                        <div>
+                          <p className="font-medium mb-0.5" style={{ color: 'hsl(var(--text-low))' }}>Machine</p>
+                          <p className="font-mono" style={{ color: 'hsl(var(--text-high))' }}>{job.bound_machine_id}</p>
+                        </div>
+                      )}
+                    </div>
+
+                    {jobRuns.length > 0 ? (
+                      <div>
+                        <p className="text-xs font-medium mb-2" style={{ color: 'hsl(var(--text-low))' }}>Runs</p>
+                        <div className="space-y-1.5">
+                          {jobRuns.map(run => (
+                            <div
+                              key={run.id}
+                              className="rounded-md px-3 py-2 flex items-center gap-3 text-xs border"
+                              style={{ borderColor: 'hsl(var(--border))', background: 'hsl(var(--bg-primary))' }}
+                            >
+                              <StatusBadge status={run.status} />
+                              <span className="font-mono" style={{ color: 'hsl(var(--text-low))' }}>{run.id}</span>
+                              {run.outcome && (
+                                <span style={{ color: 'hsl(var(--text-mid, var(--text-low)))' }}>{run.outcome}</span>
+                              )}
+                              <span className="ml-auto" style={{ color: 'hsl(var(--text-low))' }}>
+                                {run.ended_at ? timeAgo(run.ended_at) : 'running…'}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-xs" style={{ color: 'hsl(var(--text-low))' }}>No runs recorded yet.</p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EmptyJobs() {
+  return (
+    <div
+      className="rounded-lg border px-6 py-12 text-center"
+      style={{ borderColor: 'hsl(var(--border))', background: 'hsl(var(--bg-panel))' }}
+    >
+      <Layers size={32} className="mx-auto mb-3 opacity-30" style={{ color: 'hsl(var(--text-low))' }} />
+      <p className="text-sm font-medium mb-1" style={{ color: 'hsl(var(--text-high))' }}>
+        No jobs queued
+      </p>
+      <p className="text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+        Jobs appear here when issues or PRs match an operator&apos;s trigger conditions.
+      </p>
+    </div>
+  )
+}

--- a/web/src/routes/_app.cloud.machines.tsx
+++ b/web/src/routes/_app.cloud.machines.tsx
@@ -1,0 +1,160 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useEffect, useState } from 'react'
+import { Monitor, RefreshCw } from 'lucide-react'
+import { fetchMachines, isMachineOnline, timeAgo, type Machine } from '../lib/cloudApi'
+
+export const Route = createFileRoute('/_app/cloud/machines')({
+  component: MachinesPage,
+})
+
+function MachinesPage() {
+  const [machines, setMachines] = useState<Machine[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = () => {
+    setLoading(true)
+    setError(null)
+    fetchMachines()
+      .then(r => setMachines(r.machines ?? []))
+      .catch(e => setError(String(e)))
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(load, [])
+
+  return (
+    <div className="px-6 py-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-5">
+        <h1 className="text-base font-semibold" style={{ color: 'hsl(var(--text-high))' }}>
+          Machines
+        </h1>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="flex items-center gap-1.5 text-xs px-2.5 py-1.5 rounded-sm border transition-colors disabled:opacity-50"
+          style={{ borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+        >
+          <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div
+          className="mb-4 px-4 py-3 rounded-md text-sm border"
+          style={{ background: 'hsl(var(--bg-panel))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-high))' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!loading && machines.length === 0 && !error && (
+        <EmptyMachines />
+      )}
+
+      {machines.length > 0 && (
+        <div
+          className="rounded-lg border overflow-hidden"
+          style={{ borderColor: 'hsl(var(--border))' }}
+        >
+          <table className="w-full text-sm">
+            <thead>
+              <tr
+                className="text-xs font-medium border-b"
+                style={{ background: 'hsl(var(--bg-panel))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+              >
+                <th className="text-left px-4 py-2">Status</th>
+                <th className="text-left px-4 py-2">Hostname</th>
+                <th className="text-left px-4 py-2">Display name</th>
+                <th className="text-left px-4 py-2">Capabilities</th>
+                <th className="text-left px-4 py-2">Last seen</th>
+                <th className="text-left px-4 py-2">Version</th>
+              </tr>
+            </thead>
+            <tbody>
+              {machines.map((m, i) => {
+                const online = isMachineOnline(m)
+                return (
+                  <tr
+                    key={m.id}
+                    className="border-b last:border-b-0"
+                    style={{ borderColor: 'hsl(var(--border))', background: i % 2 === 0 ? 'transparent' : 'hsl(var(--bg-panel) / 0.4)' }}
+                  >
+                    <td className="px-4 py-2.5">
+                      <span
+                        className="inline-flex items-center gap-1.5 text-xs px-2 py-0.5 rounded-full font-medium"
+                        style={{
+                          background: online ? 'hsl(142 76% 36% / 0.15)' : 'hsl(var(--bg-panel))',
+                          color: online ? 'hsl(142 76% 36%)' : 'hsl(var(--text-low))',
+                          border: `1px solid ${online ? 'hsl(142 76% 36% / 0.3)' : 'hsl(var(--border))'}`,
+                        }}
+                      >
+                        <span
+                          className="w-1.5 h-1.5 rounded-full"
+                          style={{ background: online ? 'hsl(142 76% 36%)' : 'hsl(var(--text-low))' }}
+                        />
+                        {online ? 'Online' : 'Offline'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-xs" style={{ color: 'hsl(var(--text-high))' }}>
+                      {m.hostname}
+                    </td>
+                    <td className="px-4 py-2.5 text-sm" style={{ color: 'hsl(var(--text-mid, var(--text-low)))' }}>
+                      {m.display_name || '—'}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      <div className="flex flex-wrap gap-1">
+                        {(m.capabilities ?? []).map(cap => (
+                          <span
+                            key={cap}
+                            className="text-xs px-1.5 py-0.5 rounded"
+                            style={{ background: 'hsl(var(--bg-panel))', color: 'hsl(var(--text-low))', border: '1px solid hsl(var(--border))' }}
+                          >
+                            {cap}
+                          </span>
+                        ))}
+                        {(m.capabilities ?? []).length === 0 && (
+                          <span style={{ color: 'hsl(var(--text-low))' }}>—</span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-2.5 text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+                      {timeAgo(m.last_seen_at)}
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-xs" style={{ color: 'hsl(var(--text-low))' }}>
+                      {m.version || '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EmptyMachines() {
+  return (
+    <div
+      className="rounded-lg border px-6 py-12 text-center"
+      style={{ borderColor: 'hsl(var(--border))', background: 'hsl(var(--bg-panel))' }}
+    >
+      <Monitor size={32} className="mx-auto mb-3 opacity-30" style={{ color: 'hsl(var(--text-low))' }} />
+      <p className="text-sm font-medium mb-1" style={{ color: 'hsl(var(--text-high))' }}>
+        No machines registered
+      </p>
+      <p className="text-xs mb-4" style={{ color: 'hsl(var(--text-low))' }}>
+        Register a machine to start running operators in the cloud.
+      </p>
+      <div
+        className="inline-block text-left rounded-md px-3 py-2 font-mono text-xs border"
+        style={{ background: 'hsl(var(--bg-primary))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-low))' }}
+      >
+        clawflow worker register
+      </div>
+    </div>
+  )
+}

--- a/web/src/routes/_app.cloud.tsx
+++ b/web/src/routes/_app.cloud.tsx
@@ -1,0 +1,75 @@
+import { createFileRoute, Outlet, Link } from '@tanstack/react-router'
+import { Cloud } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { fetchCloudStatus, type CloudStatus } from '../lib/cloudApi'
+
+export const Route = createFileRoute('/_app/cloud')({
+  component: CloudLayout,
+})
+
+function CloudLayout() {
+  const [status, setStatus] = useState<CloudStatus | null>(null)
+
+  useEffect(() => {
+    fetchCloudStatus()
+      .then(setStatus)
+      .catch(() => setStatus({ configured: false, url: '' }))
+  }, [])
+
+  if (status && !status.configured) {
+    return (
+      <div className="max-w-2xl mx-auto px-6 py-20 text-center">
+        <Cloud className="mx-auto mb-4 opacity-30" style={{ color: 'hsl(var(--text-low))' }} size={40} />
+        <h1 className="text-xl font-semibold mb-2" style={{ color: 'hsl(var(--text-high))' }}>
+          Cloud not configured
+        </h1>
+        <p className="text-sm mb-6" style={{ color: 'hsl(var(--text-low))' }}>
+          Connect to a ClawFlow cloud instance to manage machines, bindings, and jobs.
+        </p>
+        <div
+          className="text-left rounded-lg px-4 py-3 font-mono text-xs border"
+          style={{ background: 'hsl(var(--bg-panel))', borderColor: 'hsl(var(--border))', color: 'hsl(var(--text-mid, var(--text-low)))' }}
+        >
+          <p className="mb-1" style={{ color: 'hsl(var(--text-low))' }}># Register this machine with a cloud instance</p>
+          <p>clawflow worker register --url https://your-cloud.example.com</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {/* Cloud sub-nav */}
+      <div
+        className="border-b px-6 flex gap-1 h-10 items-center"
+        style={{ background: 'hsl(var(--bg-primary))', borderColor: 'hsl(var(--border))' }}
+      >
+        <Link
+          to="/cloud/machines"
+          className="text-sm font-medium px-2.5 py-1 rounded-sm transition-colors"
+          style={{ color: 'hsl(var(--text-low))' }}
+          activeProps={{ style: { color: 'hsl(var(--brand))', background: 'hsl(var(--brand) / 0.08)' } }}
+        >
+          Machines
+        </Link>
+        <Link
+          to="/cloud/bindings"
+          className="text-sm font-medium px-2.5 py-1 rounded-sm transition-colors"
+          style={{ color: 'hsl(var(--text-low))' }}
+          activeProps={{ style: { color: 'hsl(var(--brand))', background: 'hsl(var(--brand) / 0.08)' } }}
+        >
+          Bindings
+        </Link>
+        <Link
+          to="/cloud/jobs"
+          className="text-sm font-medium px-2.5 py-1 rounded-sm transition-colors"
+          style={{ color: 'hsl(var(--text-low))' }}
+          activeProps={{ style: { color: 'hsl(var(--brand))', background: 'hsl(var(--brand) / 0.08)' } }}
+        >
+          Jobs
+        </Link>
+      </div>
+      <Outlet />
+    </div>
+  )
+}

--- a/web/src/routes/_app.tsx
+++ b/web/src/routes/_app.tsx
@@ -5,6 +5,7 @@ import { useTheme } from '../lib/useTheme'
 import { ChatProvider, useChatDrawer } from '../lib/chatContext'
 import { ChatDrawer } from '../components/ChatDrawer'
 import { SyncPopover } from '../components/SyncPopover'
+import { fetchCloudStatus } from '../lib/cloudApi'
 
 export const Route = createFileRoute('/_app')({
   component: AppLayout,
@@ -18,6 +19,7 @@ function AppLayout() {
   const [updating, setUpdating] = useState(false)
   const [restarting, setRestarting] = useState(false)
   const [showTooltip, setShowTooltip] = useState(false)
+  const [cloudConfigured, setCloudConfigured] = useState(false)
 
   // Check version once on mount
   useEffect(() => {
@@ -31,6 +33,13 @@ function AppLayout() {
         }
       })
       .catch(() => {})
+  }, [])
+
+  // Check cloud configuration once on mount so we can show/hide the Cloud nav
+  useEffect(() => {
+    fetchCloudStatus()
+      .then(s => setCloudConfigured(s.configured))
+      .catch(() => setCloudConfigured(false))
   }, [])
 
   const triggerUpdate = useCallback(() => {
@@ -190,6 +199,17 @@ function AppLayout() {
               >
                 Settings
               </Link>
+              {cloudConfigured && (
+                <Link
+                  to="/cloud/machines"
+                  className="text-sm font-medium px-2.5 py-1 rounded-sm transition-colors"
+                  style={{ color: 'hsl(var(--text-low))' }}
+                  activeOptions={{ includeSearch: false, exact: false }}
+                  activeProps={{ style: { color: 'hsl(var(--brand))', background: 'hsl(var(--brand) / 0.08)' } }}
+                >
+                  Cloud
+                </Link>
+              )}
             </nav>
           </div>
 


### PR DESCRIPTION
Fixes #155

## What changed and why

Adds a **Cloud** section to the embedded web dashboard that visualises SaaS worker state — registered machines, repo/project→machine bindings, and the job/run queue — by proxying calls through the Go web server to the configured cloud instance.

### Go backend (`internal/api/cloud.go` + `cmd/clawflow/commands/web.go`)

- New `cloudProxy` helper that loads `CloudURL` + `CloudAccessToken` from credentials, forwards the request with a bearer token header, and streams the response back. The token never leaves the server.
- Six new proxy endpoints registered in the web mux:
  - `GET /api/cloud/status` — returns `{configured, url}` so the nav entry can be shown/hidden.
  - `GET /api/cloud/machines`
  - `GET|POST /api/cloud/bindings`, `GET|PATCH /api/cloud/bindings/{id}`
  - `GET /api/cloud/jobs`
  - `GET /api/cloud/runs`
- Returns `503` with `{"error":"cloud not configured"}` when no token is set, keeping local-only users unaffected.

### Frontend (`web/src/`)

| File | Purpose |
|------|---------|
| `lib/cloudApi.ts` | TypeScript types mirroring `internal/cloud/types.go` + typed fetch helpers |
| `routes/_app.cloud.tsx` | Layout with Machines / Bindings / Jobs sub-nav; "not configured" empty state |
| `routes/_app.cloud.machines.tsx` | Table: hostname, display name, capabilities chips, online/offline pill (5-min window), last-seen age |
| `routes/_app.cloud.bindings.tsx` | Table with inline machine-rebind via optimistic `PATCH` — no full reload |
| `routes/_app.cloud.jobs.tsx` | Job list with status-filter chips for all six states; click-to-expand run detail drawer |
| `routes/_app.tsx` | Cloud nav link added, rendered only when `/api/cloud/status` returns `configured: true` |
| `routeTree.gen.ts` | Updated route tree |

### Testing

- `go test ./internal/api/... ./internal/cloud/...` — passes.
- `npm run build` (Vite + `tsc --noEmit`) — passes, no TypeScript errors.
- Existing local dashboard routes untouched; Cloud entry is hidden for local-only users.

> **Note:** This PR is stacked on top of `fix/issue-153` (cloud REST endpoints). Merge order: #153 → this PR.