### PR TITLE
fix: surface clawflow self-awareness in chat system prompts

### DIFF
--- a/internal/chat/context.go
+++ b/internal/chat/context.go
@@ -127,6 +127,14 @@ After running a command, read the real stdout/stderr and report what
 actually happened. The command's exit status is the only source of
 truth.`)
 
+	// Self-awareness: surface the ClawFlow automation model and the
+	// scope-filtered CLI cheatsheet so the AI doesn't ask "where do I
+	// file an issue?" or forget about read-only sub-commands it can use.
+	// ScopeSingleIssue keeps issue create / sub-issue ops out of the list.
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, prompts.AutomationModel())
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, prompts.CLICheatsheet(prompts.ScopeSingleIssue))
 	fmt.Fprintln(b)
 	fmt.Fprintln(b, prompts.LanguageRule())
 }
@@ -199,6 +207,13 @@ After running a command, read the real stdout/stderr and report what
 actually happened. The command's exit status is the only source of
 truth.`)
 
+	// Self-awareness: same reasoning as buildEditModeRole. Even though
+	// file edits are blocked here, the AI still benefits from knowing
+	// ClawFlow's label vocabulary and the read-only commands it can run.
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, prompts.AutomationModel())
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, prompts.CLICheatsheet(prompts.ScopeSingleIssue))
 	fmt.Fprintln(b)
 	fmt.Fprintln(b, prompts.LanguageRule())
 }
