### PR TITLE
PR 4 sub 1: cloud usage storage (run_usage + chat_usage tables)

### DIFF
--- a/internal/cloud/chat/chat_test.go
+++ b/internal/cloud/chat/chat_test.go
@@ -442,3 +442,97 @@ func TestListSessionsScopedToUser(t *testing.T) {
 		t.Errorf("bob sees %d sessions, want 0", len(listed.Sessions))
 	}
 }
+
+// TestWorkerUsageEndpoint: worker POSTs the terminal token / cost
+// breakdown for a chat session; the store row gets denorm fields
+// (user_id, machine_id, repo) from the session registry; 404 on unknown
+// session; 400 on missing Usage body.
+func TestWorkerUsageEndpoint(t *testing.T) {
+	t.Parallel()
+	h, store := newTestHandler(t)
+	makeBoundRepo(t, store, "acme/widgets", "machine-1")
+	srv := newTestServer(t, h, &cloud.User{ID: "u-alice", Login: "alice"})
+
+	// Create a session (this populates the in-memory session registry
+	// with user/machine/repo the usage endpoint will look up).
+	body := jsonBody(t, map[string]string{"repo": "acme/widgets", "message": "hi"})
+	cResp, err := http.Post(srv.URL+"/api/cloud/chat/sessions", "application/json", body)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(cResp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	cResp.Body.Close()
+
+	// Happy path.
+	usageReq := cloud.ChatUsageRequest{
+		Usage: &cloud.Usage{
+			DurationMs:   4500,
+			NumTurns:     1,
+			TotalCostUSD: 0.0321,
+			InputTokens:  420,
+			OutputTokens: 88,
+			ModelUsage: map[string]cloud.ModelUsage{
+				"claude-opus-4-7": {InputTokens: 420, OutputTokens: 88, CostUSD: 0.0321},
+			},
+		},
+	}
+	uResp, err := http.Post(
+		srv.URL+"/api/worker/chat/sessions/"+created.ID+"/usage",
+		"application/json", jsonBody(t, usageReq))
+	if err != nil {
+		t.Fatalf("usage post: %v", err)
+	}
+	uResp.Body.Close()
+	if uResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("usage status = %d, want 204", uResp.StatusCode)
+	}
+
+	got := store.GetChatUsage(created.ID)
+	if got == nil {
+		t.Fatal("GetChatUsage returned nil after worker upload")
+	}
+	if got.UserID != "u-alice" {
+		t.Errorf("denorm user_id = %q, want u-alice", got.UserID)
+	}
+	if got.MachineID != "machine-1" {
+		t.Errorf("denorm machine_id = %q, want machine-1", got.MachineID)
+	}
+	if got.Repo != "acme/widgets" {
+		t.Errorf("denorm repo = %q", got.Repo)
+	}
+	if got.TotalCostUSD != 0.0321 || got.InputTokens != 420 {
+		t.Errorf("usage round-trip mismatch: %+v", got)
+	}
+	if got.ModelUsage["claude-opus-4-7"].CostUSD != 0.0321 {
+		t.Errorf("model usage lost: %+v", got.ModelUsage)
+	}
+
+	// Unknown session.
+	resp404, err := http.Post(
+		srv.URL+"/api/worker/chat/sessions/does-not-exist/usage",
+		"application/json", jsonBody(t, usageReq))
+	if err != nil {
+		t.Fatalf("404 post: %v", err)
+	}
+	resp404.Body.Close()
+	if resp404.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown session status = %d, want 404", resp404.StatusCode)
+	}
+
+	// Missing usage body.
+	resp400, err := http.Post(
+		srv.URL+"/api/worker/chat/sessions/"+created.ID+"/usage",
+		"application/json", jsonBody(t, cloud.ChatUsageRequest{Usage: nil}))
+	if err != nil {
+		t.Fatalf("400 post: %v", err)
+	}
+	resp400.Body.Close()
+	if resp400.StatusCode != http.StatusBadRequest {
+		t.Errorf("missing usage status = %d, want 400", resp400.StatusCode)
+	}
+}

--- a/internal/cloud/chat/handler.go
+++ b/internal/cloud/chat/handler.go
@@ -106,6 +106,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// Worker side — machine-auth (kind=machine Bearer).
 	mountMachine("POST /api/worker/chat/poll", h.handlePoll)
 	mountMachine("POST /api/worker/chat/sessions/{id}/events", h.handleWorkerEvents)
+	mountMachine("POST /api/worker/chat/sessions/{id}/usage", h.handleWorkerUsage)
 }
 
 // ChatPath is the URL prefix the handler serves under. Kept for
@@ -358,6 +359,49 @@ func (h *Handler) handlePoll(w http.ResponseWriter, r *http.Request) {
 		// Client gave up first (e.g. shutdown). 499-ish.
 		w.WriteHeader(http.StatusNoContent)
 	}
