### PR TITLE
fix: pr merge deletes source branch by default with --no-delete-branch opt-out

### DIFF
--- a/cmd/clawflow/commands/pr.go
+++ b/cmd/clawflow/commands/pr.go
@@ -226,11 +226,12 @@ func newPRCIWaitCmd() *cobra.Command {
 func newPRMergeCmd() *cobra.Command {
 	var repo string
 	var number int
+	var noDeleteBranch bool
 
 	cmd := &cobra.Command{
 		Use:     "merge",
 		Short:   "Merge a pull request via the VCS API",
-		Example: "  clawflow pr merge --repo owner/repo --pr 7",
+		Example: "  clawflow pr merge --repo owner/repo --pr 7\n  clawflow pr merge --repo owner/repo --pr 7 --no-delete-branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _, err := newVCSClientForRepo(repo)
 			if err != nil {
@@ -240,11 +241,37 @@ func newPRMergeCmd() *cobra.Command {
 				return err
 			}
 			fmt.Printf("merged %s PR #%d\n", repo, number)
+
+			// Default behavior: delete the remote source branch after a
+			// successful merge, matching GitHub/GitLab's "Delete source
+			// branch" UI default. Pass --no-delete-branch to keep it.
+			// Mirrors the cleanup path in `clawflow run` auto-merge so
+			// manual and automatic merges behave consistently. Failures
+			// are non-fatal: the merge already landed, branch deletion
+			// is just housekeeping.
+			if !noDeleteBranch {
+				baseBranch := "main"
+				if cfg, err := config.Load(); err == nil {
+					if repoCfg, ok := cfg.Repos[repo]; ok && repoCfg.BaseBranch != "" {
+						baseBranch = repoCfg.BaseBranch
+					}
+				}
+				if pr, err := client.GetPR(repo, number); err != nil {
+					fmt.Fprintf(os.Stderr, "⚠ branch cleanup: lookup PR failed: %v\n", err)
+				} else if head := pr.HeadBranch; head != "" && head != baseBranch {
+					if err := client.DeleteBranch(repo, head); err != nil {
+						fmt.Fprintf(os.Stderr, "⚠ branch cleanup: delete %s failed: %v\n", head, err)
+					} else {
+						fmt.Printf("deleted branch %s\n", head)
+					}
+				}
+			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
 	cmd.Flags().IntVar(&number, "pr", 0, "PR number (required)")
+	cmd.Flags().BoolVar(&noDeleteBranch, "no-delete-branch", false, "keep the source branch after merging (default: delete)")
 	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("pr")
 	return cmd


### PR DESCRIPTION
Fixes #191

## What changed
`clawflow pr merge` now deletes the remote source branch after a successful merge, matching the established convention from GitHub/GitLab merge buttons. Added a new `--no-delete-branch` opt-out flag for callers that want to keep the branch (shared dev branches, hotfix mirrors).

## Why
Issue #191 asks for parity with the GitHub/GitLab UI defaults, and `clawflow run`'s auto-merge path already deletes branches unconditionally — so manual merges were the only path leaving stale branches behind. This change unifies the behavior.

## Implementation
- Single file: `cmd/clawflow/commands/pr.go` (`newPRMergeCmd`).
- After a successful `client.MergePR`, look up the PR via `client.GetPR` to obtain `HeadBranch`, then call `client.DeleteBranch` unless the user passed `--no-delete-branch`.
- Resolves `baseBranch` via `config.Load` → `Repos[repo].BaseBranch` (default `main`) and skips deletion when `HeadBranch == baseBranch` or empty — same guard as `run.go`.
- Cleanup errors are non-fatal warnings on stderr (the merge already landed).

## Tests
- `go build ./...` clean
- `go test ./...` all packages pass
- No new unit tests added: the cleanup path is a near-verbatim copy of the auto-merge path in `run.go` (already covered by the existing `internal/vcs/github` and `internal/vcs/gitlab` `DeleteBranch` integration tests). Happy to add a fake-VCS unit test if reviewers prefer.

## Backward compatibility note
Default behavior changes: anyone scripting `clawflow pr merge` and relying on the source branch surviving will need to add `--no-delete-branch`. This matches the issue's explicit ask but should land in release notes.