### PR TITLE
PR 4 sub 3: worker chat stream-json + usage upload

### DIFF
--- a/internal/worker/chat/chat_test.go
+++ b/internal/worker/chat/chat_test.go
@@ -179,17 +179,22 @@ func TestBuildCloneURL(t *testing.T) {
 	}
 }
 
-// fakeClaudeBin writes a tiny script to dir that emits a marker to
-// stdout, a marker to stderr, and exits 0. Returns the script path.
-// Skipped on Windows because we use a bash shebang.
+// fakeClaudeBin writes a tiny script to dir that emits a canned
+// stream-json transcript to stdout (one assistant text delta + a
+// terminal result event with usage), a marker to stderr, and exits 0.
+// The transcript matches the schema claude --output-format stream-json
+// --verbose produces. Skipped on Windows because we use a bash shebang.
 func fakeClaudeBin(t *testing.T, dir string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("posix-only test")
 	}
 	p := filepath.Join(dir, "fake-claude.sh")
+	assistant := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello-from-claude"}]}}`
+	result := `{"type":"result","duration_ms":1234,"num_turns":1,"total_cost_usd":0.0042,"usage":{"input_tokens":100,"output_tokens":42,"cache_read_input_tokens":50,"cache_creation_input_tokens":5},"modelUsage":{"claude-opus-4-7":{"inputTokens":100,"outputTokens":42,"cacheReadInputTokens":50,"cacheCreationInputTokens":5,"costUSD":0.0042}}}`
 	script := "#!/bin/sh\n" +
-		"echo hello-from-claude\n" +
+		"echo '" + assistant + "'\n" +
+		"echo '" + result + "'\n" +
 		"echo warn-line >&2\n" +
 		"exit 0\n"
 	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
@@ -210,31 +215,44 @@ func initLocalClone(t *testing.T, dir string) {
 }
 
 // fakeCloud is a minimal httptest.Server that records WorkerEvents
-// posts. Use start() to spin one up and stop via Close.
+// posts AND ChatUsage posts so tests can assert on both. Use
+// newFakeCloud to spin one up and snapshot* to inspect.
 type fakeCloud struct {
 	server *httptest.Server
 
 	mu     sync.Mutex
 	events []cloud.ChatEvent
+	usages []*cloud.Usage
 }
 
 func newFakeCloud(t *testing.T) *fakeCloud {
 	t.Helper()
 	fc := &fakeCloud{}
 	fc.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, "/events") {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/events"):
+			var req cloud.WorkerEventsRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			fc.mu.Lock()
+			fc.events = append(fc.events, req.Events...)
+			fc.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		case strings.HasSuffix(r.URL.Path, "/usage"):
+			var req cloud.ChatUsageRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			fc.mu.Lock()
+			fc.usages = append(fc.usages, req.Usage)
+			fc.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+		default:
 			http.NotFound(w, r)
-			return
 		}
-		var req cloud.WorkerEventsRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		fc.mu.Lock()
-		fc.events = append(fc.events, req.Events...)
-		fc.mu.Unlock()
-		w.WriteHeader(http.StatusNoContent)
 	}))
 	t.Cleanup(fc.server.Close)
 	return fc
@@ -245,6 +263,14 @@ func (fc *fakeCloud) snapshot() []cloud.ChatEvent {
 	defer fc.mu.Unlock()
 	out := make([]cloud.ChatEvent, len(fc.events))
 	copy(out, fc.events)
+	return out
+}
+
+func (fc *fakeCloud) usageSnapshot() []*cloud.Usage {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	out := make([]*cloud.Usage, len(fc.usages))
+	copy(out, fc.usages)
 	return out
 }
 
@@ -353,6 +379,34 @@ func TestRunSession_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(combined.String(), "hello-from-claude") {
 		t.Errorf("expected stdout to contain marker; got:\n%s", combined.String())
+	}
+
+	// Browser-side contract: text deltas come through as plain text,
+	// not as JSON envelopes. If a raw `"type":"assistant"` ever leaks
+	// into a ChatEventOutput, the browser would render it instead of
+	// the human-readable answer.
+	if strings.Contains(combined.String(), `"type":"assistant"`) {
+		t.Errorf("raw stream-json envelope leaked into output events:\n%s", combined.String())
+	}
+
+	// Usage POST: the fake claude bin emitted a terminal result event
+	// with cost 0.0042; the worker must have uploaded it.
+	usages := fc.usageSnapshot()
+	if len(usages) != 1 {
+		t.Fatalf("usage uploads = %d, want 1", len(usages))
+	}
+	u := usages[0]
+	if u == nil {
+		t.Fatal("usage upload body had nil Usage")
+	}
+	if u.TotalCostUSD != 0.0042 {
+		t.Errorf("usage.TotalCostUSD = %v, want 0.0042", u.TotalCostUSD)
+	}
+	if u.InputTokens != 100 || u.OutputTokens != 42 {
+		t.Errorf("usage tokens mismatch: %+v", u)
+	}
+	if u.ModelUsage["claude-opus-4-7"].CostUSD != 0.0042 {
+		t.Errorf("model usage round-trip lost data: %+v", u.ModelUsage)
 	}
 }
 

