### PR TITLE
ci(release): build Linux binary with CGO_ENABLED=0 (static)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,12 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          # CGO disabled so the Linux binary is statically linked and
+          # doesn't fail with "GLIBC_2.34 not found" on older base
+          # images (Ubuntu 20.04 / Aliyun ECS / etc.). The cloud build
+          # has no native deps — modernc.org/sqlite is pure Go — so
+          # this is a safe blanket setting for all three targets.
+          CGO_ENABLED: 0
         run: |
           VERSION=${GITHUB_REF_NAME}
           go build -ldflags "-s -w -X github.com/zhoushoujianwork/clawflow/cmd/clawflow/commands.Version=${VERSION}" \


### PR DESCRIPTION
## Why

v0.68.0 shipped a dynamically-linked Linux binary built on ubuntu-latest (glibc 2.39). Deploying it to the Aliyun production VM (older Ubuntu base) crashed the service:

```
/usr/local/bin/clawflow: /lib64/libc.so.6: version 'GLIBC_2.34' not found
```

I worked around v0.68.0 by rebuilding locally with \`CGO_ENABLED=0\` and re-uploading the asset; prod is now healthy on v0.68.0. This PR makes future releases automatically static.

## What

Adds \`CGO_ENABLED: 0\` to the release.yml build step env. Safe because the only native-ish dep is SQLite via modernc.org/sqlite which is pure Go.

## Test plan

- [x] release.yml syntax sanity — single env addition, no other changes.
- [ ] Next release tag will produce a static \`clawflow_linux_amd64\` (verify via \`file\` on the asset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)