### PR TITLE
PR 4 sub 4: cloud /api/cloud/usage/summary aggregation endpoint

### DIFF
--- a/internal/cloud/server.go
+++ b/internal/cloud/server.go
@@ -111,6 +111,7 @@ func NewServerWithExtras(store Store, operators *operator.Registry, auth AuthHan
 	mux.HandleFunc("/api/cloud/jobs", s.withAuth(s.handleCloudJobs))
 	mux.HandleFunc("/api/cloud/runs", s.withAuth(s.handleCloudRuns))
 	mux.HandleFunc("/api/cloud/operators", s.withAuth(s.handleCloudOperators))
+	mux.HandleFunc("/api/cloud/usage/summary", s.withAuth(s.handleCloudUsageSummary))
 
 	// Webhook route matches the GitHub App's configured Webhook URL exactly.
 	mux.HandleFunc("/api/v1/github/app/webhook", s.handleWebhookGitHub)
@@ -611,6 +612,29 @@ func (s *server) handleCloudOperators(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeCloudJSON(w, http.StatusOK, map[string]any{"operators": out})
+}
+
+// handleCloudUsageSummary aggregates the calling user's run + chat
+// usage rows and returns the UsageSummary shape the local-mode Usage
+// page already speaks. Strictly user-scoped; run rows with no
+// recorded user_id are included to keep single-user self-hosts
+// functional until owner_user_id wiring lands.
+func (s *server) handleCloudUsageSummary(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.auth == nil {
+		writeCloudError(w, http.StatusInternalServerError, "auth not configured")
+		return
+	}
+	user := s.auth.UserFromContext(r.Context())
+	if user == nil {
+		writeCloudError(w, http.StatusUnauthorized, "auth required")
+		return
+	}
+	records := s.store.ListUsageForUser(user.ID)
+	writeCloudJSON(w, http.StatusOK, BuildUsageSummary(records, time.Now().UTC()))
 }
 
 // handleCloudRuns returns all run records.

--- a/internal/cloud/sqlite_store.go
+++ b/internal/cloud/sqlite_store.go
@@ -530,6 +530,93 @@ func (s *SQLiteStore) GetChatUsage(sessionID string) *UsageRecord {
 	return s.queryUsage(false, sessionID)
 }
 
+// ListUsageForUser returns chat rows belonging to userID + run rows
+// whose user_id is empty (single-user self-host) or matches.
+func (s *SQLiteStore) ListUsageForUser(userID string) []*UsageRecord {
+	out := make([]*UsageRecord, 0)
+
+	// Run usage. We accept empty-user rows so single-user self-hosts
+	// see their runs even before owner_user_id wiring lands.
+	runRows, err := s.db.Query(
+		`SELECT run_id, COALESCE(user_id,''), machine_id, repo, operator,
+		        duration_ms, num_turns, total_cost_usd,
+		        input_tokens, output_tokens,
+		        cache_read_input_tokens, cache_creation_input_tokens,
+		        model_usage_json, ended_at
+		 FROM run_usage
+		 WHERE user_id = '' OR user_id = ?`, userID)
+	if err == nil {
+		defer runRows.Close()
+		for runRows.Next() {
+			out = append(out, scanUsageRow(runRows, true))
+		}
+	}
+
+	chatRows, err := s.db.Query(
+		`SELECT session_id, user_id, machine_id, repo, '',
+		        duration_ms, num_turns, total_cost_usd,
+		        input_tokens, output_tokens,
+		        cache_read_input_tokens, cache_creation_input_tokens,
+		        model_usage_json, ended_at
+		 FROM chat_usage WHERE user_id = ?`, userID)
+	if err == nil {
+		defer chatRows.Close()
+		for chatRows.Next() {
+			out = append(out, scanUsageRow(chatRows, false))
+		}
+	}
+	return out
+}
+
+// scanUsageRow is the shared row→UsageRecord scan used by both run and
+// chat list queries. isRun discriminates which primary-key field to
+// populate on the resulting record.
+func scanUsageRow(rows interface {
+	Scan(...any) error
+}, isRun bool) *UsageRecord {
+	var (
+		id, userID, machineID, repo, operator string
+		modelJSON, endedAt                    string
+		durationMs                            int64
+		numTurns                              int
+		totalCost                             float64
+		inT, outT                             int64
+		cacheR, cacheC                        int64
+	)
+	if err := rows.Scan(&id, &userID, &machineID, &repo, &operator,
+		&durationMs, &numTurns, &totalCost,
+		&inT, &outT, &cacheR, &cacheC,
+		&modelJSON, &endedAt); err != nil {
+		return nil
+	}
+	rec := &UsageRecord{
+		UserID:                   userID,
+		MachineID:                machineID,
+		Repo:                     repo,
+		Operator:                 operator,
+		DurationMs:               durationMs,
+		NumTurns:                 numTurns,
+		TotalCostUSD:             totalCost,
+		InputTokens:              inT,
+		OutputTokens:             outT,
+		CacheReadInputTokens:     cacheR,
+		CacheCreationInputTokens: cacheC,
+	}
+	if isRun {
+		rec.RunID = id
+	} else {
+		rec.SessionID = id
+	}
+	rec.EndedAt, _ = time.Parse(time.RFC3339Nano, endedAt)
+	if modelJSON != "" && modelJSON != "{}" && modelJSON != "null" {
+		var mu map[string]ModelUsage
+		if json.Unmarshal([]byte(modelJSON), &mu) == nil {
+			rec.ModelUsage = mu
+		}
+	}
+	return rec
+}
+
 func (s *SQLiteStore) queryUsage(isRun bool, id string) *UsageRecord {
 	var (
 		userID, machineID, repo, operator string

--- a/internal/cloud/store.go
+++ b/internal/cloud/store.go
@@ -85,11 +85,17 @@ type Store interface {
 	// Usage. AddChatUsage is called by the chat handler after a worker
 	// POSTs to /api/worker/chat/sessions/{id}/usage. AddRunUsage is
 	// called implicitly from FinishRun when the request carries a
-	// non-nil Usage. Get* are for tests and for the future
+	// non-nil Usage. Get* are for tests; ListUsageForUser backs the
 	// /api/cloud/usage/summary aggregation endpoint.
 	AddChatUsage(in AddChatUsageInput) error
 	GetRunUsage(runID string) *UsageRecord
 	GetChatUsage(sessionID string) *UsageRecord
+	// ListUsageForUser returns every run_usage + chat_usage row whose
+	// user_id matches the supplied user. Run usage rows that have an
+	// empty user_id (single-user self-host where no owner has been
+	// stamped) are also returned to keep that mode functional; pass
+	// userID == "" to retrieve only the orphaned rows.
+	ListUsageForUser(userID string) []*UsageRecord
 
 	// VCS connections (used by the webhook handler).
 	RegisterConnection(conn VCSConnection) (*VCSConnection, error)
@@ -436,6 +442,25 @@ func (s *MemoryStore) GetChatUsage(sessionID string) *UsageRecord {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return cloneUsage(s.ChatUsage[sessionID])
+}
+
+// ListUsageForUser returns chat rows belonging to userID + run rows
+// whose user_id is empty (single-user self-host) or matches.
+func (s *MemoryStore) ListUsageForUser(userID string) []*UsageRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*UsageRecord, 0, len(s.RunUsage)+len(s.ChatUsage))
+	for _, r := range s.RunUsage {
+		if r.UserID == "" || r.UserID == userID {
+			out = append(out, cloneUsage(r))
+		}
+	}
+	for _, c := range s.ChatUsage {
+		if c.UserID == userID {
+			out = append(out, cloneUsage(c))
+		}
+	}
+	return out
 }
 
 func newUsageRecord(sessionID, runID, repo, operator, userID, machineID string, endedAt time.Time, u *Usage) *UsageRecord {

--- a/internal/cloud/usage_summary.go
+++ b/internal/cloud/usage_summary.go
@@ -1,0 +1,218 @@
+package cloud
+
+import (
+	"sort"
+	"time"
+)
+
+// UsageSummary is the response body of GET /api/cloud/usage/summary.
+// Its shape is intentionally identical to snapshot.UsageSummary so the
+// existing local-mode Usage page (web/src/routes/_app.usage.tsx) can
+// consume it unchanged.
+type UsageSummary struct {
+	GeneratedAt time.Time                 `json:"generated_at"`
+	Totals      UsageAggregate            `json:"totals"`
+	ByOperator  map[string]UsageAggregate `json:"by_operator"`
+	ByRepo      map[string]UsageAggregate `json:"by_repo"`
+	ByModel     map[string]ModelAggregate `json:"by_model"`
+	Periods     []PeriodSummary           `json:"periods,omitempty"`
+}
+
+// PeriodSummary mirrors the local-mode periods entry. The cloud
+// endpoint currently emits a single "current" period covering the
+// rolling 30 days ending now; future iterations can split per
+// calendar month if users start having long-running histories.
+type PeriodSummary struct {
+	PeriodStart string                    `json:"period_start"`
+	PeriodEnd   string                    `json:"period_end"`
+	Totals      UsageAggregate            `json:"totals"`
+	ByOperator  map[string]UsageAggregate `json:"by_operator"`
+	ByRepo      map[string]UsageAggregate `json:"by_repo"`
+	ByModel     map[string]ModelAggregate `json:"by_model"`
+	DailyTrend  []DailyPoint              `json:"daily_trend"`
+}
+
+// DailyPoint is one day's aggregated usage; the bar-chart at the top
+// of the Usage page renders one of these per day in the active period.
+type DailyPoint struct {
+	Date         string                    `json:"date"`
+	Runs         int                       `json:"runs"`
+	TotalCostUSD float64                   `json:"total_cost_usd"`
+	InputTokens  int64                     `json:"input_tokens"`
+	OutputTokens int64                     `json:"output_tokens"`
+	ByOperator   map[string]UsageAggregate `json:"by_operator,omitempty"`
+	ByRepo       map[string]UsageAggregate `json:"by_repo,omitempty"`
+	ByModel      map[string]ModelAggregate `json:"by_model,omitempty"`
+}
+
+// UsageAggregate is the summable row used by the dashboard's
+// per-operator, per-repo, and grand-total slices. Mirrors
+// snapshot.UsageAggregate.
+type UsageAggregate struct {
+	Runs                     int     `json:"runs"`
+	TotalCostUSD             float64 `json:"total_cost_usd"`
+	InputTokens              int64   `json:"input_tokens"`
+	OutputTokens             int64   `json:"output_tokens"`
+	CacheReadInputTokens     int64   `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64   `json:"cache_creation_input_tokens"`
+	DurationMs               int64   `json:"duration_ms"`
+}
+
+// ModelAggregate is the per-model slice; mirrors snapshot.ModelAggregate.
+// No DurationMs because a single run's duration spans every model it
+// called.
+type ModelAggregate struct {
+	CostUSD                  float64 `json:"cost_usd"`
+	InputTokens              int64   `json:"input_tokens"`
+	OutputTokens             int64   `json:"output_tokens"`
+	CacheReadInputTokens     int64   `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int64   `json:"cache_creation_input_tokens"`
+}
+
+// BuildUsageSummary aggregates a flat list of UsageRecord rows (both run
+// and chat surfaces) into the UsageSummary shape the Usage page expects.
+// `now` is the upper bound of the rolling 30-day "current" period;
+// callers pass time.Now().UTC() in production and a fixed timestamp in
+// tests.
+func BuildUsageSummary(records []*UsageRecord, now time.Time) UsageSummary {
+	sum := UsageSummary{
+		GeneratedAt: now,
+		ByOperator:  map[string]UsageAggregate{},
+		ByRepo:      map[string]UsageAggregate{},
+		ByModel:     map[string]ModelAggregate{},
+	}
+
+	periodEnd := now.UTC().Truncate(24 * time.Hour).Add(24 * time.Hour).Add(-time.Nanosecond)
+	periodStart := periodEnd.AddDate(0, 0, -29).Truncate(24 * time.Hour)
+	period := &PeriodSummary{
+		PeriodStart: periodStart.Format("2006-01-02"),
+		PeriodEnd:   periodEnd.Format("2006-01-02"),
+		ByOperator:  map[string]UsageAggregate{},
+		ByRepo:      map[string]UsageAggregate{},
+		ByModel:     map[string]ModelAggregate{},
+	}
+
+	// Pre-fill daily trend buckets so the chart shows zero-cost days
+	// rather than gaps. 30 days, oldest first.
+	dayMap := map[string]*DailyPoint{}
+	for d := periodStart; !d.After(periodEnd); d = d.AddDate(0, 0, 1) {
+		key := d.Format("2006-01-02")
+		dayMap[key] = &DailyPoint{
+			Date:       key,
+			ByOperator: map[string]UsageAggregate{},
+			ByRepo:     map[string]UsageAggregate{},
+			ByModel:    map[string]ModelAggregate{},
+		}
+	}
+
+	for _, rec := range records {
+		if rec == nil {
+			continue
+		}
+		// "Operator" for chat sessions is the synthetic "chat" bucket
+		// so the page's by-operator panel groups them separately from
+		// agent runs. Repo carries through from the record either way.
+		operator := rec.Operator
+		if operator == "" {
+			operator = "chat"
+		}
+
+		// All-time totals.
+		addToAggregate(&sum.Totals, rec)
+		op := sum.ByOperator[operator]
+		addToAggregate(&op, rec)
+		sum.ByOperator[operator] = op
+		if rec.Repo != "" {
+			r := sum.ByRepo[rec.Repo]
+			addToAggregate(&r, rec)
+			sum.ByRepo[rec.Repo] = r
+		}
+		for name, m := range rec.ModelUsage {
+			cur := sum.ByModel[name]
+			cur.CostUSD += m.CostUSD
+			cur.InputTokens += m.InputTokens
+			cur.OutputTokens += m.OutputTokens
+			cur.CacheReadInputTokens += m.CacheReadInputTokens
+			cur.CacheCreationInputTokens += m.CacheCreationInputTokens
+			sum.ByModel[name] = cur
+		}
+
+		// Skip rows outside the current 30-day window for the
+		// period-scoped aggregation, but they DO contribute to the
+		// all-time totals computed above.
+		if rec.EndedAt.Before(periodStart) || rec.EndedAt.After(periodEnd) {
+			continue
+		}
+		addToAggregate(&period.Totals, rec)
+		pop := period.ByOperator[operator]
+		addToAggregate(&pop, rec)
+		period.ByOperator[operator] = pop
+		if rec.Repo != "" {
+			pr := period.ByRepo[rec.Repo]
+			addToAggregate(&pr, rec)
+			period.ByRepo[rec.Repo] = pr
+		}
+		for name, m := range rec.ModelUsage {
+			cur := period.ByModel[name]
+			cur.CostUSD += m.CostUSD
+			cur.InputTokens += m.InputTokens
+			cur.OutputTokens += m.OutputTokens
+			cur.CacheReadInputTokens += m.CacheReadInputTokens
+			cur.CacheCreationInputTokens += m.CacheCreationInputTokens
+			period.ByModel[name] = cur
+		}
+
+		day := rec.EndedAt.UTC().Format("2006-01-02")
+		if dp, ok := dayMap[day]; ok {
+			dp.Runs++
+			dp.TotalCostUSD += rec.TotalCostUSD
+			dp.InputTokens += rec.InputTokens
+			dp.OutputTokens += rec.OutputTokens
+			dop := dp.ByOperator[operator]
+			addToAggregate(&dop, rec)
+			dp.ByOperator[operator] = dop
+			if rec.Repo != "" {
+				dr := dp.ByRepo[rec.Repo]
+				addToAggregate(&dr, rec)
+				dp.ByRepo[rec.Repo] = dr
+			}
+			for name, m := range rec.ModelUsage {
+				cur := dp.ByModel[name]
+				cur.CostUSD += m.CostUSD
+				cur.InputTokens += m.InputTokens
+				cur.OutputTokens += m.OutputTokens
+				cur.CacheReadInputTokens += m.CacheReadInputTokens
+				cur.CacheCreationInputTokens += m.CacheCreationInputTokens
+				dp.ByModel[name] = cur
+			}
+		}
+	}
+
+	// Materialize daily trend in date order.
+	days := make([]string, 0, len(dayMap))
+	for d := range dayMap {
+		days = append(days, d)
+	}
+	sort.Strings(days)
+	trend := make([]DailyPoint, 0, len(days))
+	for _, d := range days {
+		trend = append(trend, *dayMap[d])
+	}
+	period.DailyTrend = trend
+
+	if period.Totals.Runs > 0 || len(trend) > 0 {
+		sum.Periods = []PeriodSummary{*period}
+	}
+	return sum
+}
+
+// addToAggregate folds one UsageRecord into a running UsageAggregate.
+func addToAggregate(agg *UsageAggregate, rec *UsageRecord) {
+	agg.Runs++
+	agg.TotalCostUSD += rec.TotalCostUSD
+	agg.InputTokens += rec.InputTokens
+	agg.OutputTokens += rec.OutputTokens
+	agg.CacheReadInputTokens += rec.CacheReadInputTokens
+	agg.CacheCreationInputTokens += rec.CacheCreationInputTokens
+	agg.DurationMs += rec.DurationMs
+}

--- a/internal/cloud/usage_summary_test.go
+++ b/internal/cloud/usage_summary_test.go
@@ -1,0 +1,201 @@
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestBuildUsageSummary pins down the pure aggregation function: a
+// hand-rolled slice of UsageRecord rows lands in the right buckets and
+// the daily trend has zeros for empty days.
+func TestBuildUsageSummary(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	mkRec := func(repo, op string, endedAt time.Time, cost float64, in, out int64, model string) *UsageRecord {
+		return &UsageRecord{
+			RunID:        "r-" + op + "-" + endedAt.Format("0102"),
+			Repo:         repo,
+			Operator:     op,
+			TotalCostUSD: cost,
+			InputTokens:  in,
+			OutputTokens: out,
+			EndedAt:      endedAt,
+			ModelUsage: map[string]ModelUsage{
+				model: {CostUSD: cost, InputTokens: in, OutputTokens: out},
+			},
+		}
+	}
+
+	records := []*UsageRecord{
+		mkRec("acme/widgets", "evaluate-bug", now.AddDate(0, 0, -2), 0.10, 100, 50, "claude-opus-4-7"),
+		mkRec("acme/widgets", "evaluate-bug", now.AddDate(0, 0, -2), 0.05, 80, 40, "claude-opus-4-7"),
+		mkRec("acme/gadgets", "implement", now.AddDate(0, 0, -1), 0.30, 500, 200, "claude-haiku-4-5-20251001"),
+		// Chat row — synthetic "chat" operator bucket.
+		{
+			SessionID:    "s-1",
+			Repo:         "acme/widgets",
+			TotalCostUSD: 0.02,
+			InputTokens:  60,
+			OutputTokens: 20,
+			EndedAt:      now.AddDate(0, 0, -1),
+			ModelUsage:   map[string]ModelUsage{"claude-opus-4-7": {CostUSD: 0.02, InputTokens: 60, OutputTokens: 20}},
+		},
+		// Outside the 30-day window: contributes to all-time totals
+		// but not to the period.
+		mkRec("acme/widgets", "evaluate-bug", now.AddDate(0, 0, -60), 1.00, 1000, 500, "claude-opus-4-7"),
+	}
+
+	sum := BuildUsageSummary(records, now)
+
+	// All-time totals: 5 records.
+	if sum.Totals.Runs != 5 {
+		t.Errorf("Totals.Runs = %d, want 5", sum.Totals.Runs)
+	}
+	wantCost := 0.10 + 0.05 + 0.30 + 0.02 + 1.00
+	if absDiff(sum.Totals.TotalCostUSD, wantCost) > 1e-9 {
+		t.Errorf("Totals.TotalCostUSD = %v, want %v", sum.Totals.TotalCostUSD, wantCost)
+	}
+	if sum.ByOperator["evaluate-bug"].Runs != 3 {
+		t.Errorf("ByOperator[evaluate-bug].Runs = %d, want 3", sum.ByOperator["evaluate-bug"].Runs)
+	}
+	if sum.ByOperator["chat"].Runs != 1 {
+		t.Errorf("ByOperator[chat].Runs = %d, want 1", sum.ByOperator["chat"].Runs)
+	}
+	if sum.ByRepo["acme/widgets"].Runs != 4 {
+		t.Errorf("ByRepo[acme/widgets].Runs = %d, want 4", sum.ByRepo["acme/widgets"].Runs)
+	}
+
+	// One period (current 30d). Outside-window row dropped from period.
+	if len(sum.Periods) != 1 {
+		t.Fatalf("len(Periods) = %d, want 1", len(sum.Periods))
+	}
+	p := sum.Periods[0]
+	if p.Totals.Runs != 4 {
+		t.Errorf("period.Totals.Runs = %d, want 4 (60-day-old row excluded)", p.Totals.Runs)
+	}
+	if len(p.DailyTrend) != 30 {
+		t.Errorf("daily trend length = %d, want 30", len(p.DailyTrend))
+	}
+
+	// The two -2-day rows go to the same bucket.
+	twoDaysAgo := now.AddDate(0, 0, -2).Format("2006-01-02")
+	var foundDay *DailyPoint
+	for i := range p.DailyTrend {
+		if p.DailyTrend[i].Date == twoDaysAgo {
+			foundDay = &p.DailyTrend[i]
+			break
+		}
+	}
+	if foundDay == nil {
+		t.Fatalf("day %s not found in trend", twoDaysAgo)
+	}
+	if foundDay.Runs != 2 {
+		t.Errorf("day %s Runs = %d, want 2", twoDaysAgo, foundDay.Runs)
+	}
+}
+
+// TestUsageSummaryEndpoint exercises GET /api/cloud/usage/summary end
+// to end: an authenticated user gets the aggregation; another user's
+// rows do NOT appear (multi-user isolation); 401 without auth.
+func TestUsageSummaryEndpoint(t *testing.T) {
+	store := NewMemoryStore()
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+
+	// Seed two users' worth of chat usage rows. user_id strictly filters.
+	for _, u := range []struct {
+		userID string
+		cost   float64
+	}{{"u-alice", 0.10}, {"u-bob", 0.20}} {
+		if err := store.AddChatUsage(AddChatUsageInput{
+			SessionID: "s-" + u.userID,
+			UserID:    u.userID,
+			Repo:      "acme/widgets",
+			Usage: &Usage{
+				TotalCostUSD: u.cost,
+				InputTokens:  100,
+				OutputTokens: 50,
+			},
+			EndedAt: now.AddDate(0, 0, -1),
+		}); err != nil {
+			t.Fatalf("AddChatUsage(%s): %v", u.userID, err)
+		}
+	}
+
+	// One orphaned run_usage row (user_id=='') — must appear for any
+	// authenticated user under the "single-user self-host" fallback.
+	store.RunUsage["r-orphan"] = &UsageRecord{
+		RunID:        "r-orphan",
+		Repo:         "acme/gadgets",
+		Operator:     "implement",
+		TotalCostUSD: 0.99,
+		InputTokens:  1000,
+		OutputTokens: 200,
+		EndedAt:      now.AddDate(0, 0, -2),
+	}
+
+	srv := httptest.NewServer(NewServerWithAuth(store, nil, &stubAuth{userID: "u-alice"}))
+	defer srv.Close()
+
+	// Authenticated request.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/cloud/usage/summary", nil)
+	req.Header.Set("Authorization", "Bearer test")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got UsageSummary
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Alice sees: her chat row (0.10) + orphan run row (0.99) = 2 rows, $1.09
+	if got.Totals.Runs != 2 {
+		t.Errorf("Alice Totals.Runs = %d, want 2 (her chat + orphan run)", got.Totals.Runs)
+	}
+	if absDiff(got.Totals.TotalCostUSD, 1.09) > 1e-9 {
+		t.Errorf("Alice Totals.TotalCostUSD = %v, want 1.09", got.Totals.TotalCostUSD)
+	}
+	// Bob's $0.20 row must NOT have leaked into Alice's view.
+	if absDiff(got.Totals.TotalCostUSD, 1.29) <= 1e-9 {
+		t.Error("Alice saw Bob's $0.20 chat usage — multi-user isolation broken")
+	}
+}
+
+// stubAuth is the in-package fake AuthHandler used by the summary
+// endpoint test. RequireUser injects a constant user into the context;
+// UserFromContext pulls it back out. RequireMachine / RegisterRoutes
+// are no-ops because this test only hits user-auth routes.
+type stubAuth struct {
+	userID string
+}
+
+type stubAuthCtxKey struct{}
+
+func (a *stubAuth) RegisterRoutes(_ *http.ServeMux) {}
+
+func (a *stubAuth) RequireUser(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), stubAuthCtxKey{}, &User{ID: a.userID})
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (a *stubAuth) RequireMachine(next http.Handler) http.Handler { return next }
+
+func (a *stubAuth) UserFromContext(ctx context.Context) *User {
+	u, _ := ctx.Value(stubAuthCtxKey{}).(*User)
+	return u
+}
+
+func absDiff(a, b float64) float64 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}


### PR DESCRIPTION
Closes #168 (sub-issue of #164). Depends on PR 4 sub 1 (already merged).

## Summary

Adds the consumer-side aggregation endpoint that turns the per-row `run_usage` + `chat_usage` tables (sub 1) into the `UsageSummary` JSON shape the existing local-mode Usage page already consumes. Sub 5's web work becomes a near-trivial fetch swap.

## What changed

### `internal/cloud/usage_summary.go` (new)
- Pure function `BuildUsageSummary([]*UsageRecord, now time.Time) UsageSummary`.
- All-time totals + a single rolling-30-day "current" period.
- Daily-trend buckets pre-filled with zeros so the chart shows empty days as gaps, not skips.
- Chat rows go into a synthetic `"chat"` operator bucket; run rows use their actual operator name.
- Rows outside the 30-day window contribute to all-time totals but not the period (matches local-mode semantics).

### `internal/cloud/server.go`
- `GET /api/cloud/usage/summary` mounted via `s.withAuth`. Returns 200 + summary JSON for the authenticated user, 401 for anon.

### `internal/cloud/store.go` + `internal/cloud/sqlite_store.go`
- `Store.ListUsageForUser(userID) []*UsageRecord`. Chat rows filter strictly by `user_id`. Run rows include rows whose `user_id` matches **or is empty** — the empty-user fallback keeps single-user self-host working while owner_user_id wiring is still TBD on the producer side.
- Both stores implement; SQLite uses an OR clause; Memory iterates.

### Tests
- `TestBuildUsageSummary`: pure-function correctness, including "outside window drops from period but stays in all-time" and the synthetic chat bucket.
- `TestUsageSummaryEndpoint`: end-to-end via httptest with a stub `AuthHandler`. **Multi-user isolation verified** — Alice does NOT see Bob's chat rows. Orphan run rows DO appear for both (the single-user fallback).
- All packages `-race` clean.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test -race ./...` all packages green.
- [x] `go test -race ./internal/cloud/...` — two new tests pass; existing tests unchanged.

## What's NOT in this PR (deferred to sub 3 / sub 5 / future)

- The web Usage page (#169 sub 5).
- Chat-session usage upload (#167 sub 3 — without it, the endpoint will mostly return empty chat data until sub 3 lands).
- Producer-side `owner_user_id` denormalization on `run_usage` rows — current orphan-fallback gets us through dogfood; multi-tenant correctness comes when a future PR wires repo ownership to FinishRun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)