### PR TITLE
fix(cloud): make /api/cloud/operators public (parity with local)

### DIFF
--- a/internal/cloud/server.go
+++ b/internal/cloud/server.go
@@ -110,7 +110,12 @@ func NewServerWithExtras(store Store, operators *operator.Registry, auth AuthHan
 	mux.HandleFunc("/api/cloud/machines", s.withAuth(s.handleCloudMachines))
 	mux.HandleFunc("/api/cloud/jobs", s.withAuth(s.handleCloudJobs))
 	mux.HandleFunc("/api/cloud/runs", s.withAuth(s.handleCloudRuns))
-	mux.HandleFunc("/api/cloud/operators", s.withAuth(s.handleCloudOperators))
+	// Operators registry is just the embedded SKILL.md catalog — public
+	// metadata, no user-scoped data. Skipping s.withAuth so the
+	// Operators page renders the same list on anonymous cloud as it
+	// does on local `clawflow web` (which reads /data/operators.json
+	// without auth too).
+	mux.HandleFunc("/api/cloud/operators", s.handleCloudOperators)
 	mux.HandleFunc("/api/cloud/usage/summary", s.withAuth(s.handleCloudUsageSummary))
 
 	// Webhook route matches the GitHub App's configured Webhook URL exactly.


### PR DESCRIPTION
Caught while comparing the Operators page cloud-vs-local: local renders the full Triage/Evaluation/… grouped list; cloud anon shows \"No operators registered.\"

Root cause: \`/api/cloud/operators\` is wrapped in \`s.withAuth\`, so anonymous requests get 401. The frontend silently catches the 401 and falls back to an empty list.

The operators registry is just metadata about the SKILL.md files embedded in the binary — no user-scoped state. The local-mode equivalent (\`/data/operators.json\`) is served publicly. Drop the auth gate to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)