### PR TITLE
PR 4 sub 5: web /cloud/usage renders summary (drop redirect)

### DIFF
--- a/web/src/lib/cloudApi.ts
+++ b/web/src/lib/cloudApi.ts
@@ -207,6 +207,64 @@ export async function deleteBinding(id: string): Promise<void> {
   }
 }
 
+// ---- Usage ----
+
+/** UsageAggregate mirrors the JSON shape produced by the cloud
+ * /api/cloud/usage/summary endpoint and by the local `clawflow web`
+ * data/usage.json. Both surfaces use the same shape so the Usage
+ * page can render either without translation. */
+export interface UsageAggregate {
+  runs: number
+  total_cost_usd: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_input_tokens: number
+  cache_creation_input_tokens: number
+  duration_ms: number
+}
+
+export interface ModelAggregate {
+  cost_usd: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_input_tokens: number
+  cache_creation_input_tokens: number
+}
+
+export interface DailyPoint {
+  date: string
+  runs: number
+  total_cost_usd: number
+  input_tokens: number
+  output_tokens: number
+  by_operator?: Record<string, UsageAggregate>
+  by_repo?: Record<string, UsageAggregate>
+  by_model?: Record<string, ModelAggregate>
+}
+
+export interface PeriodSummary {
+  period_start: string
+  period_end: string
+  totals: UsageAggregate
+  by_operator: Record<string, UsageAggregate>
+  by_repo: Record<string, UsageAggregate>
+  by_model: Record<string, ModelAggregate>
+  daily_trend: DailyPoint[]
+}
+
+export interface UsageSummary {
+  generated_at: string
+  totals: UsageAggregate
+  by_operator: Record<string, UsageAggregate>
+  by_repo: Record<string, UsageAggregate>
+  by_model: Record<string, ModelAggregate>
+  periods?: PeriodSummary[]
+}
+
+export function fetchUsageSummary(): Promise<UsageSummary> {
+  return cloudFetch<UsageSummary>('/api/cloud/usage/summary')
+}
+
 // ---- Repos ----
 
 export function fetchRepos(): Promise<{ repos: Repo[] }> {

--- a/web/src/routes/_app.usage.tsx
+++ b/web/src/routes/_app.usage.tsx
@@ -1,59 +1,22 @@
-import { createFileRoute, Navigate } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react'
 import { Receipt } from 'lucide-react'
 import { type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
-import { fetchAuthMe, type AuthMeResult } from '../lib/cloudApi'
+import {
+  fetchAuthMe,
+  fetchRepos,
+  fetchUsageSummary,
+  type AuthMeResult,
+  type DailyPoint,
+  type PeriodSummary,
+  type UsageAggregate,
+  type UsageSummary,
+} from '../lib/cloudApi'
 
-interface UsageAggregate {
-  runs: number
-  total_cost_usd: number
-  input_tokens: number
-  output_tokens: number
-  cache_read_input_tokens: number
-  cache_creation_input_tokens: number
-  duration_ms: number
-}
-
-interface ModelAggregate {
-  cost_usd: number
-  input_tokens: number
-  output_tokens: number
-  cache_read_input_tokens: number
-  cache_creation_input_tokens: number
-}
-
-interface DailyPoint {
-  date: string
-  runs: number
-  total_cost_usd: number
-  input_tokens: number
-  output_tokens: number
-  by_operator?: Record<string, UsageAggregate>
-  by_repo?: Record<string, UsageAggregate>
-  by_model?: Record<string, ModelAggregate>
-}
-
-interface PeriodSummary {
-  period_start: string
-  period_end: string
-  totals: UsageAggregate
-  by_operator: Record<string, UsageAggregate>
-  by_repo: Record<string, UsageAggregate>
-  by_model: Record<string, ModelAggregate>
-  daily_trend: DailyPoint[]
-}
-
-interface UsageSummary {
-  generated_at: string
-  totals: UsageAggregate
-  by_operator: Record<string, UsageAggregate>
-  by_repo: Record<string, UsageAggregate>
-  by_model: Record<string, ModelAggregate>
-  periods?: PeriodSummary[]
-}
-
-interface Repo {
+// Local-mode repo shape lives in /data/repos.json. Cloud-mode uses
+// the cloud.Repo from fetchRepos() — see CloudUsagePage.
+interface LocalRepo {
   full_name: string
   platform?: Platform
   base_url?: string
@@ -103,26 +66,87 @@ function fmtPeriodLabel(start: string, end: string): string {
 }
 
 function UsagePage() {
-  // Usage rolls up data from /data/usage.json — only `clawflow web` writes
-  // that file. On a cloud-served bundle the file doesn't exist; redirect
-  // to /cloud/jobs which is the cloud-native equivalent (job/run history).
+  // Route by auth: authenticated cloud sessions get the
+  // CloudUsagePage which fetches /api/cloud/usage/summary; local
+  // `clawflow web` sessions ('no-cloud') get the legacy local page
+  // that reads /data/usage.json.
   const [auth, setAuth] = useState<AuthMeResult | undefined>(undefined)
   useEffect(() => {
     fetchAuthMe().then(setAuth).catch(() => setAuth({ kind: 'no-cloud' }))
   }, [])
-  if (auth?.kind === 'authed' || auth?.kind === 'anon') {
-    return <Navigate to="/cloud/jobs" replace />
+  if (auth === undefined) {
+    return <p className="text-sm text-muted-foreground text-center py-8">Loading…</p>
   }
-
+  if (auth.kind === 'authed' || auth.kind === 'anon') {
+    return <CloudUsagePage />
+  }
   return <LocalUsagePage />
 }
 
+// ---- Cloud page: fetches /api/cloud/usage/summary -----------------
+
+function CloudUsagePage() {
+  const [summary, setSummary] = useState<UsageSummary | null>(null)
+  const [repoMap, setRepoMap] = useState<RepoInfoMap>({})
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    const refetch = async (initial: boolean) => {
+      if (initial) setLoading(true)
+      try {
+        const [u, repoResp] = await Promise.all([
+          fetchUsageSummary(),
+          fetchRepos().catch(() => ({ repos: [] })),
+        ])
+        if (cancelled) return
+        const m: RepoInfoMap = {}
+        for (const r of repoResp.repos) {
+          const platform: Platform = r.platform === 'gitlab' ? 'gitlab' : 'github'
+          m[r.name] = {
+            platform,
+            host: platform === 'gitlab' ? 'https://gitlab.com' : 'https://github.com',
+          }
+        }
+        setSummary(u)
+        setRepoMap(m)
+      } catch {
+        if (!cancelled) setSummary(null)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    refetch(true)
+    // Cloud aggregation is a server-side query — poll less aggressively
+    // than the local 5s rhythm to avoid pestering the cloud server.
+    const id = setInterval(() => refetch(false), 15_000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  return (
+    <UsageView
+      summary={summary}
+      repoMap={repoMap}
+      loading={loading}
+      emptyHint={
+        <>
+          No usage data yet — run a job, or open a chat against a repo
+          bound to a worker. Numbers show up here within a few seconds.
+        </>
+      }
+    />
+  )
+}
+
+// ---- Local page: reads /data/usage.json --------------------------
+
 function LocalUsagePage() {
   const [summary, setSummary] = useState<UsageSummary | null>(null)
-  const [repos, setRepos] = useState<Repo[]>([])
+  const [repos, setRepos] = useState<LocalRepo[]>([])
   const [loading, setLoading] = useState(true)
-  const [selectedPeriod, setSelectedPeriod] = useState<string>('current')
-  const [selectedDay, setSelectedDay] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -164,6 +188,38 @@ function LocalUsagePage() {
     return m
   }, [repos])
 
+  return (
+    <UsageView
+      summary={summary}
+      repoMap={repoMap}
+      loading={loading}
+      emptyHint={
+        <>
+          No completed runs with usage data yet — run{' '}
+          <code className="px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">clawflow run</code>{' '}
+          first.
+        </>
+      }
+    />
+  )
+}
+
+// ---- Shared render --------------------------------------------------
+
+function UsageView({
+  summary,
+  repoMap,
+  loading,
+  emptyHint,
+}: {
+  summary: UsageSummary | null
+  repoMap: RepoInfoMap
+  loading: boolean
+  emptyHint: React.ReactNode
+}) {
+  const [selectedPeriod, setSelectedPeriod] = useState<string>('current')
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
+
   const periods = summary?.periods ?? []
 
   const activePeriod = useMemo<PeriodSummary | null>(() => {
@@ -172,13 +228,11 @@ function LocalUsagePage() {
     return periods.find(p => p.period_start === selectedPeriod) ?? null
   }, [selectedPeriod, periods])
 
-  // When a day bar is clicked, drill down into that day's breakdowns
   const activeDay = useMemo<DailyPoint | null>(() => {
     if (!selectedDay || !activePeriod) return null
     return activePeriod.daily_trend.find(d => d.date === selectedDay) ?? null
   }, [selectedDay, activePeriod])
 
-  // Clear day selection when period changes
   useEffect(() => { setSelectedDay(null) }, [selectedPeriod])
 
   const viewTotals = activeDay
@@ -244,11 +298,7 @@ function LocalUsagePage() {
         <div className="bg-card border border-border rounded-xl p-12 flex flex-col items-center text-center">
           <Receipt className="w-12 h-12 text-muted-foreground/40 mb-4" />
           <p className="text-base font-semibold text-foreground mb-1">No usage data yet</p>
-          <p className="text-sm text-muted-foreground">
-            No completed runs with usage data yet — run{' '}
-            <code className="px-1.5 py-0.5 bg-secondary rounded text-xs font-mono">clawflow run</code>{' '}
-            first.
-          </p>
+          <p className="text-sm text-muted-foreground">{emptyHint}</p>
         </div>
       ) : (
         <>


### PR DESCRIPTION
Closes #169 (sub-issue of #164). Depends on PR 4 subs 1 + 4 (already merged).

## Summary

Final piece of PR 4. The cloud-mode Usage page is no longer empty — it fetches `/api/cloud/usage/summary` (sub 4) and renders the panels that local mode has always had: totals, daily-cost trend, per-operator / per-model / per-repo breakdowns.

End-to-end of PR 4 is now closed:

```
worker (job run / chat session)
  → cost numbers from events.jsonl OR stream-json result event
  → POST /finish (jobs) OR /usage (chat)
  → run_usage / chat_usage tables
  → GET /api/cloud/usage/summary
  → /cloud/usage page
```

## What changed

### `web/src/lib/cloudApi.ts`
- New TS interfaces: `UsageAggregate`, `ModelAggregate`, `DailyPoint`, `PeriodSummary`, `UsageSummary`. Match the Go shape exactly.
- New helper: `fetchUsageSummary()` → `/api/cloud/usage/summary`.

### `web/src/routes/_app.usage.tsx`
- **Drops the redirect** at the old `if (auth?.kind === 'authed' || 'anon') return <Navigate to="/cloud/jobs" />`.
- `UsagePage` now routes auth='authed'|'anon' → `CloudUsagePage`, auth='no-cloud' → `LocalUsagePage`.
- `CloudUsagePage`: fetches `fetchUsageSummary()` + `fetchRepos()`, builds the `RepoInfoMap` from the cloud repo shape, polls every 15s.
- `LocalUsagePage`: unchanged behavior — still reads `/data/usage.json` + `/data/repos.json` on the 5s rhythm.
- `UsageView` shared component renders both. Empty-state hint customized per surface ("run a job or chat" vs "run clawflow run").
- Duplicate TS type defs in the route file deleted; route imports them from `cloudApi.ts`.

## Test plan

- [x] `npm run build` (vite + `tsc --noEmit`) clean.
- [x] `go test -race ./...` clean (no Go changes, just sanity).
- [ ] **Manual E2E** on `clawflow.daboluo.cc` (caller's job — I can't reach the cloud from here): after worker is updated, run an `evaluate-bug` against a real issue or open a chat drawer; cost should show on `/usage` within 5-15s. (Sub 1–4 ship the producer/consumer chain; this PR is the viewer.)

## What's done with PR 4 after this lands

All 5 sub-issues closed. The parent #164 closes via the comment summary I'll post after merge.

## Follow-ups (not in PR 4)

- Populate `run_usage.user_id` from repo ownership at FinishRun time (currently relies on the "empty-user fallback" in `ListUsageForUser`). Untangles full multi-tenant scoping.
- Multi-turn chat memory (`claude --continue`). Already flagged in #163's "Not in this PR" list — orthogonal to usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)