--- a/internal/worker/chat/loop.go
+++ b/internal/worker/chat/loop.go
@@ -210,6 +210,39 @@ func (l *Loop) postEvents(ctx context.Context, sessionID string, events []cloud.
 	return nil
 }
 
+// postChatUsage uploads the terminal token / cost breakdown for one
+// chat session to cloud's /api/worker/chat/sessions/{id}/usage
+// endpoint. Best-effort: a transport failure is returned but does not
+// fail the session (the browser already saw the answer).
+func (l *Loop) postChatUsage(ctx context.Context, sessionID string, usage *cloud.Usage) error {
+	body, err := json.Marshal(cloud.ChatUsageRequest{Usage: usage})
+	if err != nil {
+		return err
+	}
+	endpoint, err := l.endpoint("/api/worker/chat/sessions/" + url.PathEscape(sessionID) + "/usage")
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if tok := l.cfg.Client.Token(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	resp, err := l.eventClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		buf, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("chat usage HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(buf))
+	}
+	return nil
+}
+
 func (l *Loop) endpoint(path string) (string, error) {
 	base := l.cfg.Client.BaseURL()
 	if base == "" {

--- a/internal/worker/chat/session.go
+++ b/internal/worker/chat/session.go
@@ -70,9 +70,16 @@ func runSession(parent context.Context, l *Loop, a *cloud.ChatAssignment) error 
 }
 
 // runClaude spawns the claude subprocess and shuttles stdout/stderr
-// back to cloud as ChatEvents.
+// back to cloud as ChatEvents. stdout is parsed as `--output-format
+// stream-json --verbose` so the worker can both unwrap assistant text
+// deltas for the browser AND extract the terminal "result" event's
+// token/cost breakdown for the cloud usage POST.
 func (l *Loop) runClaude(ctx context.Context, a *cloud.ChatAssignment, workdir, apiKey, baseURL string) error {
-	cmd := exec.CommandContext(ctx, l.cfg.ClaudeBin, "-p", a.Message)
+	cmd := exec.CommandContext(ctx, l.cfg.ClaudeBin,
+		"-p", a.Message,
+		"--output-format", "stream-json",
+		"--verbose",
+	)
 	cmd.Dir = workdir
 	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
 	// Provide the message on stdin too so claude clients that prefer
@@ -100,14 +107,19 @@ func (l *Loop) runClaude(ctx context.Context, a *cloud.ChatAssignment, workdir, 
 
 	stderrTail := &boundedBuffer{cap: stderrTailBytes}
 
-	var wg sync.WaitGroup
+	var (
+		wg    sync.WaitGroup
+		usage *cloud.Usage
+	)
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		streamReader(stdout, func(chunk []byte) {
+		// parseStreamJSON unwraps assistant text deltas (→ browser via
+		// the batcher) and captures the terminal result event's usage.
+		usage = parseStreamJSON(stdout, func(text string) {
 			b.add(cloud.ChatEvent{
 				Type: cloud.ChatEventOutput,
-				Text: string(chunk),
+				Text: text,
 				Time: time.Now().UTC(),
 			})
 		})
@@ -127,6 +139,16 @@ func (l *Loop) runClaude(ctx context.Context, a *cloud.ChatAssignment, workdir, 
 	wg.Wait()
 	waitErr := cmd.Wait()
 	b.flushNow()
+
+	// Best-effort usage upload: a transport error here is logged but
+	// does NOT fail the session — the browser already saw the answer.
+	if usage != nil {
+		bg, cancel := context.WithTimeout(context.Background(), eventHTTPTimeout)
+		if err := l.postChatUsage(bg, a.SessionID, usage); err != nil {
+			fmt.Fprintf(stderr(), "clawflow chat: post usage: %v\n", err)
+		}
+		cancel()
+	}
 
 	if waitErr == nil {
 		l.emitEnd(a.SessionID)

--- a/internal/worker/chat/streamjson.go
+++ b/internal/worker/chat/streamjson.go
@@ -1,0 +1,103 @@
+package chat
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/zhoushoujianwork/clawflow/internal/cloud"
+)
+
+// parseStreamJSON reads claude's `--output-format stream-json --verbose`
+// output line-by-line, emits each assistant text delta via onText, and
+// returns the terminal `"type":"result"` event's token/cost breakdown
+// (or nil when claude exited without one).
+//
+// Lines that aren't valid JSON or don't carry a recognized event type
+// are silently skipped — claude-cli is allowed to interleave debug
+// breadcrumbs in --verbose mode, and a future event-type addition
+// shouldn't break the parser.
+func parseStreamJSON(r io.Reader, onText func(string)) *cloud.Usage {
+	sc := bufio.NewScanner(r)
+	// Lift the scanner cap so a long result event isn't truncated.
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	var usage *cloud.Usage
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 || line[0] != '{' {
+			continue
+		}
+		var probe struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(line, &probe); err != nil {
+			continue
+		}
+		switch probe.Type {
+		case "assistant", "user":
+			// {"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}
+			var ev struct {
+				Message struct {
+					Content []struct {
+						Type string `json:"type"`
+						Text string `json:"text"`
+					} `json:"content"`
+				} `json:"message"`
+			}
+			if json.Unmarshal(line, &ev) != nil {
+				continue
+			}
+			for _, c := range ev.Message.Content {
+				if c.Type == "text" && c.Text != "" {
+					onText(c.Text)
+				}
+			}
+		case "result":
+			var ev struct {
+				DurationMs   int64   `json:"duration_ms"`
+				NumTurns     int     `json:"num_turns"`
+				TotalCostUSD float64 `json:"total_cost_usd"`
+				Usage        struct {
+					InputTokens              int64 `json:"input_tokens"`
+					OutputTokens             int64 `json:"output_tokens"`
+					CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+					CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+				} `json:"usage"`
+				ModelUsage map[string]struct {
+					InputTokens              int64   `json:"inputTokens"`
+					OutputTokens             int64   `json:"outputTokens"`
+					CacheReadInputTokens     int64   `json:"cacheReadInputTokens"`
+					CacheCreationInputTokens int64   `json:"cacheCreationInputTokens"`
+					CostUSD                  float64 `json:"costUSD"`
+				} `json:"modelUsage"`
+			}
+			if json.Unmarshal(line, &ev) != nil {
+				continue
+			}
+			u := &cloud.Usage{
+				DurationMs:               ev.DurationMs,
+				NumTurns:                 ev.NumTurns,
+				TotalCostUSD:             ev.TotalCostUSD,
+				InputTokens:              ev.Usage.InputTokens,
+				OutputTokens:             ev.Usage.OutputTokens,
+				CacheReadInputTokens:     ev.Usage.CacheReadInputTokens,
+				CacheCreationInputTokens: ev.Usage.CacheCreationInputTokens,
+			}
+			if len(ev.ModelUsage) > 0 {
+				u.ModelUsage = make(map[string]cloud.ModelUsage, len(ev.ModelUsage))
+				for name, m := range ev.ModelUsage {
+					u.ModelUsage[name] = cloud.ModelUsage{
+						InputTokens:              m.InputTokens,
+						OutputTokens:             m.OutputTokens,
+						CacheReadInputTokens:     m.CacheReadInputTokens,
+						CacheCreationInputTokens: m.CacheCreationInputTokens,
+						CostUSD:                  m.CostUSD,
+					}
+				}
+			}
+			usage = u
+		}
+	}
+	return usage
+}

--- a/internal/worker/chat/streamjson_test.go
+++ b/internal/worker/chat/streamjson_test.go
@@ -1,0 +1,62 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseStreamJSON covers the worker-side parser standalone: text
+// deltas come out via the callback in order; the terminal result
+// event's usage is returned; non-recognized / non-JSON lines are
+// tolerated silently.
+func TestParseStreamJSON(t *testing.T) {
+	transcript := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,                                                                                                                                                                              // ignored
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Hello "}]}}`,                                                                                                                                    // delta 1
+		`debug breadcrumb that is not JSON`,                                                                                                                                                                               // ignored (not JSON)
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"world!"}]}}`,                                                                                                                                    // delta 2
+		`{"type":"user","message":{"content":[{"type":"tool_result","content":"..."}]}}`,                                                                                                                                  // ignored (no text content)
+		`{"type":"result","duration_ms":2500,"num_turns":2,"total_cost_usd":0.0099,"usage":{"input_tokens":300,"output_tokens":75,"cache_read_input_tokens":1000,"cache_creation_input_tokens":20},"modelUsage":{"claude-opus-4-7":{"inputTokens":300,"outputTokens":75,"cacheReadInputTokens":1000,"cacheCreationInputTokens":20,"costUSD":0.0099}}}`,
+	}, "\n")
+
+	var sb strings.Builder
+	usage := parseStreamJSON(strings.NewReader(transcript), func(s string) { sb.WriteString(s) })
+
+	if sb.String() != "Hello world!" {
+		t.Errorf("text deltas = %q, want %q", sb.String(), "Hello world!")
+	}
+	if usage == nil {
+		t.Fatal("usage is nil; expected result event to be parsed")
+	}
+	if usage.TotalCostUSD != 0.0099 {
+		t.Errorf("TotalCostUSD = %v, want 0.0099", usage.TotalCostUSD)
+	}
+	if usage.InputTokens != 300 || usage.OutputTokens != 75 {
+		t.Errorf("tokens mismatch: %+v", usage)
+	}
+	if usage.DurationMs != 2500 || usage.NumTurns != 2 {
+		t.Errorf("metadata mismatch: %+v", usage)
+	}
+	m, ok := usage.ModelUsage["claude-opus-4-7"]
+	if !ok {
+		t.Fatalf("model breakdown missing: %+v", usage.ModelUsage)
+	}
+	if m.CostUSD != 0.0099 || m.InputTokens != 300 {
+		t.Errorf("model usage round-trip wrong: %+v", m)
+	}
+}
+
+// TestParseStreamJSON_NoResultEvent verifies the parser returns nil
+// when claude exits before emitting a result event (e.g. crash). The
+// worker treats this as "session ran but no usage to report".
+func TestParseStreamJSON_NoResultEvent(t *testing.T) {
+	transcript := `{"type":"assistant","message":{"content":[{"type":"text","text":"partial..."}]}}`
+	var got string
+	usage := parseStreamJSON(strings.NewReader(transcript), func(s string) { got = s })
+	if usage != nil {
+		t.Errorf("usage = %+v, want nil", usage)
+	}
+	if got != "partial..." {
+		t.Errorf("got = %q, want %q", got, "partial...")
+	}
+}


### PR DESCRIPTION
Closes #167 (sub-issue of #164). Depends on PR 4 sub 1 (already merged).

## Summary

The chat path now uploads token/cost numbers per session. Worker switches from raw `claude -p` to `claude -p --output-format stream-json --verbose`, parses out the terminal result event, and POSTs it to the endpoint sub 1 stood up. The browser contract is unchanged — SSE consumers still see plain text, never JSON envelopes.

## What changed

### `internal/worker/chat/streamjson.go` (new)
- `parseStreamJSON(reader, onText) → *cloud.Usage`. Reads claude's stream-json line-by-line, fires `onText` for each `assistant`/`user` text content chunk, captures the terminal `"type":"result"` event including per-model breakdown.
- Lenient: lines that aren't valid JSON, or that carry types we don't recognize, are silently skipped. Lets claude-cli interleave debug breadcrumbs in `--verbose` mode without breaking the parser.

### `internal/worker/chat/session.go`
- `runClaude` invokes claude with `-p <message> --output-format stream-json --verbose`. stdout drains through `parseStreamJSON` instead of `streamReader`.
- Usage captured via a goroutine closure; after `cmd.Wait` the worker POSTs it via the new `postChatUsage`. Upload errors logged but don't fail the session.

### `internal/worker/chat/loop.go`
- New `postChatUsage(ctx, sessionID, *cloud.Usage)` helper. Same shape as `postEvents`: 20s `eventClient`, Bearer auth, JSON body.

### Tests
- `chat_test.go`: `fakeClaudeBin` now emits a canned stream-json transcript (one text delta + one result event). `fakeCloud` accepts `/usage` POSTs too and exposes them via `usageSnapshot()`.
- `TestRunSession_HappyPath`: extended to assert (a) the browser receives plain text (no `"type":"assistant"` envelope leak) and (b) the usage upload happened with the right cost / tokens / model breakdown.
- `streamjson_test.go` (new): parser-level coverage — ordered text deltas, result event extraction, non-JSON line tolerance, nil return on missing result event.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test -race ./...` all packages green.
- [x] `go test -race ./internal/worker/chat/...` — new parser tests + extended HappyPath pass.

## Backward compatibility

Browser-side wire format unchanged: `ChatEventOutput` events still carry plain text. The new `/usage` POST is best-effort — a worker that fails to upload doesn't fail the session, and the cloud row simply doesn't carry cost numbers (graceful degradation).

## What's NOT in this PR

- Web `/cloud/usage` page (#169 sub 5) — final piece of PR 4.
- Multi-turn chat history (`claude --continue`) — still one fresh `claude -p` per user message. That was already on the PR 4+ wishlist; orthogonal to usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)