### PR TITLE
feat(web,api): cloud-shape repos in local mode + cloud→localhost agent chat

### DIFF
--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -233,7 +233,10 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/run/status", api.HandleRunStatus)
 			mux.HandleFunc("/api/run/pause", api.HandleRunPause)
 			mux.HandleFunc("/api/run/cancel", api.HandleRunCancel)
-			mux.HandleFunc("/api/version", api.HandleVersion)
+			// /api/version doubles as the cloud bundle's local-agent
+			// probe; CORS-gated so a remote browser can detect this
+			// machine without exposing the endpoint to arbitrary sites.
+			mux.HandleFunc("/api/version", api.WithChatAgentCORS(api.HandleVersion))
 			mux.HandleFunc("/api/update", api.HandleUpdate)
 			mux.HandleFunc("/api/repo/config", api.HandleRepoConfig)
 			mux.HandleFunc("/api/repo/bind", api.HandleRepoBind)
@@ -277,7 +280,10 @@ here — run 'clawflow run' first if you want fresh data.`,
 				}
 			})
 			mux.HandleFunc("/api/browse-directory", api.HandleBrowseDirectory)
-			mux.HandleFunc("/api/chat/spawn", api.HandleChatSpawn)
+			// CORS-gated so a remote cloud bundle can spawn a local
+			// terminal here. Only the user's configured cloud URL is
+			// allowed (worker.yaml `saas_url`) — see cors_chat_agent.go.
+			mux.HandleFunc("/api/chat/spawn", api.WithChatAgentCORS(api.HandleChatSpawn))
 			mux.HandleFunc("/api/project/create", api.HandleProjectCreate)
 			mux.HandleFunc("/api/project/delete", api.HandleProjectDelete)
 			mux.HandleFunc("/api/project/add-repo", api.HandleProjectAddRepo)
@@ -298,8 +304,14 @@ here — run 'clawflow run' first if you want fresh data.`,
 			// same-origin and never sees the token.
 			mux.HandleFunc("/api/cloud/status", api.HandleCloudStatus)
 			mux.HandleFunc("/api/cloud/config", api.HandleCloudConfig)
-			mux.HandleFunc("/api/cloud/machines", api.HandleCloudMachines)
-			mux.HandleFunc("/api/cloud/bindings", api.HandleCloudBindings)
+			// /api/cloud/{repos,projects,machines,bindings} dual-mode:
+			// proxy upstream when cloud is configured, or translate the
+			// local config.yaml to the cloud shape so the Repos /
+			// Projects pages render the same filter UI in offline mode.
+			mux.HandleFunc("/api/cloud/repos", api.HandleCloudRepos)
+			mux.HandleFunc("/api/cloud/projects", api.HandleCloudProjects)
+			mux.HandleFunc("/api/cloud/machines", api.HandleCloudMachinesLocal)
+			mux.HandleFunc("/api/cloud/bindings", api.HandleCloudBindingsLocal)
 			mux.HandleFunc("/api/cloud/bindings/", api.HandleCloudBindingByID)
 			mux.HandleFunc("/api/cloud/jobs", api.HandleCloudJobs)
 			mux.HandleFunc("/api/cloud/runs", api.HandleCloudRuns)

