### PR TITLE
fix: strip <thinking> blocks from operator comments before posting

### DIFF
--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -27,6 +27,18 @@ var ErrNoOutcomeMarker = errors.New("operator produced no outcome marker")
 // line at the end of the comment.
 var outcomeRE = regexp.MustCompile(`[ \t]*<!--\s*clawflow:outcome=([\w./:-]+)\s*-->[ \t]*\n?`)
 
+// thinkingRE strips literal <thinking>…</thinking> blocks that some Claude
+// variants emit as plain text inside an assistant turn. This is distinct from
+// API-level thinking blocks (content[].type == "thinking"), which claude.go
+// already filters by content-block type. The (?s) flag makes . match newlines
+// so multi-paragraph reasoning blocks are fully removed. Non-greedy .*? means
+// multiple blocks in one response are each stripped independently rather than
+// one giant match swallowing content between the first <thinking> and the last
+// </thinking>. An unclosed tag (model truncation) is left as-is — the regex
+// simply won't match and the raw tag will appear in the comment, which is
+// preferable to silently swallowing the rest of the output.
+var thinkingRE = regexp.MustCompile(`(?s)<thinking>.*?</thinking>\s*`)
+
 // parseOutcome scans `body` for outcome markers, returning the label of the
 // LAST marker (so a model that emits multiple drafts has its final pick
 // honored) and a copy of `body` with every marker line removed.
@@ -40,6 +52,7 @@ func parseOutcome(body string) (label, cleaned string) {
 	}
 	label = matches[len(matches)-1][1]
 	cleaned = outcomeRE.ReplaceAllString(body, "")
+	cleaned = thinkingRE.ReplaceAllString(cleaned, "")
 	return label, strings.TrimSpace(cleaned)
 }
 

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -529,6 +529,31 @@ func TestParseOutcome_Direct(t *testing.T) {
 		{"label with hyphens and dots", "x\n<!-- clawflow:outcome=v1.2-rc -->\n", "v1.2-rc", "x"},
 		{"trailing whitespace tolerant", "x\n<!-- clawflow:outcome=agent-skipped --> \n", "agent-skipped", "x"},
 		{"multiple — last wins", "<!-- clawflow:outcome=a -->\nfoo\n<!-- clawflow:outcome=b -->\n", "b", "foo"},
+		// thinking-block stripping (issue #196)
+		{
+			"single thinking block stripped",
+			"<thinking>\nNow I have enough context.\nMore reasoning.\n</thinking>\n\n## Eval\n\nbody\n\n<!-- clawflow:outcome=agent-evaluated -->\n",
+			"agent-evaluated",
+			"## Eval\n\nbody",
+		},
+		{
+			"multiple thinking blocks stripped",
+			"<thinking>first</thinking>\n\n## Eval\n\n<thinking>second\nmultiline</thinking>\n\nbody\n\n<!-- clawflow:outcome=agent-evaluated -->\n",
+			"agent-evaluated",
+			"## Eval\n\nbody",
+		},
+		{
+			"thinking block before outcome marker stripped",
+			"## Result\n\nbody\n\n<thinking>internal notes</thinking>\n\n<!-- clawflow:outcome=agent-skipped -->\n",
+			"agent-skipped",
+			"## Result\n\nbody",
+		},
+		{
+			"unclosed thinking tag left as-is (no swallow)",
+			"<thinking>truncated\n\n## Eval\n\nbody\n\n<!-- clawflow:outcome=agent-evaluated -->\n",
+			"agent-evaluated",
+			"<thinking>truncated\n\n## Eval\n\nbody",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #196

## What changed

Added  regex in  alongside the existing . It strips literal `<thinking>…</thinking>` blocks from the operator output before the comment is posted to the issue.

Applied in  after the outcome marker is removed, before the final . The regex uses `(?s)` so `." matches newlines (the leaked block in #195 was multi-paragraph), and `.*?` (non-greedy) handles multiple blocks independently.

An unclosed `<thinking>` tag (model truncation) is intentionally left as-is — the regex won't match and the raw tag appears in the comment rather than silently swallowing everything after it.

## Why this approach

The API-level thinking blocks (`content[].type == "thinking"`) are already filtered in `claude.go` by the `c.Type == "text"` check. The leak path is models that emit literal `<thinking>…</thinking>` XML inside a text content block. This fix closes that path at the `parseOutcome` layer, which is the single point where all operator output passes through before being posted.

## Tests

Four new table-driven cases added to `TestParseOutcome_Direct`:
- Single thinking block stripped
- Multiple thinking blocks stripped  
- Thinking block appearing before the outcome marker
- Unclosed tag left as-is (no content swallowed)