@@ -311,6 +326,8 @@ the user can cancel — side effects are gated, not silent.
 Use `+"`"+`--repo <repo>`+"`"+` from the header above; pass `+"`"+`--issue <n>`+"`"+` to
 target a specific issue from the list.`)
 
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, prompts.AutomationModel())
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, prompts.CLICheatsheet(prompts.ScopeRepo))
 	fmt.Fprintln(&b)

--- a/internal/chat/context_test.go
+++ b/internal/chat/context_test.go
@@ -1,0 +1,82 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/vcs"
+)
+
+// All issue-level and repo-level chat builders must surface ClawFlow's own
+// automation model + CLI cheatsheet so the AI doesn't ask "where do I file
+// an issue?" or fail to recognize clawflow's label vocabulary. See #192.
+
+func TestBuildIssueContext_HasSelfAwareness(t *testing.T) {
+	issue := vcs.Issue{Number: 42, Title: "x", State: "open", Labels: []string{"bug"}, Body: "details"}
+	out := BuildIssueContext("o/r", issue, nil)
+	assertSelfAwareness(t, "BuildIssueContext", out)
+
+	// Single-issue scope cheatsheet must NOT teach `issue create`. The
+	// existing hard-constraint paragraph mentions it as forbidden — but
+	// the actionable invocation form (with --title) must be absent.
+	if strings.Contains(out, "issue create --repo") || strings.Contains(out, "issue create --title") {
+		t.Error("BuildIssueContext (edit mode) leaked actionable `issue create` form into single-issue scope")
+	}
+}
+
+func TestBuildIssueModeContext_HasSelfAwareness(t *testing.T) {
+	issue := vcs.Issue{Number: 42, Title: "x", State: "open", Labels: []string{"feat"}, Body: "details"}
+	out := BuildIssueModeContext("o/r", issue, nil)
+	assertSelfAwareness(t, "BuildIssueModeContext", out)
+
+	if strings.Contains(out, "issue create --repo") || strings.Contains(out, "issue create --title") {
+		t.Error("BuildIssueModeContext leaked actionable `issue create` form into single-issue scope")
+	}
+}
+
+func TestBuildRepoContext_HasSelfAwareness(t *testing.T) {
+	out := BuildRepoContext("o/r", "github", "main", nil)
+	assertSelfAwareness(t, "BuildRepoContext", out)
+
+	// Repo scope is allowed to create issues — the actionable form should
+	// be present in the cheatsheet.
+	if !strings.Contains(out, "issue create --repo") {
+		t.Error("BuildRepoContext should advertise the actionable `issue create --repo ...` form (ScopeRepo)")
+	}
+}
+
+// LanguageRule must be the very last instruction across all chat builders so
+// it isn't crowded out by anything we appended.
+func TestChatBuilders_LanguageRuleIsLast(t *testing.T) {
+	issue := vcs.Issue{Number: 1, Title: "t", State: "open"}
+	cases := map[string]string{
+		"BuildIssueContext":     BuildIssueContext("o/r", issue, nil),
+		"BuildIssueModeContext": BuildIssueModeContext("o/r", issue, nil),
+	}
+	for name, prompt := range cases {
+		langIdx := strings.Index(prompt, "Match the user's input language")
+		autoIdx := strings.Index(prompt, "ClawFlow automation model")
+		cliIdx := strings.Index(prompt, "clawflow CLI cheatsheet")
+		if langIdx < 0 || autoIdx < 0 || cliIdx < 0 {
+			t.Fatalf("%s: missing one of the expected sections (lang=%d auto=%d cli=%d)", name, langIdx, autoIdx, cliIdx)
+		}
+		if langIdx < autoIdx || langIdx < cliIdx {
+			t.Errorf("%s: LanguageRule must come after both automation model and CLI cheatsheet", name)
+		}
+	}
+}
+
+func assertSelfAwareness(t *testing.T, builder, prompt string) {
+	t.Helper()
+	for _, want := range []string{
+		"ClawFlow automation model", // AutomationModel header
+		"ready-for-agent",           // label vocabulary
+		"clawflow CLI cheatsheet",   // CLICheatsheet header
+		"clawflow issue",            // at least one clawflow command
+		"clawflow feedback",         // self-feedback escape hatch
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("%s: missing self-awareness fragment %q", builder, want)
+		}
+	}
+}

--- a/internal/chat/prompts/module_cli_cheatsheet.go
+++ b/internal/chat/prompts/module_cli_cheatsheet.go
@@ -66,6 +66,18 @@ func CLICheatsheet(scope Scope) string {
 	fmt.Fprintln(&b, "### Labels")
 	fmt.Fprintln(&b, "- `clawflow label add --repo <owner/name> --issue <n> --label <name>`")
 	fmt.Fprintln(&b, "- `clawflow label remove --repo <owner/name> --issue <n> --label <name>`")
+	fmt.Fprintln(&b)
+
+	// Other top-level commands users (and the AI) should know about.
+	// Always present regardless of scope — these are about clawflow itself,
+	// not about the current issue/repo, so scope filtering doesn't apply.
+	fmt.Fprintln(&b, "### Other")
+	fmt.Fprintln(&b, "- `clawflow feedback` — open an interactive chat to file a")
+	fmt.Fprintln(&b, "  feedback / bug / feature issue against the upstream ClawFlow repo")
+	fmt.Fprintln(&b, "  (`zhoushoujianwork/clawflow`). Use this when the user wants to")
+	fmt.Fprintln(&b, "  report something about clawflow itself, not the current project.")
+	fmt.Fprintln(&b, "- `clawflow repo list` — list configured repositories")
+	fmt.Fprintln(&b, "- `clawflow status` — show running operators, locks, recent activity")
 
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/chat/prompts/module_cli_cheatsheet_test.go
+++ b/internal/chat/prompts/module_cli_cheatsheet_test.go
@@ -64,6 +64,19 @@ func TestCLICheatsheet_AllScopes_HaveBasicCommands(t *testing.T) {
 	}
 }
 
+func TestCLICheatsheet_AllScopes_HaveFeedback(t *testing.T) {
+	// `clawflow feedback` is a top-level user-facing command that lets the
+	// AI route project-unrelated complaints to the upstream ClawFlow repo.
+	// It must be visible in every chat scope so the AI doesn't ask "where
+	// should I file the issue?" when the user complains about clawflow itself.
+	for _, scope := range []Scope{ScopeFull, ScopeRepo, ScopeSingleIssue} {
+		out := CLICheatsheet(scope)
+		if !strings.Contains(out, "clawflow feedback") {
+			t.Errorf("scope %d: cheatsheet missing `clawflow feedback`", scope)
+		}
+	}
+}
+
 func TestLanguageRule_Content(t *testing.T) {
 	out := LanguageRule()
 	if !strings.Contains(out, "Match the user's input language") {


### PR DESCRIPTION
Fixes #192

## What changed

`clawflow chat` system prompts now include ClawFlow's own automation model and CLI cheatsheet across **all** chat builders, so the AI no longer asks "where should I file the issue?" or forgets that it can run clawflow commands directly.

### Wiring

- `buildEditModeRole` (issue edit chat) — appended `prompts.AutomationModel()` + `prompts.CLICheatsheet(prompts.ScopeSingleIssue)` before `LanguageRule`.
- `buildIssueModeRole` (issue discussion chat) — same pair, same scope.
- `BuildRepoContext` — added `prompts.AutomationModel()` before the existing `CLICheatsheet(ScopeRepo)` call so repo-level chats also see the trigger-label vocabulary.

`ScopeSingleIssue` continues to filter out `issue create` and sub-issue commands, preserving the existing single-issue guardrails. The hard-constraint paragraph forbidding `clawflow issue create` stays adjacent to the cheatsheet so visibility doesn't invite scope violation.

### Cheatsheet additions

A new **Other** section in `module_cli_cheatsheet.go` is always present (independent of scope):

- `clawflow feedback` — opens an interactive chat to file a feedback / bug / feature issue against the upstream ClawFlow repo. Surfacing this lets the AI route project-unrelated complaints about clawflow itself to the right place.
- `clawflow repo list` — list configured repositories.
- `clawflow status` — show running operators, locks, recent activity.

### Tests

- New `internal/chat/context_test.go`:
  - `TestBuildIssueContext_HasSelfAwareness` / `TestBuildIssueModeContext_HasSelfAwareness` / `TestBuildRepoContext_HasSelfAwareness` — assert each builder includes the AutomationModel header, label vocabulary, the CLI cheatsheet, and `clawflow feedback`.
  - Single-issue scopes still must NOT advertise the actionable `issue create --repo` form; repo scope must.
  - `TestChatBuilders_LanguageRuleIsLast` — guards the prompt-section ordering invariant noted in the evaluation: language rule stays the final instruction.
- Extended `internal/chat/prompts/module_cli_cheatsheet_test.go`:
  - `TestCLICheatsheet_AllScopes_HaveFeedback` — `clawflow feedback` must appear in every scope.

### Verification

`go test ./...` passes (full suite). No runtime SOP applies — change is internal to prompt assembly with no I/O.