--- a/internal/api/cloud_local_repos.go
+++ b/internal/api/cloud_local_repos.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/cloud"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+// HandleCloudRepos serves GET /api/cloud/repos in two modes:
+//
+//   - If a cloud is configured (access token present), proxy the request
+//     upstream so the browser sees the cloud's authoritative repo list.
+//   - Otherwise translate the local ~/.clawflow/config/config.yaml into
+//     the cloud Repo shape so the React Repos page can render its
+//     existing filter / table UI without any frontend branching.
+//
+// The local translation is intentionally read-only — POST/DELETE/PATCH
+// against /api/cloud/repos still 503 in unconfigured mode because there
+// is no cloud Store to mutate.
+func HandleCloudRepos(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		// Write paths require the real cloud — proxy and let it answer
+		// (or 503 if not configured).
+		cloudProxy(w, r, "/api/cloud/repos")
+		return
+	}
+	cfg, _ := cloud.LoadConfig()
+	if cfg.AccessToken != "" {
+		cloudProxy(w, r, "/api/cloud/repos")
+		return
+	}
+	// Local mode: translate config.yaml → []cloud.Repo
+	local, err := config.Load()
+	if err != nil || local == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"repos": []cloud.Repo{}})
+		return
+	}
+	now := time.Now().UTC()
+	out := make([]cloud.Repo, 0, len(local.Repos))
+	for name, r := range local.Repos {
+		platform := r.Platform
+		if platform == "" {
+			platform = "github"
+		}
+		out = append(out, cloud.Repo{
+			// Use full_name as the opaque ID so binding/filter wiring
+			// has a stable handle. The cloud-side uses repo-XXXX
+			// random IDs; local mode is single-user so colliding with
+			// a real cloud ID is impossible.
+			ID:         name,
+			Name:       name,
+			Platform:   platform,
+			BaseBranch: r.BaseBranch,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"repos": out})
+}
+
+// HandleCloudProjects serves GET /api/cloud/projects. Local config has
+// no project concept, so the unconfigured-mode path returns an empty
+// list — the Repos page's project filter chip count stays at zero, and
+// the Projects page renders its empty state.
+func HandleCloudProjects(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		cloudProxy(w, r, "/api/cloud/projects")
+		return
+	}
+	cfg, _ := cloud.LoadConfig()
+	if cfg.AccessToken != "" {
+		cloudProxy(w, r, "/api/cloud/projects")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"projects": []cloud.Project{}})
+}
+
+// HandleCloudMachinesLocal replaces the proxy-only HandleCloudMachines
+// when local mode is in effect: returns one synthetic Machine per
+// unique bound_machine value in config so the Repos page's
+// "Last bound machine" column renders the hostname instead of "—".
+func HandleCloudMachinesLocal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		HandleCloudMachines(w, r)
+		return
+	}
+	cfg, _ := cloud.LoadConfig()
+	if cfg.AccessToken != "" {
+		HandleCloudMachines(w, r)
+		return
+	}
+	local, err := config.Load()
+	if err != nil || local == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"machines": []cloud.Machine{}})
+		return
+	}
+	seen := map[string]bool{}
+	now := time.Now().UTC()
+	out := []cloud.Machine{}
+	for _, r := range local.Repos {
+		h := r.BoundMachine
+		if h == "" || seen[h] {
+			continue
+		}
+		seen[h] = true
+		out = append(out, cloud.Machine{
+			ID:          h,
+			Hostname:    h,
+			DisplayName: h,
+			LastSeenAt:  now,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"machines": out})
+}
+
+// HandleCloudBindingsLocal returns one Binding per repo whose
+// bound_machine is set. machine_id reuses the hostname (matching the
+// synthetic machine IDs above), repo_id reuses the repo's full_name
+// (matching HandleCloudRepos).
+func HandleCloudBindingsLocal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		HandleCloudBindings(w, r)
+		return
+	}
+	cfg, _ := cloud.LoadConfig()
+	if cfg.AccessToken != "" {
+		HandleCloudBindings(w, r)
+		return
+	}
+	local, err := config.Load()
+	if err != nil || local == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"bindings": []cloud.Binding{}})
+		return
+	}
+	now := time.Now().UTC()
+	out := []cloud.Binding{}
+	for name, r := range local.Repos {
+		if r.BoundMachine == "" {
+			continue
+		}
+		out = append(out, cloud.Binding{
+			ID:        "local:" + name,
+			MachineID: r.BoundMachine,
+			RepoID:    name,
+			CreatedAt: now,
+			UpdatedAt: now,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"bindings": out})
+}

--- a/internal/api/cors_chat_agent.go
+++ b/internal/api/cors_chat_agent.go
@@ -1,0 +1,61 @@
+// Package api — cors_chat_agent gates cross-origin access to the local
+// chat-spawn endpoint so a remote ClawFlow cloud bundle (e.g.
+// clawflow.daboluo.cc) can detect this machine's local `clawflow web`
+// and spawn a native terminal here instead of the in-browser drawer.
+//
+// Security model: only the EXACT cloud URL the user has explicitly
+// configured via `clawflow login` (written to ~/.clawflow/config/
+// worker.yaml as `saas_url`) is allowed. Random websites cannot reach
+// `/api/chat/spawn` from a remote origin — the Access-Control-Allow-
+// Origin header is only emitted when r.Origin matches that URL, so the
+// browser blocks the request before it reaches the handler.
+//
+// This means the user must `clawflow login` once for the cloud → local
+// terminal flow to work, which is already the prereq for cloud chat at
+// all. No new config knob.
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/cloud"
+)
+
+// WithChatAgentCORS wraps the local-agent endpoints (/api/version,
+// /api/chat/spawn) with origin-restricted CORS. Same-origin (no Origin
+// header, or Origin matching this server) passes through unchanged.
+func WithChatAgentCORS(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if origin := r.Header.Get("Origin"); origin != "" && isAllowedAgentOrigin(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			w.Header().Set("Access-Control-Max-Age", "300")
+			w.Header().Add("Vary", "Origin")
+		}
+		if r.Method == http.MethodOptions {
+			// Preflight: 204 with whatever CORS headers were set above
+			// (or none, which the browser interprets as "not allowed").
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		h(w, r)
+	}
+}
+
+// isAllowedAgentOrigin returns true when origin exactly matches the
+// configured cloud URL (no scheme/path tolerance — strict equality
+// against the trimmed saas_url). Empty cloud config means no
+// cross-origin access; the user must `clawflow login` first.
+func isAllowedAgentOrigin(origin string) bool {
+	cfg, err := cloud.LoadConfig()
+	if err != nil {
+		return false
+	}
+	cloudURL := strings.TrimRight(cfg.BaseURL, "/")
+	if cloudURL == "" {
+		return false
+	}
+	return origin == cloudURL
+}