+}
+
+// handleWorkerUsage receives the terminal token / cost breakdown for
+// one chat session, posted by the worker after its claude subprocess
+// exits. The session_id comes from the URL; user_id / machine_id / repo
+// are looked up server-side from the active session registry so the
+// worker can't claim usage for a session it doesn't own.
+func (h *Handler) handleWorkerUsage(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	var req cloud.ChatUsageRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if req.Usage == nil {
+		writeError(w, http.StatusBadRequest, "usage is required")
+		return
+	}
+
+	h.sessionsMu.Lock()
+	s, ok := h.sessions[id]
+	h.sessionsMu.Unlock()
+	if !ok {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	if err := h.cfg.Store.AddChatUsage(cloud.AddChatUsageInput{
+		SessionID: s.ID,
+		UserID:    s.UserID,
+		MachineID: s.MachineID,
+		Repo:      s.Repo,
+		Usage:     req.Usage,
+		EndedAt:   h.cfg.Now(),
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // handleWorkerEvents accepts a batch of ChatEvents pushed by the

--- a/internal/cloud/migrations/0004_usage.sql
+++ b/internal/cloud/migrations/0004_usage.sql
@@ -1,0 +1,55 @@
+-- 0004_usage.sql: per-run / per-chat-session token & cost storage.
+--
+-- Worker uploads `cloud.Usage` after a claude subprocess exits; cloud
+-- stores it here so /api/cloud/usage/summary (PR 4 / sub 4) can render
+-- the same shape the local `clawflow web` Usage page already speaks.
+--
+-- Denormalized columns (repo, operator, user_id, machine_id) live on
+-- the row itself so aggregation can GROUP BY without joining jobs /
+-- runs / bindings. Per-model breakdown is stored as JSON because its
+-- arity is per-claude-version and not worth a side table for the
+-- five-or-fewer models a typical run touches.
+
+-- user_id is stored as plain TEXT (no FK) because: (a) cloud authorises
+-- by *current* user from the auth context, not by a stored FK, and (b)
+-- a deleted user shouldn't cascade-delete historical usage. Same for
+-- the run_id reference — we want usage to outlive a runs-table cleanup.
+CREATE TABLE IF NOT EXISTS run_usage (
+    run_id                       TEXT PRIMARY KEY,
+    user_id                      TEXT NOT NULL DEFAULT '',
+    machine_id                   TEXT NOT NULL DEFAULT '',
+    repo                         TEXT NOT NULL DEFAULT '',
+    operator                     TEXT NOT NULL DEFAULT '',
+    duration_ms                  INTEGER NOT NULL DEFAULT 0,
+    num_turns                    INTEGER NOT NULL DEFAULT 0,
+    total_cost_usd               REAL NOT NULL DEFAULT 0,
+    input_tokens                 INTEGER NOT NULL DEFAULT 0,
+    output_tokens                INTEGER NOT NULL DEFAULT 0,
+    cache_read_input_tokens      INTEGER NOT NULL DEFAULT 0,
+    cache_creation_input_tokens  INTEGER NOT NULL DEFAULT 0,
+    model_usage_json             TEXT NOT NULL DEFAULT '{}',
+    ended_at                     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_usage_user_ended ON run_usage (user_id, ended_at);
+CREATE INDEX IF NOT EXISTS idx_run_usage_repo       ON run_usage (repo);
+CREATE INDEX IF NOT EXISTS idx_run_usage_operator   ON run_usage (operator);
+
+CREATE TABLE IF NOT EXISTS chat_usage (
+    session_id                   TEXT PRIMARY KEY,
+    user_id                      TEXT NOT NULL,
+    machine_id                   TEXT NOT NULL DEFAULT '',
+    repo                         TEXT NOT NULL DEFAULT '',
+    duration_ms                  INTEGER NOT NULL DEFAULT 0,
+    num_turns                    INTEGER NOT NULL DEFAULT 0,
+    total_cost_usd               REAL NOT NULL DEFAULT 0,
+    input_tokens                 INTEGER NOT NULL DEFAULT 0,
+    output_tokens                INTEGER NOT NULL DEFAULT 0,
+    cache_read_input_tokens      INTEGER NOT NULL DEFAULT 0,
+    cache_creation_input_tokens  INTEGER NOT NULL DEFAULT 0,
+    model_usage_json             TEXT NOT NULL DEFAULT '{}',
+    ended_at                     TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_usage_user_ended ON chat_usage (user_id, ended_at);
+CREATE INDEX IF NOT EXISTS idx_chat_usage_repo       ON chat_usage (repo);

--- a/internal/cloud/sqlite_store.go
+++ b/internal/cloud/sqlite_store.go
@@ -374,9 +374,12 @@ func (s *SQLiteStore) AppendRunEvents(runID string, events []RunEvent) error {
 }
 
 // FinishRun marks a run as completed (succeeded, failed, etc.) and updates the
-// parent job status accordingly.
+// parent job status accordingly. If req.Usage is non-nil it is also
+// persisted to run_usage with denormalized repo/operator from the job spec
+// so the aggregation endpoint (sub 4) can GROUP BY without joins.
 func (s *SQLiteStore) FinishRun(runID string, req FinishRunRequest) error {
-	now := sqliteTime(time.Now().UTC())
+	nowT := time.Now().UTC()
+	now := sqliteTime(nowT)
 	status := req.Status
 	if status == "" {
 		status = JobStatusFailed
@@ -398,11 +401,196 @@ func (s *SQLiteStore) FinishRun(runID string, req FinishRunRequest) error {
 		return err
 	}
 
-	_, err := s.db.Exec(
+	if _, err := s.db.Exec(
 		`UPDATE jobs SET status = ?, lease_worker_id = '', lease_expires_at = NULL, updated_at = ? WHERE id = ?`,
 		status, now, jobID,
+	); err != nil {
+		return err
+	}
+
+	if req.Usage != nil {
+		var (
+			specJSON         string
+			repo, operator   string
+			boundMachineID   string
+		)
+		if err := s.db.QueryRow(
+			`SELECT spec_json, bound_machine_id FROM jobs WHERE id = ?`, jobID,
+		).Scan(&specJSON, &boundMachineID); err == nil {
+			var spec JobSpec
+			if json.Unmarshal([]byte(specJSON), &spec) == nil {
+				repo = spec.Repo
+				operator = spec.Operator
+			}
+		}
+		if err := s.upsertRunUsage(runID, repo, operator, boundMachineID, nowT, req.Usage); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// upsertRunUsage inserts or replaces a run_usage row. Idempotent on
+// run_id; a worker retry overwrites with the (presumably more complete)
+// later upload. user_id is left NULL — derived from machine→owner in a
+// follow-up PR once machines carry an owner column.
+func (s *SQLiteStore) upsertRunUsage(runID, repo, operator, machineID string, endedAt time.Time, u *Usage) error {
+	modelJSON, err := json.Marshal(u.ModelUsage)
+	if err != nil {
+		modelJSON = []byte("{}")
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO run_usage (
+			run_id, machine_id, repo, operator,
+			duration_ms, num_turns, total_cost_usd,
+			input_tokens, output_tokens,
+			cache_read_input_tokens, cache_creation_input_tokens,
+			model_usage_json, ended_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id) DO UPDATE SET
+			machine_id = excluded.machine_id,
+			repo = excluded.repo,
+			operator = excluded.operator,
+			duration_ms = excluded.duration_ms,
+			num_turns = excluded.num_turns,
+			total_cost_usd = excluded.total_cost_usd,
+			input_tokens = excluded.input_tokens,
+			output_tokens = excluded.output_tokens,
+			cache_read_input_tokens = excluded.cache_read_input_tokens,
+			cache_creation_input_tokens = excluded.cache_creation_input_tokens,
+			model_usage_json = excluded.model_usage_json,
+			ended_at = excluded.ended_at`,
+		runID, machineID, repo, operator,
+		u.DurationMs, u.NumTurns, u.TotalCostUSD,
+		u.InputTokens, u.OutputTokens,
+		u.CacheReadInputTokens, u.CacheCreationInputTokens,
+		string(modelJSON), sqliteTime(endedAt),
 	)
 	return err
+}
+
+// AddChatUsage persists one chat session's token / cost breakdown.
+// Idempotent on session_id.
+func (s *SQLiteStore) AddChatUsage(in AddChatUsageInput) error {
+	if in.SessionID == "" {
+		return fmt.Errorf("session_id is required")
+	}
+	if in.Usage == nil {
+		return fmt.Errorf("usage is required")
+	}
+	if in.UserID == "" {
+		return fmt.Errorf("user_id is required")
+	}
+	endedAt := in.EndedAt
+	if endedAt.IsZero() {
+		endedAt = time.Now().UTC()
+	}
+	modelJSON, err := json.Marshal(in.Usage.ModelUsage)
+	if err != nil {
+		modelJSON = []byte("{}")
+	}
+	_, err = s.db.Exec(
+		`INSERT INTO chat_usage (
+			session_id, user_id, machine_id, repo,
+			duration_ms, num_turns, total_cost_usd,
+			input_tokens, output_tokens,
+			cache_read_input_tokens, cache_creation_input_tokens,
+			model_usage_json, ended_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(session_id) DO UPDATE SET
+			user_id = excluded.user_id,
+			machine_id = excluded.machine_id,
+			repo = excluded.repo,
+			duration_ms = excluded.duration_ms,
+			num_turns = excluded.num_turns,
+			total_cost_usd = excluded.total_cost_usd,
+			input_tokens = excluded.input_tokens,
+			output_tokens = excluded.output_tokens,
+			cache_read_input_tokens = excluded.cache_read_input_tokens,
+			cache_creation_input_tokens = excluded.cache_creation_input_tokens,
+			model_usage_json = excluded.model_usage_json,
+			ended_at = excluded.ended_at`,
+		in.SessionID, in.UserID, in.MachineID, in.Repo,
+		in.Usage.DurationMs, in.Usage.NumTurns, in.Usage.TotalCostUSD,
+		in.Usage.InputTokens, in.Usage.OutputTokens,
+		in.Usage.CacheReadInputTokens, in.Usage.CacheCreationInputTokens,
+		string(modelJSON), sqliteTime(endedAt),
+	)
+	return err
+}
+
+// GetRunUsage returns the run_usage row for a given run_id, or nil.
+func (s *SQLiteStore) GetRunUsage(runID string) *UsageRecord {
+	return s.queryUsage(true, runID)
+}
+
+// GetChatUsage returns the chat_usage row for a given session_id, or nil.
+func (s *SQLiteStore) GetChatUsage(sessionID string) *UsageRecord {
+	return s.queryUsage(false, sessionID)
+}
+
+func (s *SQLiteStore) queryUsage(isRun bool, id string) *UsageRecord {
+	var (
+		userID, machineID, repo, operator string
+		modelJSON, endedAt                string
+		durationMs                        int64
+		numTurns                          int
+		totalCost                         float64
+		inTokens, outTokens               int64
+		cacheRead, cacheCreate            int64
+		row                               *sql.Row
+	)
+	if isRun {
+		row = s.db.QueryRow(
+			`SELECT COALESCE(user_id,''), machine_id, repo, operator,
+			        duration_ms, num_turns, total_cost_usd,
+			        input_tokens, output_tokens,
+			        cache_read_input_tokens, cache_creation_input_tokens,
+			        model_usage_json, ended_at
+			 FROM run_usage WHERE run_id = ?`, id)
+	} else {
+		row = s.db.QueryRow(
+			`SELECT user_id, machine_id, repo, '' AS operator,
+			        duration_ms, num_turns, total_cost_usd,
+			        input_tokens, output_tokens,
+			        cache_read_input_tokens, cache_creation_input_tokens,
+			        model_usage_json, ended_at
+			 FROM chat_usage WHERE session_id = ?`, id)
+	}
+	if err := row.Scan(&userID, &machineID, &repo, &operator,
+		&durationMs, &numTurns, &totalCost,
+		&inTokens, &outTokens,
+		&cacheRead, &cacheCreate,
+		&modelJSON, &endedAt); err != nil {
+		return nil
+	}
+	rec := &UsageRecord{
+		UserID:                   userID,
+		MachineID:                machineID,
+		Repo:                     repo,
+		Operator:                 operator,
+		DurationMs:               durationMs,
+		NumTurns:                 numTurns,
+		TotalCostUSD:             totalCost,
+		InputTokens:              inTokens,
+		OutputTokens:             outTokens,
+		CacheReadInputTokens:     cacheRead,
+		CacheCreationInputTokens: cacheCreate,
+	}
+	rec.EndedAt, _ = time.Parse(time.RFC3339Nano, endedAt)
+	if isRun {
+		rec.RunID = id
+	} else {
+		rec.SessionID = id
+	}
+	if modelJSON != "" && modelJSON != "{}" && modelJSON != "null" {
+		var mu map[string]ModelUsage
+		if json.Unmarshal([]byte(modelJSON), &mu) == nil {
+			rec.ModelUsage = mu
+		}
+	}
+	return rec
 }
 
 // GetJob returns the current state of a job by ID, or nil if not found.

--- a/internal/cloud/sqlite_store_test.go
+++ b/internal/cloud/sqlite_store_test.go
@@ -28,3 +28,14 @@ func TestSQLiteStoreLeaseExpiry(t *testing.T) {
 		return s
 	})
 }
+
+func TestSQLiteStoreUsage(t *testing.T) {
+	runStoreUsage(t, func() Store {
+		s, err := NewSQLiteStore(":memory:")
+		if err != nil {
+			t.Fatalf("NewSQLiteStore: %v", err)
+		}
+		t.Cleanup(func() { s.Close() })
+		return s
+	})
+}

--- a/internal/cloud/store.go
+++ b/internal/cloud/store.go
@@ -82,6 +82,15 @@ type Store interface {
 	GetJob(id string) *JobRecord
 	GetRun(id string) *RunRecord
 
+	// Usage. AddChatUsage is called by the chat handler after a worker
+	// POSTs to /api/worker/chat/sessions/{id}/usage. AddRunUsage is
+	// called implicitly from FinishRun when the request carries a
+	// non-nil Usage. Get* are for tests and for the future
+	// /api/cloud/usage/summary aggregation endpoint.
+	AddChatUsage(in AddChatUsageInput) error
+	GetRunUsage(runID string) *UsageRecord
+	GetChatUsage(sessionID string) *UsageRecord
+
 	// VCS connections (used by the webhook handler).
 	RegisterConnection(conn VCSConnection) (*VCSConnection, error)
 	GetConnectionByRepo(repo string) *VCSConnection
@@ -148,6 +157,11 @@ type MemoryStore struct {
 	Repos    map[string]*Repo
 	Bindings map[string]*Binding
 
+	// Usage by primary key. RunUsage is keyed by run_id, ChatUsage by
+	// session_id.
+	RunUsage  map[string]*UsageRecord
+	ChatUsage map[string]*UsageRecord
+
 	dedupe map[string]string
 	// repoConn maps "owner/repo" → connection ID for O(1) webhook lookup.
 	repoConn map[string]string
@@ -163,6 +177,8 @@ func NewMemoryStore() *MemoryStore {
 		Projects:    make(map[string]*Project),
 		Repos:       make(map[string]*Repo),
 		Bindings:    make(map[string]*Binding),
+		RunUsage:    make(map[string]*UsageRecord),
+		ChatUsage:   make(map[string]*UsageRecord),
 		dedupe:      make(map[string]string),
 		repoConn:    make(map[string]string),
 	}
@@ -369,13 +385,97 @@ func (s *MemoryStore) FinishRun(runID string, req FinishRunRequest) error {
 	run.Error = req.Error
 	run.EndedAt = &now
 
+	var (
+		repo     string
+		operator string
+	)
 	if job := s.Jobs[run.JobID]; job != nil {
 		job.Status = status
 		job.LeaseWorkerID = ""
 		job.LeaseExpiresAt = time.Time{}
 		job.UpdatedAt = now
+		repo = job.Spec.Repo
+		operator = job.Spec.Operator
+	}
+	if req.Usage != nil {
+		// Idempotent on duplicate run_id: later upload wins (a retry
+		// usually means later events.jsonl is more complete).
+		s.RunUsage[runID] = newUsageRecord("", runID, repo, operator, "", "", now, req.Usage)
 	}
 	return nil
+}
+
+// AddChatUsage stores a chat session's terminal token / cost breakdown.
+// Idempotent on (session_id): retries from the worker simply overwrite.
+func (s *MemoryStore) AddChatUsage(in AddChatUsageInput) error {
+	if in.SessionID == "" {
+		return fmt.Errorf("session_id is required")
+	}
+	if in.Usage == nil {
+		return fmt.Errorf("usage is required")
+	}
+	endedAt := in.EndedAt
+	if endedAt.IsZero() {
+		endedAt = time.Now().UTC()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ChatUsage[in.SessionID] = newUsageRecord(in.SessionID, "", in.Repo, "", in.UserID, in.MachineID, endedAt, in.Usage)
+	return nil
+}
+
+// GetRunUsage returns a copy of the stored run usage, or nil.
+func (s *MemoryStore) GetRunUsage(runID string) *UsageRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneUsage(s.RunUsage[runID])
+}
+
+// GetChatUsage returns a copy of the stored chat usage, or nil.
+func (s *MemoryStore) GetChatUsage(sessionID string) *UsageRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneUsage(s.ChatUsage[sessionID])
+}
+
+func newUsageRecord(sessionID, runID, repo, operator, userID, machineID string, endedAt time.Time, u *Usage) *UsageRecord {
+	rec := &UsageRecord{
+		RunID:                    runID,
+		SessionID:                sessionID,
+		UserID:                   userID,
+		MachineID:                machineID,
+		Repo:                     repo,
+		Operator:                 operator,
+		DurationMs:               u.DurationMs,
+		NumTurns:                 u.NumTurns,
+		TotalCostUSD:             u.TotalCostUSD,
+		InputTokens:              u.InputTokens,
+		OutputTokens:             u.OutputTokens,
+		CacheReadInputTokens:     u.CacheReadInputTokens,
+		CacheCreationInputTokens: u.CacheCreationInputTokens,
+		EndedAt:                  endedAt,
+	}
+	if len(u.ModelUsage) > 0 {
+		rec.ModelUsage = make(map[string]ModelUsage, len(u.ModelUsage))
+		for k, v := range u.ModelUsage {
+			rec.ModelUsage[k] = v
+		}
+	}
+	return rec
+}
+
+func cloneUsage(u *UsageRecord) *UsageRecord {
+	if u == nil {
+		return nil
+	}
+	cp := *u
+	if u.ModelUsage != nil {
+		cp.ModelUsage = make(map[string]ModelUsage, len(u.ModelUsage))
+		for k, v := range u.ModelUsage {
+			cp.ModelUsage[k] = v
+		}
+	}
+	return &cp
 }
 
 func (s *MemoryStore) GetJob(id string) *JobRecord {

--- a/internal/cloud/store_lifecycle_test.go
+++ b/internal/cloud/store_lifecycle_test.go
@@ -176,6 +176,174 @@ func runLeaseExpiry(t *testing.T, newStore func() Store) {
 	}
 }
 
+// runStoreUsage exercises the usage write/read path for any Store:
+// FinishRun-with-usage persists a run_usage row; AddChatUsage persists
+// a chat_usage row; a duplicate run_id upload overwrites (idempotent).
+func runStoreUsage(t *testing.T, newStore func() Store) {
+	t.Helper()
+	store := newStore()
+
+	// Stand up a registered worker + job + leased run so FinishRun has
+	// a row to update.
+	reg, err := store.RegisterWorker(RegisterWorkerRequest{Hostname: "host-usage"})
+	if err != nil {
+		t.Fatalf("RegisterWorker: %v", err)
+	}
+	rec, err := store.EnqueueJob(JobSpec{
+		Repo:     "acme/widget",
+		Platform: "github",
+		Operator: "evaluate-bug",
+		Target:   "issue",
+		Number:   42,
+	}, reg.MachineID)
+	if err != nil {
+		t.Fatalf("EnqueueJob: %v", err)
+	}
+	spec, err := store.Lease(LeaseRequest{
+		MachineID: reg.MachineID,
+		WorkerID:  reg.WorkerID,
+	}, time.Minute)
+	if err != nil || spec == nil {
+		t.Fatalf("Lease: spec=%v err=%v", spec, err)
+	}
+	runID := spec.RunID
+
+	// FinishRun with usage attached.
+	usage := &Usage{
+		DurationMs:               12_345,
+		NumTurns:                 7,
+		TotalCostUSD:             0.1234,
+		InputTokens:              1000,
+		OutputTokens:             200,
+		CacheReadInputTokens:     5000,
+		CacheCreationInputTokens: 50,
+		ModelUsage: map[string]ModelUsage{
+			"claude-opus-4-7": {
+				InputTokens:  900,
+				OutputTokens: 180,
+				CostUSD:      0.10,
+			},
+			"claude-haiku-4-5-20251001": {
+				InputTokens:  100,
+				OutputTokens: 20,
+				CostUSD:      0.02,
+			},
+		},
+	}
+	if err := store.FinishRun(runID, FinishRunRequest{
+		Status:  JobStatusSucceeded,
+		Outcome: "agent-evaluated",
+		Usage:   usage,
+	}); err != nil {
+		t.Fatalf("FinishRun with usage: %v", err)
+	}
+
+	got := store.GetRunUsage(runID)
+	if got == nil {
+		t.Fatal("GetRunUsage returned nil after FinishRun with usage")
+	}
+	if got.TotalCostUSD != 0.1234 {
+		t.Fatalf("TotalCostUSD = %v, want 0.1234", got.TotalCostUSD)
+	}
+	if got.Repo != "acme/widget" || got.Operator != "evaluate-bug" {
+		t.Fatalf("denorm fail: repo=%q operator=%q", got.Repo, got.Operator)
+	}
+	if got.NumTurns != 7 || got.InputTokens != 1000 || got.OutputTokens != 200 {
+		t.Fatalf("scalar mismatch: %+v", got)
+	}
+	if len(got.ModelUsage) != 2 || got.ModelUsage["claude-opus-4-7"].CostUSD != 0.10 {
+		t.Fatalf("model usage round-trip lost data: %+v", got.ModelUsage)
+	}
+	if got.EndedAt.IsZero() {
+		t.Fatal("EndedAt is zero")
+	}
+
+	// Idempotency: a retry with different numbers overwrites.
+	updated := *usage
+	updated.TotalCostUSD = 0.9999
+	updated.InputTokens = 9999
+	if err := store.FinishRun(runID, FinishRunRequest{
+		Status: JobStatusSucceeded,
+		Usage:  &updated,
+	}); err != nil {
+		t.Fatalf("FinishRun (retry): %v", err)
+	}
+	got = store.GetRunUsage(runID)
+	if got == nil || got.TotalCostUSD != 0.9999 || got.InputTokens != 9999 {
+		t.Fatalf("idempotent overwrite did not take: %+v", got)
+	}
+
+	// FinishRun without Usage on a different run must NOT crash and
+	// must leave run_usage empty for that run.
+	rec2, err := store.EnqueueJob(JobSpec{
+		Repo:      "acme/widget",
+		Platform:  "github",
+		Operator:  "evaluate-bug",
+		Target:    "issue",
+		Number:    43,
+		DedupeKey: "no-usage-run",
+	}, reg.MachineID)
+	if err != nil {
+		t.Fatalf("EnqueueJob 2: %v", err)
+	}
+	spec2, err := store.Lease(LeaseRequest{
+		MachineID: reg.MachineID,
+		WorkerID:  reg.WorkerID,
+	}, time.Minute)
+	if err != nil || spec2 == nil {
+		t.Fatalf("Lease 2: spec=%v err=%v", spec2, err)
+	}
+	if err := store.FinishRun(spec2.RunID, FinishRunRequest{
+		Status: JobStatusFailed,
+	}); err != nil {
+		t.Fatalf("FinishRun no-usage: %v", err)
+	}
+	if store.GetRunUsage(spec2.RunID) != nil {
+		t.Fatal("GetRunUsage non-nil for run without uploaded usage")
+	}
+	_ = rec
+	_ = rec2
+
+	// AddChatUsage path. user_id is required by SQLite (FK to users).
+	// MemoryStore doesn't enforce that; we use a non-empty string so
+	// the same test body works on both implementations. The lifecycle
+	// suite that calls this seeds a real user in SQLite mode.
+	chatUsage := &Usage{
+		DurationMs:   3_400,
+		NumTurns:     1,
+		TotalCostUSD: 0.0042,
+		InputTokens:  300,
+		OutputTokens: 80,
+	}
+	if err := store.AddChatUsage(AddChatUsageInput{
+		SessionID: "sess-abc",
+		UserID:    "user-test",
+		MachineID: reg.MachineID,
+		Repo:      "acme/widget",
+		Usage:     chatUsage,
+	}); err != nil {
+		t.Fatalf("AddChatUsage: %v", err)
+	}
+	gotChat := store.GetChatUsage("sess-abc")
+	if gotChat == nil {
+		t.Fatal("GetChatUsage returned nil")
+	}
+	if gotChat.TotalCostUSD != 0.0042 || gotChat.InputTokens != 300 {
+		t.Fatalf("chat usage round-trip mismatch: %+v", gotChat)
+	}
+	if gotChat.UserID != "user-test" || gotChat.Repo != "acme/widget" {
+		t.Fatalf("chat denorm fail: %+v", gotChat)
+	}
+
+	// Missing usage / id rejected.
+	if err := store.AddChatUsage(AddChatUsageInput{SessionID: "x", UserID: "user-test"}); err == nil {
+		t.Fatal("AddChatUsage with nil Usage should error")
+	}
+	if err := store.AddChatUsage(AddChatUsageInput{UserID: "user-test", Usage: chatUsage}); err == nil {
+		t.Fatal("AddChatUsage with empty session id should error")
+	}
+}
+
 // MemoryStore runs of the shared suite.
 
 func TestMemoryStoreLifecycle(t *testing.T) {
@@ -184,4 +352,8 @@ func TestMemoryStoreLifecycle(t *testing.T) {
 
 func TestMemoryStoreLeaseExpiry(t *testing.T) {
 	runLeaseExpiry(t, func() Store { return NewMemoryStore() })
+}
+
+func TestMemoryStoreUsage(t *testing.T) {
+	runStoreUsage(t, func() Store { return NewMemoryStore() })
 }

--- a/internal/cloud/types.go
+++ b/internal/cloud/types.go
@@ -358,4 +358,79 @@ type FinishRunRequest struct {
 	Outcome string `json:"outcome,omitempty"`
 	Summary string `json:"summary,omitempty"`
 	Error   string `json:"error,omitempty"`
+	// Usage, when non-nil, carries the run's token / cost breakdown
+	// extracted from the terminal "result" event in events.jsonl. Optional
+	// for backward compat with older workers; consumers must handle nil.
+	Usage *Usage `json:"usage,omitempty"`
+}
+
+// Usage is the wire shape of one run or chat session's terminal token /
+// cost breakdown. It mirrors snapshot.Usage field-for-field so the worker
+// can json.Marshal one into the other; the duplicated declaration avoids
+// internal/cloud → internal/snapshot import coupling.
+type Usage struct {
+	DurationMs               int64                 `json:"duration_ms"`
+	NumTurns                 int                   `json:"num_turns"`
+	TotalCostUSD             float64               `json:"total_cost_usd"`
+	InputTokens              int64                 `json:"input_tokens"`
+	OutputTokens             int64                 `json:"output_tokens"`
+	CacheReadInputTokens     int64                 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64                 `json:"cache_creation_input_tokens"`
+	ModelUsage               map[string]ModelUsage `json:"model_usage,omitempty"`
+}
+
+// ModelUsage is the per-model slice of a single Usage. Mirrors
+// snapshot.ModelUsage; same wire shape.
+type ModelUsage struct {
+	InputTokens              int64   `json:"input_tokens"`
+	OutputTokens             int64   `json:"output_tokens"`
+	CacheReadInputTokens     int64   `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64   `json:"cache_creation_input_tokens"`
+	CostUSD                  float64 `json:"cost_usd"`
+}
+
+// ChatUsageRequest is what a worker POSTs to
+// /api/worker/chat/sessions/{id}/usage after a chat session's claude
+// subprocess exits. The session_id comes from the URL; the body carries
+// the Usage and the model bucket (or empty if claude didn't report one).
+type ChatUsageRequest struct {
+	Usage *Usage `json:"usage"`
+}
+
+// UsageRecord is the stored form of one run or chat session's usage,
+// returned by Store.GetRunUsage / Store.GetChatUsage. The denormalized
+// columns (Repo, Operator) are filled in by the store at insert time so
+// the aggregation endpoint (sub 4) doesn't have to JOIN runs/jobs.
+//
+// Either RunID or SessionID is set, never both — the same shape is reused
+// for both surfaces so the eventual summary endpoint can union them.
+type UsageRecord struct {
+	RunID                    string                `json:"run_id,omitempty"`
+	SessionID                string                `json:"session_id,omitempty"`
+	UserID                   string                `json:"user_id,omitempty"`
+	MachineID                string                `json:"machine_id,omitempty"`
+	Repo                     string                `json:"repo,omitempty"`
+	Operator                 string                `json:"operator,omitempty"`
+	DurationMs               int64                 `json:"duration_ms"`
+	NumTurns                 int                   `json:"num_turns"`
+	TotalCostUSD             float64               `json:"total_cost_usd"`
+	InputTokens              int64                 `json:"input_tokens"`
+	OutputTokens             int64                 `json:"output_tokens"`
+	CacheReadInputTokens     int64                 `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64                 `json:"cache_creation_input_tokens"`
+	ModelUsage               map[string]ModelUsage `json:"model_usage,omitempty"`
+	EndedAt                  time.Time             `json:"ended_at"`
+}
+
+// AddChatUsageInput is what the chat handler hands to Store.AddChatUsage
+// after a worker POSTs to /api/worker/chat/sessions/{id}/usage. The
+// handler fills in UserID / MachineID / Repo from the active session
+// registry; the wire body only carries Usage.
+type AddChatUsageInput struct {
+	SessionID string
+	UserID    string
+	MachineID string
+	Repo      string
+	Usage     *Usage
+	EndedAt   time.Time
 }


### PR DESCRIPTION
Closes #165 (sub-issue of #164).

## Summary

Foundational layer for the PR 4 usage feature. Cloud now has a place to put per-run / per-chat-session token + cost data, and the wire protocol to receive it. Subsequent PRs (#166 worker job-run upload, #167 worker chat upload, #168 aggregation endpoint, #169 web page) plug into the surface this PR creates.

No user-visible change yet — `Usage` is `nil` from every current caller, so production behavior is unchanged.

## What changed

### Wire (`internal/cloud/types.go`)
- `Usage`, `ModelUsage` — wire shapes mirroring `snapshot.Usage` field-for-field. Duplicated declaration avoids a `cloud → snapshot` import edge.
- `FinishRunRequest.Usage *Usage` — optional, backward-compatible.
- `ChatUsageRequest { Usage *Usage }` — body of the new chat endpoint; session_id comes from the URL.
- `UsageRecord` — stored form, shared by run and chat lookups.
- `AddChatUsageInput` — what the chat handler hands to the store after server-side identity lookup.

### Storage (`internal/cloud/migrations/0004_usage.sql`)
- `run_usage` keyed by `run_id`, `chat_usage` keyed by `session_id`. Denormalized columns (`repo`, `operator`, `user_id`, `machine_id`) live on the row so #168's aggregation can `GROUP BY` without joining. `model_usage_json` for the per-model breakdown.
- `user_id` is plain `TEXT` (no FK) so a deleted user doesn't cascade-delete historical usage.

### Store interface
- `AddChatUsage(in AddChatUsageInput) error`
- `GetRunUsage(runID) *UsageRecord`
- `GetChatUsage(sessionID) *UsageRecord`
- `FinishRun` on both stores persists `req.Usage` when non-nil; denormalized `repo` / `operator` come from the job spec.
- Idempotent on `run_id` / `session_id`: SQLite uses `ON CONFLICT … DO UPDATE`, Memory overwrites the map entry. Worker retries are safe.

### Chat handler (`internal/cloud/chat/handler.go`)
- New machine-auth route: `POST /api/worker/chat/sessions/{id}/usage`.
- Resolves `user_id` / `machine_id` / `repo` server-side from the in-memory session registry (workers can't claim usage for sessions they don't own).
- 404 on unknown session; 400 on nil `Usage`; 204 on success.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test -race ./...` all packages green.
- [x] `runStoreUsage` shared lifecycle runs on both `MemoryStore` and `SQLiteStore`. Covers:
  - FinishRun with usage → row appears with denormalized fields
  - FinishRun retry with different numbers → idempotent overwrite
  - FinishRun without usage → no row, no error
  - AddChatUsage round-trip → user_id / machine_id / repo / model breakdown preserved
  - Missing session_id / nil Usage rejected
- [x] `TestWorkerUsageEndpoint` covers the new HTTP route: happy path, 404 unknown session, 400 missing usage.

## Out of scope (per #164 decomp)

- Worker calling these write paths (#166 + #167)
- Aggregation endpoint (#168)
- Cloud Usage page (#169)

## Numbers

`8 files changed, 742 insertions(+), 3 deletions(-)`. Net surface: 1 new migration, 1 new handler route, 3 new Store methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)