### PR TITLE
fix(worker): bind machine tokens to claimed machines and guard dev jobs

### DIFF
--- a/internal/cloud/auth/middleware.go
+++ b/internal/cloud/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -69,4 +70,10 @@ func (h *Handler) RequireMachine(next http.Handler) http.Handler {
 		ctx = withToken(ctx, tok)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// TokenFromContext on *Handler satisfies cloud.AuthHandler so server.go can
+// read the authenticated machine token without importing the auth package.
+func (h *Handler) TokenFromContext(ctx context.Context) *cloud.APIToken {
+	return TokenFromContext(ctx)
 }

--- a/internal/cloud/chat/chat_test.go
+++ b/internal/cloud/chat/chat_test.go
@@ -28,6 +28,10 @@ func (fakeAuth) UserFromContext(ctx context.Context) *cloud.User {
 	return u
 }
 
+// TokenFromContext returns nil in test mode (no machine token is injected
+// by fakeAuth), so the machine ownership guard is a no-op in existing tests.
+func (fakeAuth) TokenFromContext(_ context.Context) *cloud.APIToken { return nil }
+
 // RequireUser / RequireMachine are pass-through in tests: the user is
 // already in context via the withUser wrapper below. Production uses
 // auth.Handler's real session/Bearer validation.

--- a/internal/cloud/chat/handler.go
+++ b/internal/cloud/chat/handler.go
@@ -19,8 +19,14 @@ import (
 // it has to gate browser routes with RequireUser and worker routes with
 // RequireMachine itself. The real implementation is auth.Handler; tests
 // inject a stub.
+//
+// TokenFromContext returns the machine token the surrounding
+// RequireMachine middleware injected (or nil in no-auth mode). Worker
+// handlers use it to verify the token's machine_id matches the machine
+// the request claims to act on.
 type AuthExtractor interface {
 	UserFromContext(ctx context.Context) *cloud.User
+	TokenFromContext(ctx context.Context) *cloud.APIToken
 	RequireUser(http.Handler) http.Handler
 	RequireMachine(http.Handler) http.Handler
 }
@@ -326,10 +332,30 @@ func (h *Handler) handleDelete(w http.ResponseWriter, r *http.Request) {
 
 // ---- Worker handlers ----
 
+// tokenMatchesMachine returns false and writes 403 if the authenticated
+// token's machine_id does not match wantMachineID. It is a no-op (returns
+// true) when auth is nil or no token is present in the context — those
+// cases cover no-auth mode and existing tests that bypass RequireMachine.
+func (h *Handler) tokenMatchesMachine(w http.ResponseWriter, r *http.Request, wantMachineID string) bool {
+	if h.auth == nil {
+		return true
+	}
+	tok := h.auth.TokenFromContext(r.Context())
+	if tok == nil {
+		// No token injected means the middleware didn't enforce it
+		// (e.g. fakeAuth pass-through in unit tests). Allow.
+		return true
+	}
+	if tok.MachineID != wantMachineID {
+		writeError(w, http.StatusForbidden, "token does not match machine")
+		return false
+	}
+	return true
+}
+
 // handlePoll long-polls for the next ChatAssignment targeted at the
 // caller's machine. The worker authenticates via RequireMachine in the
-// outer mux; we accept the machine_id off the request body and trust
-// it (in test mode there is no middleware to enforce a match).
+// outer mux; we bind-check the token's machine_id against the request body.
 func (h *Handler) handlePoll(w http.ResponseWriter, r *http.Request) {
 	var req cloud.ChatPollRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -338,6 +364,9 @@ func (h *Handler) handlePoll(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.MachineID == "" {
 		writeError(w, http.StatusBadRequest, "machine_id is required")
+		return
+	}
+	if !h.tokenMatchesMachine(w, r, req.MachineID) {
 		return
 	}
 	wait := defaultPollWait
@@ -365,7 +394,8 @@ func (h *Handler) handlePoll(w http.ResponseWriter, r *http.Request) {
 // one chat session, posted by the worker after its claude subprocess
 // exits. The session_id comes from the URL; user_id / machine_id / repo
 // are looked up server-side from the active session registry so the
-// worker can't claim usage for a session it doesn't own.
+// worker can't claim usage for a session it doesn't own. The caller's
+// token machine_id must also match the session's bound machine.
 func (h *Handler) handleWorkerUsage(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -389,6 +419,9 @@ func (h *Handler) handleWorkerUsage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "session not found")
 		return
 	}
+	if !h.tokenMatchesMachine(w, r, s.MachineID) {
+		return
+	}
 
 	if err := h.cfg.Store.AddChatUsage(cloud.AddChatUsageInput{
 		SessionID: s.ID,
@@ -406,7 +439,8 @@ func (h *Handler) handleWorkerUsage(w http.ResponseWriter, r *http.Request) {
 
 // handleWorkerEvents accepts a batch of ChatEvents pushed by the
 // worker and fans them out onto the session's SSE channel. An
-// end-typed event in the batch closes the session.
+// end-typed event in the batch closes the session. The caller's token
+// machine_id must match the session's bound machine.
 func (h *Handler) handleWorkerEvents(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -424,6 +458,9 @@ func (h *Handler) handleWorkerEvents(w http.ResponseWriter, r *http.Request) {
 	h.sessionsMu.Unlock()
 	if !ok {
 		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	if !h.tokenMatchesMachine(w, r, s.MachineID) {
 		return
 	}
 

--- a/internal/cloud/migrations/0005_runs_machine_id.sql
+++ b/internal/cloud/migrations/0005_runs_machine_id.sql
@@ -1,0 +1,5 @@
+-- 0005_runs_machine_id.sql: record which machine executed each run so the
+-- worker-protocol handlers can verify ownership (issue #185).
+-- Default '' preserves compatibility with runs created before this migration.
+
+ALTER TABLE runs ADD COLUMN machine_id TEXT NOT NULL DEFAULT '';

--- a/internal/cloud/server.go
+++ b/internal/cloud/server.go
@@ -21,11 +21,17 @@ import (
 // UserFromContext returns the authenticated user that the surrounding
 // RequireUser/RequireMachine middleware injected, or nil if no auth ran.
 // Cloud handlers use it to attribute writes (e.g. worker registration → owner).
+//
+// TokenFromContext returns the APIToken injected by RequireMachine, or nil
+// when the request was not authenticated via a machine Bearer token.
+// Worker handlers use it to bind-check the token's machine_id against the
+// machine_id carried in the request body.
 type AuthHandler interface {
 	RegisterRoutes(mux *http.ServeMux)
 	RequireUser(http.Handler) http.Handler
 	RequireMachine(http.Handler) http.Handler
 	UserFromContext(context.Context) *User
+	TokenFromContext(context.Context) *APIToken
 }
 
 // RouteMounter is anything that can register additional routes onto the cloud
@@ -96,7 +102,12 @@ func NewServerWithExtras(store Store, operators *operator.Registry, auth AuthHan
 	mux.HandleFunc("/api/worker/heartbeat", gateMachine(s.handleHeartbeat))
 	mux.HandleFunc("/api/worker/lease", gateMachine(s.handleLease))
 	mux.HandleFunc("/api/worker/runs/", gateMachine(s.handleRun))
-	mux.HandleFunc("/api/cloud/dev/jobs", s.handleDevJobs)
+	// /api/cloud/dev/jobs is only available in no-auth mode (local dev / tests).
+	// When real auth is configured this route is intentionally omitted so the
+	// endpoint does not exist in production.
+	if auth == nil {
+		mux.HandleFunc("/api/cloud/dev/jobs", s.handleDevJobs)
+	}
 
 	// Cloud config — auth.RequireUser when configured, fallback to legacy
 	// bearer check otherwise. The s.withAuth wrapper handles both paths.
@@ -265,6 +276,9 @@ func (s *server) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		writeCloudError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
+	if !s.guardMachineID(w, r, req.MachineID) {
+		return
+	}
 	resp, err := s.store.Heartbeat(req)
 	if err != nil {
 		writeCloudError(w, http.StatusBadRequest, err.Error())
@@ -281,6 +295,9 @@ func (s *server) handleLease(w http.ResponseWriter, r *http.Request) {
 	var req LeaseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeCloudError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if !s.guardMachineID(w, r, req.MachineID) {
 		return
 	}
 	job, err := s.store.Lease(req, DefaultLeaseDuration)
@@ -303,6 +320,10 @@ func (s *server) handleRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	runID, action := parts[0], parts[1]
+	// Verify the requesting machine owns this run before processing any action.
+	if !s.guardRunOwner(w, r, runID) {
+		return
+	}
 	switch action {
 	case "events":
 		var req RunEventsRequest
@@ -369,6 +390,53 @@ func writeCloudError(w http.ResponseWriter, status int, msg string) {
 		"error": msg,
 		"time":  time.Now().UTC().Format(time.RFC3339),
 	})
+}
+
+// ---- Worker-protocol ownership guards ----
+
+// guardMachineID returns false and writes 403 if the authenticated token's
+// machine_id does not match machineID. In no-auth mode (s.auth == nil) it is
+// a no-op that always returns true, preserving test and local-dev behaviour.
+func (s *server) guardMachineID(w http.ResponseWriter, r *http.Request, machineID string) bool {
+	if s.auth == nil {
+		return true
+	}
+	tok := s.auth.TokenFromContext(r.Context())
+	if tok == nil || tok.MachineID == "" {
+		// RequireMachine ensures we only reach here with a machine token,
+		// so a nil/empty token indicates an unexpected code path.
+		writeCloudError(w, http.StatusForbidden, "machine credential required")
+		return false
+	}
+	if tok.MachineID != machineID {
+		writeCloudError(w, http.StatusForbidden, "token does not match machine")
+		return false
+	}
+	return true
+}
+
+// guardRunOwner returns false and writes 403 if the run identified by runID
+// does not belong to the machine in the authenticated token. It also writes
+// 404 when the run does not exist. In no-auth mode it always returns true.
+func (s *server) guardRunOwner(w http.ResponseWriter, r *http.Request, runID string) bool {
+	if s.auth == nil {
+		return true
+	}
+	tok := s.auth.TokenFromContext(r.Context())
+	if tok == nil || tok.MachineID == "" {
+		writeCloudError(w, http.StatusForbidden, "machine credential required")
+		return false
+	}
+	run := s.store.GetRun(runID)
+	if run == nil {
+		writeCloudError(w, http.StatusNotFound, "run not found")
+		return false
+	}
+	if run.MachineID != tok.MachineID {
+		writeCloudError(w, http.StatusForbidden, "token does not own this run")
+		return false
+	}
+	return true
 }
 
 // ---- Cloud config auth middleware ----

--- a/internal/cloud/server_test.go
+++ b/internal/cloud/server_test.go
@@ -2,12 +2,128 @@ package cloud
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
+
+// ---- Test auth stub ----
+
+// testAuth is a minimal AuthHandler for unit-testing worker token enforcement.
+// It holds a flat map of plaintext-token → APIToken so tests can verify that
+// machine A's token is rejected when the request body claims machine B.
+type testAuth struct {
+	tokens map[string]*APIToken // plaintext → token row
+	users  map[string]*User     // user_id → User
+}
+
+type testAuthUserKey struct{}
+type testAuthTokenKey struct{}
+
+func (a *testAuth) RegisterRoutes(_ *http.ServeMux) {}
+
+func (a *testAuth) RequireUser(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, tok := a.resolve(r)
+		if tok == nil {
+			writeCloudError(w, http.StatusUnauthorized, "not authenticated")
+			return
+		}
+		u := a.users[tok.UserID]
+		if u == nil {
+			writeCloudError(w, http.StatusUnauthorized, "not authenticated")
+			return
+		}
+		ctx := context.WithValue(r.Context(), testAuthUserKey{}, u)
+		ctx = context.WithValue(ctx, testAuthTokenKey{}, tok)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (a *testAuth) RequireMachine(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, tok := a.resolve(r)
+		if tok == nil || tok.Kind != APITokenKindMachine {
+			writeCloudError(w, http.StatusUnauthorized, "machine credential required")
+			return
+		}
+		u := a.users[tok.UserID]
+		ctx := context.WithValue(r.Context(), testAuthUserKey{}, u)
+		ctx = context.WithValue(ctx, testAuthTokenKey{}, tok)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func (a *testAuth) UserFromContext(ctx context.Context) *User {
+	u, _ := ctx.Value(testAuthUserKey{}).(*User)
+	return u
+}
+
+func (a *testAuth) TokenFromContext(ctx context.Context) *APIToken {
+	tok, _ := ctx.Value(testAuthTokenKey{}).(*APIToken)
+	return tok
+}
+
+func (a *testAuth) resolve(r *http.Request) (*User, *APIToken) {
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "Bearer ") {
+		return nil, nil
+	}
+	plain := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
+	tok := a.tokens[plain]
+	if tok == nil {
+		return nil, nil
+	}
+	u := a.users[tok.UserID]
+	return u, tok
+}
+
+// newTestAuthWithMachines registers two machines (A and B) plus one personal
+// token and returns the auth, the store, and each machine's token plaintext.
+func newTestAuthWithMachines(t *testing.T) (ta *testAuth, store *MemoryStore, tokenA, tokenB, personalToken string, machineA, machineB RegisterWorkerResponse) {
+	t.Helper()
+	store = NewMemoryStore()
+
+	// Seed one user for token attribution (testAuth resolves users from its own map).
+	alice := &User{ID: "u1", Login: "alice"}
+	ta = &testAuth{
+		tokens: make(map[string]*APIToken),
+		users:  map[string]*User{"u1": alice},
+	}
+
+	// Register machine A.
+	var err error
+	machineA, err = store.RegisterWorker(RegisterWorkerRequest{Hostname: "machine-a"})
+	if err != nil {
+		t.Fatalf("register machine-a: %v", err)
+	}
+	tokenA = "wtok-machine-a"
+	ta.tokens[tokenA] = &APIToken{
+		ID: "tok-a", UserID: "u1", Kind: APITokenKindMachine, MachineID: machineA.MachineID,
+	}
+
+	// Register machine B.
+	machineB, err = store.RegisterWorker(RegisterWorkerRequest{Hostname: "machine-b"})
+	if err != nil {
+		t.Fatalf("register machine-b: %v", err)
+	}
+	tokenB = "wtok-machine-b"
+	ta.tokens[tokenB] = &APIToken{
+		ID: "tok-b", UserID: "u1", Kind: APITokenKindMachine, MachineID: machineB.MachineID,
+	}
+
+	// Personal token (kind=personal — should be rejected by all worker routes).
+	personalToken = "pat-personal"
+	ta.tokens[personalToken] = &APIToken{
+		ID: "tok-p", UserID: "u1", Kind: APITokenKindPersonal,
+	}
+
+	return
+}
 
 func TestMemoryStoreLeaseHonorsMachineBinding(t *testing.T) {
 	store := NewMemoryStore()
@@ -165,5 +281,209 @@ func TestServerDevJobEndpoint(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("status = %d", resp.StatusCode)
+	}
+}
+
+// ---- Security regression tests (issue #185) ----
+
+// machineReq is a helper that builds an authenticated POST request using the
+// supplied Bearer token and JSON body.
+func machineReq(t *testing.T, srvURL, path, token string, body any) *http.Response {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, srvURL+path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return resp
+}
+
+// TestMachineTokenEnforcesHeartbeatOwnership verifies that machine A's token
+// cannot send a heartbeat claiming to be machine B.
+func TestMachineTokenEnforcesHeartbeatOwnership(t *testing.T) {
+	ta, store, tokenA, tokenB, personalToken, machA, machB := newTestAuthWithMachines(t)
+	srv := httptest.NewServer(NewServerWithAuth(store, nil, ta))
+	defer srv.Close()
+
+	hbBodyA := HeartbeatRequest{
+		MachineID: machA.MachineID, WorkerID: machA.WorkerID,
+		Status: WorkerStatusOnline, Capacity: 1,
+	}
+	hbBodyB := HeartbeatRequest{
+		MachineID: machB.MachineID, WorkerID: machB.WorkerID,
+		Status: WorkerStatusOnline, Capacity: 1,
+	}
+
+	// Token A → heartbeat as machine A: should succeed (200).
+	resp := machineReq(t, srv.URL, "/api/worker/heartbeat", tokenA, hbBodyA)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("token-A heartbeating as machine-A: got %d, want 200", resp.StatusCode)
+	}
+
+	// Token A → heartbeat as machine B: must be 403.
+	resp = machineReq(t, srv.URL, "/api/worker/heartbeat", tokenA, hbBodyB)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("token-A heartbeating as machine-B: got %d, want 403", resp.StatusCode)
+	}
+
+	// Token B → heartbeat as machine B: should succeed (200).
+	resp = machineReq(t, srv.URL, "/api/worker/heartbeat", tokenB, hbBodyB)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("token-B heartbeating as machine-B: got %d, want 200", resp.StatusCode)
+	}
+
+	// Personal token → must be rejected by RequireMachine (401).
+	resp = machineReq(t, srv.URL, "/api/worker/heartbeat", personalToken, hbBodyA)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("personal token on heartbeat: got %d, want 401", resp.StatusCode)
+	}
+
+	// No token → 401.
+	resp = machineReq(t, srv.URL, "/api/worker/heartbeat", "", hbBodyA)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("no token on heartbeat: got %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestMachineTokenEnforcesLeaseOwnership verifies that machine A's token
+// cannot lease as machine B.
+func TestMachineTokenEnforcesLeaseOwnership(t *testing.T) {
+	ta, store, tokenA, tokenB, personalToken, machA, machB := newTestAuthWithMachines(t)
+	srv := httptest.NewServer(NewServerWithAuth(store, nil, ta))
+	defer srv.Close()
+
+	// Enqueue two jobs, one bound to each machine.
+	store.EnqueueJob(JobSpec{
+		Repo: "o/r", Platform: "github",
+		Operator: "evaluate-bug", Target: "issue", Number: 10,
+	}, machA.MachineID)
+	store.EnqueueJob(JobSpec{
+		Repo: "o/r", Platform: "github",
+		Operator: "evaluate-bug", Target: "issue", Number: 11,
+	}, machB.MachineID)
+
+	leaseA := LeaseRequest{MachineID: machA.MachineID, WorkerID: machA.WorkerID, Capacity: 1}
+	leaseB := LeaseRequest{MachineID: machB.MachineID, WorkerID: machB.WorkerID, Capacity: 1}
+
+	// Token A → lease as machine A: should succeed.
+	resp := machineReq(t, srv.URL, "/api/worker/lease", tokenA, leaseA)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("token-A leasing as machine-A: got %d, want 200", resp.StatusCode)
+	}
+
+	// Token A → lease claiming machine B: must be 403.
+	resp = machineReq(t, srv.URL, "/api/worker/lease", tokenA, leaseB)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("token-A leasing as machine-B: got %d, want 403", resp.StatusCode)
+	}
+
+	// Token B → lease as machine B: should succeed.
+	resp = machineReq(t, srv.URL, "/api/worker/lease", tokenB, leaseB)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("token-B leasing as machine-B: got %d, want 200", resp.StatusCode)
+	}
+
+	// Personal token on lease → 401.
+	resp = machineReq(t, srv.URL, "/api/worker/lease", personalToken, leaseA)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("personal token on lease: got %d, want 401", resp.StatusCode)
+	}
+}
+
+// TestMachineTokenEnforcesRunOwnership verifies that machine A's token cannot
+// post events or finish a run that was leased by machine B.
+func TestMachineTokenEnforcesRunOwnership(t *testing.T) {
+	ta, store, tokenA, tokenB, _, _, machB := newTestAuthWithMachines(t)
+	srv := httptest.NewServer(NewServerWithAuth(store, nil, ta))
+	defer srv.Close()
+
+	// Machine B leases a job directly via the store (bypass HTTP so we don't
+	// need to deal with HTTP lease ownership check for this setup step).
+	store.EnqueueJob(JobSpec{
+		Repo: "o/r", Platform: "github",
+		Operator: "evaluate-bug", Target: "issue", Number: 20,
+	}, machB.MachineID)
+	jobSpec, err := store.Lease(LeaseRequest{
+		MachineID: machB.MachineID, WorkerID: machB.WorkerID,
+	}, time.Minute)
+	if err != nil || jobSpec == nil {
+		t.Fatalf("store lease for machine-B: %v / %v", err, jobSpec)
+	}
+	runID := jobSpec.RunID
+
+	eventsPath := "/api/worker/runs/" + runID + "/events"
+	finishPath := "/api/worker/runs/" + runID + "/finish"
+
+	// Machine A trying to append events to machine B's run → 403.
+	resp := machineReq(t, srv.URL, eventsPath, tokenA,
+		RunEventsRequest{Events: []RunEvent{{Message: "hijack"}}})
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("token-A events on machine-B's run: got %d, want 403", resp.StatusCode)
+	}
+
+	// Machine A trying to finish machine B's run → 403.
+	resp = machineReq(t, srv.URL, finishPath, tokenA,
+		FinishRunRequest{Status: JobStatusSucceeded})
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("token-A finish on machine-B's run: got %d, want 403", resp.StatusCode)
+	}
+
+	// Machine B posting events for its own run → 204.
+	resp = machineReq(t, srv.URL, eventsPath, tokenB,
+		RunEventsRequest{Events: []RunEvent{{Message: "progress"}}})
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("token-B events on machine-B's run: got %d, want 204", resp.StatusCode)
+	}
+
+	// Machine B finishing its own run → 204.
+	resp = machineReq(t, srv.URL, finishPath, tokenB,
+		FinishRunRequest{Status: JobStatusSucceeded, Outcome: "agent-evaluated"})
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("token-B finish on machine-B's run: got %d, want 204", resp.StatusCode)
+	}
+}
+
+// TestDevJobsDisabledInProdMode verifies that /api/cloud/dev/jobs returns 404
+// when the server is started with a real auth handler (production mode).
+func TestDevJobsDisabledInProdMode(t *testing.T) {
+	ta, store, tokenA, _, _, _, _ := newTestAuthWithMachines(t)
+	srv := httptest.NewServer(NewServerWithAuth(store, nil, ta))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"job": map[string]any{
+			"repo": "o/r", "operator": "evaluate-bug", "number": 99,
+		},
+	})
+	// Even with a valid machine token the endpoint should not exist.
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/cloud/dev/jobs",
+		bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tokenA)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("dev/jobs in prod mode: got %d, want 404", resp.StatusCode)
 	}
 }

--- a/internal/cloud/sqlite_store.go
+++ b/internal/cloud/sqlite_store.go
@@ -335,8 +335,8 @@ func (s *SQLiteStore) Lease(req LeaseRequest, leaseFor time.Duration) (*JobSpec,
 	}
 
 	if _, err = tx.Exec(
-		`INSERT INTO runs (id, job_id, status, started_at) VALUES (?, ?, ?, ?)`,
-		runID, chosen.id, JobStatusRunning, nowStr,
+		`INSERT INTO runs (id, job_id, machine_id, status, started_at) VALUES (?, ?, ?, ?, ?)`,
+		runID, chosen.id, req.MachineID, JobStatusRunning, nowStr,
 	); err != nil {
 		tx.Rollback()
 		return nil, err
@@ -720,25 +720,26 @@ func (s *SQLiteStore) GetJob(id string) *JobRecord {
 
 // GetRun returns a run record including all appended events, or nil if not found.
 func (s *SQLiteStore) GetRun(id string) *RunRecord {
-	var jobID, status, outcome, summary, errStr, startedAt string
+	var jobID, machineID, status, outcome, summary, errStr, startedAt string
 	var endedAt sql.NullString
 
 	err := s.db.QueryRow(
-		`SELECT job_id, status, outcome, summary, error, started_at, ended_at
+		`SELECT job_id, machine_id, status, outcome, summary, error, started_at, ended_at
 		 FROM runs WHERE id = ?`,
 		id,
-	).Scan(&jobID, &status, &outcome, &summary, &errStr, &startedAt, &endedAt)
+	).Scan(&jobID, &machineID, &status, &outcome, &summary, &errStr, &startedAt, &endedAt)
 	if err != nil {
 		return nil
 	}
 
 	rec := &RunRecord{
-		ID:      id,
-		JobID:   jobID,
-		Status:  status,
-		Outcome: outcome,
-		Summary: summary,
-		Error:   errStr,
+		ID:        id,
+		JobID:     jobID,
+		MachineID: machineID,
+		Status:    status,
+		Outcome:   outcome,
+		Summary:   summary,
+		Error:     errStr,
 	}
 	rec.StartedAt, _ = time.Parse(time.RFC3339Nano, startedAt)
 	if endedAt.Valid {

--- a/internal/cloud/store.go
+++ b/internal/cloud/store.go
@@ -60,6 +60,10 @@ type JobRecord struct {
 type RunRecord struct {
 	ID        string     `json:"id"`
 	JobID     string     `json:"job_id"`
+	// MachineID is the machine that leased and is executing this run.
+	// Populated by Lease(); used by worker-protocol handlers to verify
+	// that only the owning machine can post events or finish the run.
+	MachineID string     `json:"machine_id,omitempty"`
 	Status    string     `json:"status"`
 	Outcome   string     `json:"outcome,omitempty"`
 	Summary   string     `json:"summary,omitempty"`
@@ -353,6 +357,7 @@ func (s *MemoryStore) Lease(req LeaseRequest, leaseFor time.Duration) (*JobSpec,
 		s.Runs[runID] = &RunRecord{
 			ID:        runID,
 			JobID:     job.Spec.JobID,
+			MachineID: req.MachineID,
 			Status:    JobStatusRunning,
 			StartedAt: now,
 		}

--- a/internal/cloud/usage_summary_test.go
+++ b/internal/cloud/usage_summary_test.go
@@ -193,6 +193,8 @@ func (a *stubAuth) UserFromContext(ctx context.Context) *User {
 	return u
 }
 
+func (a *stubAuth) TokenFromContext(_ context.Context) *APIToken { return nil }
+
 func absDiff(a, b float64) float64 {
 	if a > b {
 		return a - b


### PR DESCRIPTION
Fixes #185

## What changed and why

Closes the immediate worker-route security gaps described in #185 before the full RBAC rollout.

### Core ownership enforcement

**`TokenFromContext` added to `AuthHandler` / `AuthExtractor` interfaces** — lets worker handlers read `tok.MachineID` from context without importing the auth package, keeping the dependency arrow clean.

**`guardMachineID(w, r, machineID)` helper** — compares the authenticated token's `machine_id` against the machine_id in the request body; writes 403 if they differ. In no-auth mode (tests / `--no-auth`) it is a no-op.

**`guardRunOwner(w, r, runID)` helper** — looks up the run by ID and compares its stored `MachineID` to the token's `machine_id`; writes 403 or 404 as appropriate.

### Changes per acceptance criterion

| AC | Fix |
|---|---|
| Machine token A cannot heartbeat as B | `handleHeartbeat` calls `guardMachineID` before forwarding |
| Machine token A cannot lease as B | `handleLease` calls `guardMachineID` before forwarding |
| Machine token A cannot finish / append events for a run it doesn't own | `handleRun` calls `guardRunOwner` before the action switch |
| Machine token A cannot poll chat assignments for B | `chat.handlePoll` calls `tokenMatchesMachine` |
| Personal tokens rejected by all worker-only routes | Already enforced by `RequireMachine` middleware; regression test added |
| `/api/cloud/dev/jobs` unavailable in production | Route not registered when `auth != nil`; returns 404 |

### Data model

`RunRecord.MachineID` (new field, populated at `Lease()` time in both `MemoryStore` and `SQLiteStore`) stores which machine executed a run. Migration `0005_runs_machine_id.sql` adds `machine_id TEXT NOT NULL DEFAULT ''` to the `runs` table; the default preserves compatibility with pre-migration rows.

### Tests added (`server_test.go`)

- `TestMachineTokenEnforcesHeartbeatOwnership` — token A cannot heartbeat as machine B (403); token A can heartbeat as machine A (200); personal token rejected (401)
- `TestMachineTokenEnforcesLeaseOwnership` — same pattern for `/lease`
- `TestMachineTokenEnforcesRunOwnership` — machine A token cannot post events or finish a run leased by machine B (403); machine B can (204)
- `TestDevJobsDisabledInProdMode` — endpoint returns 404 when auth is configured

All existing tests continue to pass (`go test ./...`).