--- a/web/src/lib/chatContext.tsx
+++ b/web/src/lib/chatContext.tsx
@@ -147,8 +147,55 @@ function makeId(prefix: string): string {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 }
 
+// LOCAL_AGENT_CANDIDATES is the short list of localhost URLs the cloud
+// bundle probes on mount to detect a co-located `clawflow web`. The
+// first 200-OK response (with CORS allow — see internal/api/
+// cors_chat_agent.go) wins; chat.open() then targets that URL's
+// /api/chat/spawn instead of the in-browser cloud drawer.
+//
+// 8090 is the `clawflow web --port` default; 7070 is a common
+// override. If a user binds elsewhere they can still use the drawer.
+const LOCAL_AGENT_CANDIDATES = [
+  'http://127.0.0.1:8090',
+  'http://127.0.0.1:7070',
+]
+
+// probeLocalAgent races the GET /api/version probes against the
+// candidate list and resolves to the first reachable URL, or null
+// when nothing answers within 800 ms (typical localhost RTT is sub-
+// 10 ms; the cap is just a guard against blocking the cloud drawer
+// behind a slow probe).
+async function probeLocalAgent(): Promise<string | null> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 800)
+  try {
+    const results = await Promise.allSettled(
+      LOCAL_AGENT_CANDIDATES.map(async url => {
+        const r = await fetch(`${url}/api/version`, {
+          mode: 'cors',
+          signal: controller.signal,
+        })
+        if (!r.ok) throw new Error(`probe ${url}: ${r.status}`)
+        return url
+      }),
+    )
+    for (const res of results) {
+      if (res.status === 'fulfilled') return res.value
+    }
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 export function ChatProvider({ children }: { children: ReactNode }) {
   const [hostMode, setHostMode] = useState<HostMode>(undefined)
+  // agentURL is the prefix used by openLocal when hostMode === 'local'.
+  // Empty string = same-origin local web bundle (chatContext is on the
+  // local server itself). A full http://127.0.0.1:NNNN URL = a remote
+  // cloud bundle that discovered a co-located local-web via the
+  // localhost probe above.
+  const [agentURL, setAgentURL] = useState<string>('')
   const [spawnError, setSpawnError] = useState<SpawnError | null>(null)
   const [cloud, setCloud] = useState<CloudState>({ messages: [], status: 'idle' })
   const [cloudOpen, setCloudOpen] = useState(false)
@@ -161,20 +208,43 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // fresh assistant bubble.
   const activeAssistantIdRef = useRef<string | null>(null)
 
-  // Probe host mode on mount. fetchAuthMe returns 'no-cloud' when
-  // /api/v1/auth/me doesn't exist on this origin (local bundle).
+  // Probe host mode on mount. Two probes race:
+  //
+  //   1. fetchAuthMe — 'no-cloud' (404) means we're on a local-web
+  //      bundle, so hostMode is unambiguously 'local'.
+  //   2. probeLocalAgent — looks for a `clawflow web` on common
+  //      localhost ports. Only succeeds when origin === user's
+  //      configured cloud URL (CORS gate). When it succeeds the
+  //      remote cloud bundle gets to spawn a native terminal here
+  //      via /api/chat/spawn instead of falling back to the in-
+  //      browser drawer (the user's stated preference).
+  //
+  // Local-web bundle always gets hostMode='local' with agentURL=''
+  // (relative paths). Cloud bundle gets 'local' + the probed agent
+  // URL when reachable, else 'cloud' for the drawer fallback.
   useEffect(() => {
     let cancelled = false
-    fetchAuthMe()
-      .then(r => {
-        if (cancelled) return
-        setHostMode(r.kind === 'no-cloud' ? 'local' : 'cloud')
-      })
-      .catch(() => {
-        // Treat network errors as local — fetchAuthMe already maps
-        // network failures to 'no-cloud', but be defensive.
-        if (!cancelled) setHostMode('local')
-      })
+    ;(async () => {
+      const me = await fetchAuthMe().catch(() => ({ kind: 'no-cloud' as const }))
+      if (cancelled) return
+      if (me.kind === 'no-cloud') {
+        setHostMode('local')
+        setAgentURL('')
+        return
+      }
+      // Remote bundle — try the localhost agent. If found, route
+      // chat through it; otherwise stay in cloud (drawer) mode.
+      const agent = await probeLocalAgent()
+      if (cancelled) return
+      if (agent) {
+        setAgentURL(agent)
+        setHostMode('local')
+      } else {
+        setHostMode('cloud')
+      }
+    })().catch(() => {
+      if (!cancelled) setHostMode('local')
+    })
     return () => {
       cancelled = true
     }
@@ -273,7 +343,10 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const openLocal = useCallback(async (t: ChatTarget) => {
     setSpawnError(null)
     try {
-      const r = await fetch('/api/chat/spawn', {
+      // agentURL is empty string for same-origin (local-web bundle)
+      // and a full http://127.0.0.1:NNNN URL when this is a cloud
+      // bundle that found a co-located local-web during the probe.
+      const r = await fetch(`${agentURL}/api/chat/spawn`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(t),
@@ -295,7 +368,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         error: String((e as Error).message || e),
       })
     }
-  }, [])
+  }, [agentURL])
 
   const openCloud = useCallback(
     async (t: ChatTarget) => {


### PR DESCRIPTION
Two polish items from the post-v0.68.0 local-vs-cloud comparison.

## 1. Local /repos and /projects now show real data

The Repos page was showing the Sign-in panel even when running on local `clawflow web`, because the page hits \`/api/cloud/repos\` and that endpoint wasn't mounted on local web. Now mounted in dual mode:

- **Cloud configured** (\`worker.yaml\` has \`saas_url\` + \`worker_token\`): proxy upstream as before.
- **No cloud**: translate the local \`config.yaml\` into the cloud \`Repo\` shape so the React page renders its filter / table UI unchanged.

Same dual-mode wiring for \`/api/cloud/{projects,machines,bindings}\`. Mutating methods (POST / DELETE / PATCH) still proxy → cloud and 503 if not configured; this is a read-only fallback for local viewing.

## 2. Cloud bundle → native terminal via local agent

Per the user's recorded preference (\"chat opens native Terminal via localhost agent, not browser drawer; cloud drawer kept behind opt-in\"). When viewing the cloud bundle on a machine that ALSO runs \`clawflow web\` locally, the chat icon now spawns the native terminal — the cloud drawer is the fallback only when no local agent is reachable.

- \`internal/api/cors_chat_agent.go\`: origin-restricted CORS wrapper. Only the EXACT cloud URL the user configured via \`clawflow login\` (\`worker.yaml\` \`saas_url\`) is allowed — random websites cannot trigger a local terminal spawn.
- \`/api/version\` and \`/api/chat/spawn\` are wrapped with this middleware in local web.
- \`web/src/lib/chatContext.tsx\`: \`probeLocalAgent()\` races GET \`/api/version\` against \`http://127.0.0.1:{8090,7070}\` on mount with an 800 ms timeout. First 200-OK wins; \`agentURL\` is then prepended to \`/api/chat/spawn\` POSTs.

## Verified

- \`go test -race ./internal/api/...\` clean.
- \`pnpm build\` clean.
- CORS:
  - configured cloud origin → \`Access-Control-Allow-Origin\` set ✓
  - unrelated origin → no ACAO header → browser blocks ✓
- localhost:7070 \`/repos\` now renders the full filter UI with 19 repos (was the Sign-in panel before).

## Test plan after merge

- [ ] Reload \`clawflow.daboluo.cc/repos\` with a local \`clawflow web --port 7070\` running; chat icon should spawn iTerm.
- [ ] Same page with NO local web running; chat icon should fall back to the cloud drawer.
- [ ] localhost:7070/repos shows real repos (verified pre-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)