### PR TITLE
feat: 支持多语言设置 (zh/en) 全局注入 AI 系统提示

### DIFF
--- a/cmd/clawflow/commands/chat.go
+++ b/cmd/clawflow/commands/chat.go
@@ -173,11 +173,17 @@ func runChat(_ context.Context, repo string, issueNum int, model string, modeFla
 	// repo/issue context. The resume branch was removed when chat moved
 	// to the user's native terminal — see the comment on sessionID
 	// above for the full rationale.
+	// Resolve language preference for AI output.
+	var lang string
+	if globalCfg, cfgErr := config.Load(); cfgErr == nil {
+		lang = globalCfg.Settings.Language
+	}
+
 	var systemCtx string
 	if issueNum > 0 {
-		systemCtx, err = buildIssueChatContext(client, repo, issueNum, modeFlag)
+		systemCtx, err = buildIssueChatContext(client, repo, issueNum, modeFlag, lang)
 	} else {
-		systemCtx, err = buildRepoChatContext(client, repo, repoCfg.Platform, repoCfg.BaseBranch)
+		systemCtx, err = buildRepoChatContext(client, repo, repoCfg.Platform, repoCfg.BaseBranch, lang)
 	}
 	if err != nil {
 		return fmt.Errorf("build context: %w", err)
@@ -238,7 +244,7 @@ func runChat(_ context.Context, repo string, issueNum int, model string, modeFla
 	return cmd.Run()
 }
 
-func buildIssueChatContext(client vcs.Client, repo string, issueNum int, mode string) (string, error) {
+func buildIssueChatContext(client vcs.Client, repo string, issueNum int, mode string, lang string) (string, error) {
 	issues, err := client.ListOpenIssues(repo)
 	if err != nil {
 		return "", err
@@ -271,12 +277,12 @@ func buildIssueChatContext(client vcs.Client, repo string, issueNum int, mode st
 
 	comments, _ := client.ListIssueCommentsDetail(repo, issueNum)
 	if mode == "edit" {
-		return chat.BuildIssueContext(repo, issue, comments), nil
+		return chat.BuildIssueContext(repo, issue, comments, lang), nil
 	}
-	return chat.BuildIssueModeContext(repo, issue, comments), nil
+	return chat.BuildIssueModeContext(repo, issue, comments, lang), nil
 }
 
-func buildRepoChatContext(client vcs.Client, repo, platform, baseBranch string) (string, error) {
+func buildRepoChatContext(client vcs.Client, repo, platform, baseBranch string, lang string) (string, error) {
 	if platform == "" {
 		platform = "github"
 	}
@@ -287,5 +293,5 @@ func buildRepoChatContext(client vcs.Client, repo, platform, baseBranch string) 
 	if err != nil {
 		return "", err
 	}
-	return chat.BuildRepoContext(repo, platform, baseBranch, issues), nil
+	return chat.BuildRepoContext(repo, platform, baseBranch, issues, lang), nil
 }

--- a/cmd/clawflow/commands/project.go
+++ b/cmd/clawflow/commands/project.go
@@ -446,7 +446,7 @@ func runProjectChat(name, model string) error {
 		}
 	}
 
-	systemCtx := chat.BuildProjectChatContext(name, chatRepos, originalCtx, originalTesting)
+	systemCtx := chat.BuildProjectChatContext(name, chatRepos, originalCtx, originalTesting, cfg.Settings.Language)
 
 	sessionID := chat.NewSessionID("project/"+name, 0)
 	sessionName := fmt.Sprintf("clawflow: project/%s [project]", name)

--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -268,6 +268,11 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error on %s: %v\n", fullName, err)
 		}
+		// Propagate language preference to each job so the operator runner
+		// can inject the correct language directive into the system prompt.
+		for _, j := range repoJobs {
+			j.language = cfg.Settings.Language
+		}
 		pending = append(pending, repoPending...)
 		jobs = append(jobs, repoJobs...)
 	}
@@ -345,11 +350,12 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 // runJob is one (issue, operator) pair that scanRepoOnce decided is
 // eligible to fire. The worker pool in runJobsParallel consumes these.
 type runJob struct {
-	op      *operator.Operator
-	sub     *operator.Subject
-	repo    string
-	repoCfg config.Repo
-	client  vcs.Client
+	op       *operator.Operator
+	sub      *operator.Subject
+	repo     string
+	repoCfg  config.Repo
+	client   vcs.Client
+	language string // Settings.Language propagated from cfg at job creation time
 }
 
 // firedKey identifies a (repo, issue, operator) triple that ran to a
@@ -794,6 +800,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		Role:          role,
 		EventWriter:   eventsFile,
 		ResumeContext: resumeCtx,
+		Language:      j.language,
 	})
 	runDur := time.Since(runStart).Round(time.Second)
 	if eventsFile != nil {

--- a/internal/api/project_updatedoc.go
+++ b/internal/api/project_updatedoc.go
@@ -109,7 +109,12 @@ func HandleProjectUpdateDoc(w http.ResponseWriter, r *http.Request) {
 		model = config.ResolveModelForRole(creds, config.RoleOperator)
 	}
 
-	prompt := buildDocUpdatePrompt(p.Name, file, current, instructions)
+	var lang string
+	if cfg, cfgErr := config.Load(); cfgErr == nil {
+		lang = cfg.Settings.Language
+	}
+
+	prompt := buildDocUpdatePrompt(p.Name, file, current, instructions, lang)
 	workdir := project.ProjectDir(p.Name)
 
 	ctx, cancel := context.WithTimeout(r.Context(), updateDocTimeout)
@@ -189,7 +194,8 @@ func writeDocFile(projectName, file, content string) error {
 
 // buildDocUpdatePrompt is the pure prompt-builder. Separated from the
 // HTTP handler so it can be unit-tested without a running claude.
-func buildDocUpdatePrompt(projectName, file, current, instructions string) string {
+// lang is the preferred output language from Settings.Language.
+func buildDocUpdatePrompt(projectName, file, current, instructions, lang string) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "# Update `%s` for project `%s`\n\n", file, projectName)
@@ -249,6 +255,9 @@ func buildDocUpdatePrompt(projectName, file, current, instructions string) strin
 	fmt.Fprintln(&b, "  gaps worth filling — use A (with the new content).")
 	fmt.Fprintln(&b, "- Never both. Never neither. Do not add commentary outside the")
 	fmt.Fprintln(&b, "  chosen output (the runner ignores it and will reject the response).")
+	if directive := config.LanguageDirective(lang); directive != "" {
+		b.WriteString(directive)
+	}
 
 	return b.String()
 }

--- a/internal/api/project_updatedoc_test.go
+++ b/internal/api/project_updatedoc_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBuildDocUpdatePrompt_IncludesCurrentAndInstructions(t *testing.T) {
-	prompt := buildDocUpdatePrompt("my-proj", "context.md", "# Existing\n\nFoo bar.", "Add a section on testing")
+	prompt := buildDocUpdatePrompt("my-proj", "context.md", "# Existing\n\nFoo bar.", "Add a section on testing", "")
 
 	for _, want := range []string{
 		"my-proj",
@@ -33,7 +33,7 @@ func TestBuildDocUpdatePrompt_OffersBothOutcomes(t *testing.T) {
 	// audit questions where the doc is already accurate. Without the
 	// no-change escape hatch, audit-style requests (the user's
 	// "看下要不要更新" case) always fail validation.
-	prompt := buildDocUpdatePrompt("p", "context.md", "ctx", "is this still accurate?")
+	prompt := buildDocUpdatePrompt("p", "context.md", "ctx", "is this still accurate?", "")
 
 	for _, want := range []string{
 		"Rewrite path",
@@ -49,7 +49,7 @@ func TestBuildDocUpdatePrompt_OffersBothOutcomes(t *testing.T) {
 }
 
 func TestBuildDocUpdatePrompt_EmptyCurrentFlagged(t *testing.T) {
-	prompt := buildDocUpdatePrompt("p", "deployment.md", "", "Add SSH log retrieval")
+	prompt := buildDocUpdatePrompt("p", "deployment.md", "", "Add SSH log retrieval", "")
 
 	if !strings.Contains(prompt, "fresh authoring task") {
 		t.Error("empty-current case should signal 'fresh authoring task' to the model")

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -49,6 +49,9 @@ type settingsView struct {
 		// the dashboard can decide whether a given repo is "mine"
 		// without round-tripping through the bind endpoint.
 		Hostname string `json:"hostname,omitempty"`
+		// Language is the preferred AI output language. Supported values:
+		// "" (auto), "zh" (Simplified Chinese), "en" (English).
+		Language string `json:"language,omitempty"`
 	} `json:"global"`
 }
 
@@ -96,6 +99,7 @@ func HandleGetSettings(w http.ResponseWriter, r *http.Request) {
 	v.Global.Terminal = cfg.Settings.Terminal
 	v.Global.DefaultIDE = cfg.Settings.DefaultIDE
 	v.Global.RequireBinding = cfg.Settings.RequireBinding
+	v.Global.Language = cfg.Settings.Language
 	if h, hErr := os.Hostname(); hErr == nil {
 		v.Global.Hostname = h
 	}
@@ -198,6 +202,7 @@ type globalUpdate struct {
 	Terminal            *string `json:"terminal,omitempty"`
 	DefaultIDE          *string `json:"default_ide,omitempty"`
 	RequireBinding      *bool   `json:"require_binding,omitempty"`
+	Language            *string `json:"language,omitempty"`
 }
 
 // HandleUpdateGlobalSettings handles POST /api/settings/global.
@@ -261,6 +266,17 @@ func HandleUpdateGlobalSettings(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.RequireBinding != nil {
 		cfg.Settings.RequireBinding = *req.RequireBinding
+	}
+	if req.Language != nil {
+		lang := strings.TrimSpace(*req.Language)
+		// Validate: only "", "zh", "en" are accepted.
+		switch lang {
+		case "", "zh", "en":
+			cfg.Settings.Language = lang
+		default:
+			writeJSON(w, 400, map[string]string{"error": "language must be '' (auto), 'zh', or 'en'"})
+			return
+		}
 	}
 	if err := cfg.Save(); err != nil {
 		writeErr(w, err)

--- a/internal/chat/context.go
+++ b/internal/chat/context.go
@@ -10,19 +10,22 @@ import (
 
 // BuildIssueContext assembles the system prompt for issue-level chat in
 // edit mode — the AI can read AND modify files in the repo working tree.
-func BuildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment) string {
-	return buildIssueContext(repo, issue, comments, "edit")
+// lang is the preferred output language from Settings.Language (see
+// prompts.LanguageRule for accepted values).
+func BuildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment, lang string) string {
+	return buildIssueContext(repo, issue, comments, "edit", lang)
 }
 
 // BuildIssueModeContext assembles the system prompt for issue-level chat
 // in issue mode — the AI is restricted to discussion and issue-tracker
 // operations; file editing is disallowed at the claude CLI level.
-func BuildIssueModeContext(repo string, issue vcs.Issue, comments []vcs.IssueComment) string {
-	return buildIssueContext(repo, issue, comments, "issue")
+// lang is the preferred output language from Settings.Language.
+func BuildIssueModeContext(repo string, issue vcs.Issue, comments []vcs.IssueComment, lang string) string {
+	return buildIssueContext(repo, issue, comments, "issue", lang)
 }
 
 // buildIssueContext is the shared builder. mode is "issue" or "edit".
-func buildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment, mode string) string {
+func buildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment, mode string, lang string) string {
 	var b strings.Builder
 
 	fmt.Fprintln(&b, "# Chat Context")
@@ -53,16 +56,16 @@ func buildIssueContext(repo string, issue vcs.Issue, comments []vcs.IssueComment
 	fmt.Fprintln(&b)
 
 	if mode == "edit" {
-		buildEditModeRole(&b, repo, issue)
+		buildEditModeRole(&b, repo, issue, lang)
 	} else {
-		buildIssueModeRole(&b, repo, issue)
+		buildIssueModeRole(&b, repo, issue, lang)
 	}
 
 	return b.String()
 }
 
 // buildEditModeRole writes the "edit mode" role section — full file access.
-func buildEditModeRole(b *strings.Builder, repo string, issue vcs.Issue) {
+func buildEditModeRole(b *strings.Builder, repo string, issue vcs.Issue, lang string) {
 	fmt.Fprintf(b, "## Your role\n\n")
 	fmt.Fprintf(b, "You are a hands-on development assistant focused EXCLUSIVELY on\n")
 	fmt.Fprintf(b, "issue #%d in repo %s. You can directly read, analyze, AND fix\n", issue.Number, repo)
@@ -136,12 +139,12 @@ truth.`)
 	fmt.Fprintln(b)
 	fmt.Fprintln(b, prompts.CLICheatsheet(prompts.ScopeSingleIssue))
 	fmt.Fprintln(b)
-	fmt.Fprintln(b, prompts.LanguageRule())
+	fmt.Fprintln(b, prompts.LanguageRule(lang))
 }
 
 // buildIssueModeRole writes the "issue mode" role section — discussion and
 // issue-tracker operations only; file editing is blocked at the CLI level.
-func buildIssueModeRole(b *strings.Builder, repo string, issue vcs.Issue) {
+func buildIssueModeRole(b *strings.Builder, repo string, issue vcs.Issue, lang string) {
 	fmt.Fprintf(b, "## Your role\n\n")
 	fmt.Fprintf(b, "You are a planning and discussion assistant focused EXCLUSIVELY on\n")
 	fmt.Fprintf(b, "issue #%d in repo %s. Your job is to help the user think through\n", issue.Number, repo)
@@ -215,12 +218,13 @@ truth.`)
 	fmt.Fprintln(b)
 	fmt.Fprintln(b, prompts.CLICheatsheet(prompts.ScopeSingleIssue))
 	fmt.Fprintln(b)
-	fmt.Fprintln(b, prompts.LanguageRule())
+	fmt.Fprintln(b, prompts.LanguageRule(lang))
 }
 
 
 // BuildRepoContext assembles the system prompt for repo-level chat.
-func BuildRepoContext(repo string, platform string, baseBranch string, issues []vcs.Issue) string {
+// lang is the preferred output language from Settings.Language.
+func BuildRepoContext(repo string, platform string, baseBranch string, issues []vcs.Issue, lang string) string {
 	var b strings.Builder
 
 	fmt.Fprintln(&b, "# Chat Context")
@@ -333,7 +337,7 @@ target a specific issue from the list.`)
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, prompts.BehaviorRules())
 	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, prompts.LanguageRule())
+	fmt.Fprintln(&b, prompts.LanguageRule(lang))
 	fmt.Fprintln(&b)
 	fmt.Fprintln(&b, `After running a command, read the real stdout/stderr (issue URL, new label
 state) and report what actually happened. Do NOT claim success

--- a/internal/chat/context_test.go
+++ b/internal/chat/context_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestBuildIssueContext_HasSelfAwareness(t *testing.T) {
 	issue := vcs.Issue{Number: 42, Title: "x", State: "open", Labels: []string{"bug"}, Body: "details"}
-	out := BuildIssueContext("o/r", issue, nil)
+	out := BuildIssueContext("o/r", issue, nil, "")
 	assertSelfAwareness(t, "BuildIssueContext", out)
 
 	// Single-issue scope cheatsheet must NOT teach `issue create`. The
@@ -26,7 +26,7 @@ func TestBuildIssueContext_HasSelfAwareness(t *testing.T) {
 
 func TestBuildIssueModeContext_HasSelfAwareness(t *testing.T) {
 	issue := vcs.Issue{Number: 42, Title: "x", State: "open", Labels: []string{"feat"}, Body: "details"}
-	out := BuildIssueModeContext("o/r", issue, nil)
+	out := BuildIssueModeContext("o/r", issue, nil, "")
 	assertSelfAwareness(t, "BuildIssueModeContext", out)
 
 	if strings.Contains(out, "issue create --repo") || strings.Contains(out, "issue create --title") {
@@ -35,7 +35,7 @@ func TestBuildIssueModeContext_HasSelfAwareness(t *testing.T) {
 }
 
 func TestBuildRepoContext_HasSelfAwareness(t *testing.T) {
-	out := BuildRepoContext("o/r", "github", "main", nil)
+	out := BuildRepoContext("o/r", "github", "main", nil, "")
 	assertSelfAwareness(t, "BuildRepoContext", out)
 
 	// Repo scope is allowed to create issues — the actionable form should
@@ -50,8 +50,8 @@ func TestBuildRepoContext_HasSelfAwareness(t *testing.T) {
 func TestChatBuilders_LanguageRuleIsLast(t *testing.T) {
 	issue := vcs.Issue{Number: 1, Title: "t", State: "open"}
 	cases := map[string]string{
-		"BuildIssueContext":     BuildIssueContext("o/r", issue, nil),
-		"BuildIssueModeContext": BuildIssueModeContext("o/r", issue, nil),
+		"BuildIssueContext":     BuildIssueContext("o/r", issue, nil, ""),
+		"BuildIssueModeContext": BuildIssueModeContext("o/r", issue, nil, ""),
 	}
 	for name, prompt := range cases {
 		langIdx := strings.Index(prompt, "Match the user's input language")
@@ -62,6 +62,34 @@ func TestChatBuilders_LanguageRuleIsLast(t *testing.T) {
 		}
 		if langIdx < autoIdx || langIdx < cliIdx {
 			t.Errorf("%s: LanguageRule must come after both automation model and CLI cheatsheet", name)
+		}
+	}
+}
+
+// TestChatBuilders_LanguageOverride verifies that the language parameter is
+// threaded into each builder's output.
+func TestChatBuilders_LanguageOverride(t *testing.T) {
+	issue := vcs.Issue{Number: 1, Title: "t", State: "open"}
+
+	for _, lang := range []string{"zh", "en"} {
+		outIssue := BuildIssueContext("o/r", issue, nil, lang)
+		outIssueMode := BuildIssueModeContext("o/r", issue, nil, lang)
+		outRepo := BuildRepoContext("o/r", "github", "main", nil, lang)
+		for name, out := range map[string]string{
+			"BuildIssueContext[" + lang + "]":     outIssue,
+			"BuildIssueModeContext[" + lang + "]": outIssueMode,
+			"BuildRepoContext[" + lang + "]":      outRepo,
+		} {
+			switch lang {
+			case "zh":
+				if !strings.Contains(out, "简体中文") {
+					t.Errorf("%s: expected Chinese directive, not found", name)
+				}
+			case "en":
+				if !strings.Contains(out, "Always respond in **English**") {
+					t.Errorf("%s: expected English directive, not found", name)
+				}
+			}
 		}
 	}
 }

--- a/internal/chat/project.go
+++ b/internal/chat/project.go
@@ -42,7 +42,8 @@ type ProjectChatRepo struct {
 // The prompt establishes the role, lists member repos with paths,
 // enumerates allowed tools and CLI commands, and pins the output
 // contract for both context.md and testing.md updates.
-func BuildProjectChatContext(name string, repos []ProjectChatRepo, contextMD, testingMD string) string {
+// lang is the preferred output language from Settings.Language.
+func BuildProjectChatContext(name string, repos []ProjectChatRepo, contextMD, testingMD string, lang string) string {
 	var b strings.Builder
 
 	fmt.Fprintln(&b, "# Project Chat Context")
@@ -146,7 +147,7 @@ func BuildProjectChatContext(name string, repos []ProjectChatRepo, contextMD, te
 	fmt.Fprintln(&b)
 
 	// Language rule — unified across all chat kinds
-	fmt.Fprintln(&b, prompts.LanguageRule())
+	fmt.Fprintln(&b, prompts.LanguageRule(lang))
 	fmt.Fprintln(&b)
 
 	fmt.Fprintln(&b, "## Updating context.md or testing.md")

--- a/internal/chat/project_pilot.go
+++ b/internal/chat/project_pilot.go
@@ -66,12 +66,14 @@ type PilotWakeSummary struct {
 // Two safety rails: skip any issue carrying agent-running, and
 // don't duplicate prior Pilot actions (cooldown + recent-wake
 // history give the Pilot the data to enforce this itself).
+// lang is the preferred output language from Settings.Language.
 func BuildPilotContext(
 	name string,
 	contextMD string,
 	deploymentMD string,
 	recent []PilotWakeSummary,
 	repos []PilotRepoDigest,
+	lang string,
 ) string {
 	var b strings.Builder
 
@@ -457,6 +459,9 @@ Examples:
 
 The runner uses this line as your next wake's short-term memory entry.
 Make it specific.`)
+
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, prompts.LanguageRule(lang))
 
 	return b.String()
 }

--- a/internal/chat/project_test.go
+++ b/internal/chat/project_test.go
@@ -174,7 +174,7 @@ func TestBuildProjectChatContext(t *testing.T) {
 		{Name: "owner/repo-a", LocalPath: "/tmp/repo-a"},
 		{Name: "owner/repo-b", LocalPath: ""},
 	}
-	ctx := BuildProjectChatContext("my-proj", repos, "# My Project\n\nSome content.\n", "")
+	ctx := BuildProjectChatContext("my-proj", repos, "# My Project\n\nSome content.\n", "", "")
 
 	if !containsStr(ctx, "Project: my-proj") {
 		t.Error("missing project name in context")
@@ -205,7 +205,7 @@ func TestBuildPilotContext_WithDeployment(t *testing.T) {
 	}
 	deploymentMD := "## Logs\n\n```bash\nssh prod 'journalctl -u myapp -n 200'\n```"
 
-	prompt := BuildPilotContext("my-proj", "# Context\n\nSome overview.", deploymentMD, nil, repos)
+	prompt := BuildPilotContext("my-proj", "# Context\n\nSome overview.", deploymentMD, nil, repos, "")
 
 	if !containsStr(prompt, "Deployment & runtime health") {
 		t.Error("missing 'Deployment & runtime health' section")
@@ -233,7 +233,7 @@ func TestBuildPilotContext_WithDeployment(t *testing.T) {
 func TestBuildPilotContext_NoDeployment(t *testing.T) {
 	repos := []PilotRepoDigest{}
 
-	prompt := BuildPilotContext("empty-proj", "", "", nil, repos)
+	prompt := BuildPilotContext("empty-proj", "", "", nil, repos, "")
 
 	if !containsStr(prompt, "Deployment & runtime health") {
 		t.Error("missing 'Deployment & runtime health' section even when empty")
@@ -257,7 +257,7 @@ func TestBuildPilotContext_RecentHistory(t *testing.T) {
 		{StartedAt: "2026-05-05T12:00:00Z", Status: "success", Result: "PILOT-RESULT: no-action — backlog coherent"},
 	}
 
-	prompt := BuildPilotContext("my-proj", "", "", recent, repos)
+	prompt := BuildPilotContext("my-proj", "", "", recent, repos, "")
 
 	if !containsStr(prompt, "Recent wake history") {
 		t.Error("missing Recent wake history section")
@@ -279,7 +279,7 @@ func TestBuildPilotContext_RecentHistory(t *testing.T) {
 
 func TestBuildPilotContext_StandardPlays(t *testing.T) {
 	repos := []PilotRepoDigest{}
-	prompt := BuildPilotContext("p", "", "", nil, repos)
+	prompt := BuildPilotContext("p", "", "", nil, repos, "")
 
 	// Section header present
 	if !containsStr(prompt, "Standard plays") {
@@ -336,7 +336,7 @@ func TestBuildPilotContext_StandardPlays(t *testing.T) {
 
 func TestBuildPilotContext_SOPDriftAndDeploymentUpdate(t *testing.T) {
 	repos := []PilotRepoDigest{}
-	prompt := BuildPilotContext("p", "", "## Logs\n\n```bash\ncat /tmp/old.log\n```", nil, repos)
+	prompt := BuildPilotContext("p", "", "## Logs\n\n```bash\ncat /tmp/old.log\n```", nil, repos, "")
 
 	// 4th PATROL output must be present
 	if !containsStr(prompt, "PATROL: SOP drift") {
@@ -372,7 +372,7 @@ func TestBuildPilotContext_DeploymentUpdateProtocolAlwaysPresent(t *testing.T) {
 	// The deployment.md update protocol section should appear even when
 	// deployment.md is empty — Pilot may discover the file is missing and
 	// create it from scratch.
-	prompt := BuildPilotContext("p", "", "", nil, []PilotRepoDigest{})
+	prompt := BuildPilotContext("p", "", "", nil, []PilotRepoDigest{}, "")
 
 	if !containsStr(prompt, "Updating the project's runtime SOP (deployment.md)") {
 		t.Error("deployment.md update protocol section must be present even when deployment.md is empty")
@@ -382,7 +382,7 @@ func TestBuildPilotContext_DeploymentUpdateProtocolAlwaysPresent(t *testing.T) {
 
 func TestBuildProjectChatContext_AutomationModel(t *testing.T) {
 	repos := []ProjectChatRepo{{Name: "owner/repo-a", LocalPath: "/tmp/repo-a"}}
-	ctx := BuildProjectChatContext("my-proj", repos, "", "")
+	ctx := BuildProjectChatContext("my-proj", repos, "", "", "")
 
 	// Core automation model concepts must be present
 	if !containsStr(ctx, "ClawFlow automation model") {
@@ -422,7 +422,7 @@ func TestBuildProjectChatContext_AutomationModel(t *testing.T) {
 
 func TestBuildPilotContext_AutomationModel(t *testing.T) {
 	repos := []PilotRepoDigest{}
-	prompt := BuildPilotContext("my-proj", "", "", nil, repos)
+	prompt := BuildPilotContext("my-proj", "", "", nil, repos, "")
 
 	// Core automation model concepts must be present
 	if !containsStr(prompt, "ClawFlow automation model") {

--- a/internal/chat/prompts/module_cli_cheatsheet_test.go
+++ b/internal/chat/prompts/module_cli_cheatsheet_test.go
@@ -78,12 +78,25 @@ func TestCLICheatsheet_AllScopes_HaveFeedback(t *testing.T) {
 }
 
 func TestLanguageRule_Content(t *testing.T) {
-	out := LanguageRule()
+	// Default (empty) — mirror input language, fallback to Chinese.
+	out := LanguageRule("")
 	if !strings.Contains(out, "Match the user's input language") {
-		t.Error("LanguageRule missing language-mirroring instruction")
+		t.Error("LanguageRule('') missing language-mirroring instruction")
 	}
 	if !strings.Contains(out, "Chinese") {
-		t.Error("LanguageRule missing Chinese default fallback")
+		t.Error("LanguageRule('') missing Chinese default fallback")
+	}
+
+	// "zh" — always Chinese.
+	outZH := LanguageRule("zh")
+	if !strings.Contains(outZH, "简体中文") {
+		t.Error("LanguageRule('zh') missing Simplified Chinese instruction")
+	}
+
+	// "en" — always English.
+	outEN := LanguageRule("en")
+	if !strings.Contains(outEN, "English") {
+		t.Error("LanguageRule('en') missing English instruction")
 	}
 }
 

--- a/internal/chat/prompts/module_language.go
+++ b/internal/chat/prompts/module_language.go
@@ -1,13 +1,27 @@
 package prompts
 
-// LanguageRule returns the language-matching directive injected into
-// all chat kinds.
+// LanguageRule returns the language directive injected into all chat kinds.
 //
-// The rule: mirror the user's input language; default to Chinese when
-// the language cannot be determined yet.
-func LanguageRule() string {
-	return `## Language
+// Behaviour by lang:
+//
+//	"zh" — always respond in Simplified Chinese (简体中文).
+//	"en" — always respond in English.
+//	""   — mirror the user's input language; default to Chinese when
+//	        the language cannot be determined yet (historical behaviour).
+func LanguageRule(lang string) string {
+	switch lang {
+	case "zh":
+		return `## Language
+
+始终使用**简体中文**回复。所有输出——分析、计划、评论及正文——均须以中文书写，无论用户的输入语言如何。代码标识符、日志片段及机器可读标记（如 ` + "`<!-- clawflow:outcome=… -->`" + `）保持不变。`
+	case "en":
+		return `## Language
+
+Always respond in **English**. All output — analysis, plans, comments, and prose — must be written in English regardless of the input language.`
+	default:
+		return `## Language
 
 Match the user's input language. If you can't tell yet, default to
 Chinese (本项目用户母语为中文，但请尊重用户实际输入的语言).`
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,6 +124,18 @@ type Settings struct {
 	// being processed by all machines simultaneously — they must be
 	// explicitly bound first. Synced via Gist as a shared fleet policy.
 	RequireBinding bool `yaml:"require_binding,omitempty"`
+
+	// Language, when set, overrides the language of all AI-generated output
+	// (operator comments, chat replies, Pilot verdicts, doc generation).
+	// Supported values:
+	//   ""   — auto: match the user's input language; default to Chinese
+	//           (preserves historical behaviour).
+	//   "zh" — always respond in Simplified Chinese (简体中文).
+	//   "en" — always respond in English.
+	// The directive is injected into every AI system prompt at build time
+	// so all current and future operators inherit the setting automatically.
+	// Synced via Gist as a shared preference.
+	Language string `yaml:"language,omitempty"`
 }
 
 // ResolveGithubCloneDir returns the configured GitHub clone directory, defaulting to ~/github.
@@ -158,6 +170,28 @@ func (s *Settings) ResolveIDEScheme() string {
 		return "vscode-insiders://file/"
 	default: // "", "vscode", or any unrecognised value
 		return "vscode://file/"
+	}
+}
+
+// LanguageDirective returns a short instruction to append to any AI system
+// prompt so the model responds in the user's preferred language.
+//
+// Values:
+//
+//	"zh" → instruct the model to always respond in Simplified Chinese.
+//	"en" → instruct the model to always respond in English.
+//	""   → return "" (no override; the model's default language behaviour applies).
+//
+// The returned string is either empty or starts with "\n\n" so callers can
+// concatenate it directly without extra spacing.
+func LanguageDirective(lang string) string {
+	switch lang {
+	case "zh":
+		return "\n\n**Language directive:** Respond in 简体中文 (Simplified Chinese). All output — analysis, plans, comments, and prose — must be written in Chinese regardless of the input language. Code identifiers, log snippets, and machine-stable markers (e.g. `<!-- clawflow:outcome=… -->`) must remain unchanged.\n"
+	case "en":
+		return "\n\n**Language directive:** Respond in English. All output — analysis, plans, comments, and prose — must be written in English regardless of the input language.\n"
+	default:
+		return ""
 	}
 }
 

--- a/internal/operator/context.go
+++ b/internal/operator/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/zhoushoujianwork/clawflow/internal/config"
 	"github.com/zhoushoujianwork/clawflow/internal/project"
 )
 
@@ -12,7 +13,12 @@ import (
 // body. This content is identical across every issue the same operator
 // processes, so passing it via `--system-prompt` lets Anthropic's prompt
 // cache hit on subsequent runs of the same operator.
-func BuildSystemPrompt(op *Operator, repo string) string {
+//
+// lang is the preferred output language from Settings.Language ("zh", "en",
+// or "" for the historical auto-detect behaviour). A non-empty value appends
+// a language directive so all operator output (comments, verdicts) uses the
+// configured language.
+func BuildSystemPrompt(op *Operator, repo string, lang string) string {
 	var b strings.Builder
 
 	if header := project.HeaderForRepo(repo); header != "" {
@@ -21,6 +27,9 @@ func BuildSystemPrompt(op *Operator, repo string) string {
 
 	fmt.Fprintf(&b, "# Your Task (Operator: %s)\n\n", op.Name)
 	fmt.Fprint(&b, op.Prompt)
+	if directive := config.LanguageDirective(lang); directive != "" {
+		b.WriteString(directive)
+	}
 	return b.String()
 }
 
@@ -74,8 +83,10 @@ func BuildUserMessage(sub *Subject, repo string, comments []string) string {
 // BuildPrompt constructs the full prompt handed to `claude -p` as a single
 // string. Retained for back-compat with callers that don't use the split
 // system-prompt / user-message path (e.g. tests, one-off invocations).
+// It passes an empty language string (auto-detect), which preserves the
+// historical default behaviour.
 func BuildPrompt(op *Operator, sub *Subject, repo string, comments []string) string {
-	sys := BuildSystemPrompt(op, repo)
+	sys := BuildSystemPrompt(op, repo, "")
 	usr := BuildUserMessage(sub, repo, comments)
 	return usr + "---\n\n" + sys
 }

--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -98,6 +98,11 @@ type RunOptions struct {
 	// rather than start from scratch.
 	ResumeContext string
 
+	// Language is the preferred output language from Settings.Language
+	// ("zh", "en", or "" for auto). Passed to BuildSystemPrompt so all
+	// operator output (comments, verdicts) uses the configured language.
+	Language string
+
 	// RunFunc executes the claude subprocess. Leave nil to use the real
 	// RunClaude; tests inject a fake that returns canned output without
 	// spawning a process.
@@ -118,7 +123,7 @@ var writeBackTimeout = 5 * time.Minute
 // Run executes one operator against one subject and returns the operator's
 // final stdout text, the outcome label (empty if none), or an error.
 func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions) (string, string, error) {
-	systemPrompt := BuildSystemPrompt(op, opts.Repo)
+	systemPrompt := BuildSystemPrompt(op, opts.Repo, opts.Language)
 	userMessage := BuildUserMessage(sub, opts.Repo, opts.Comments)
 	if opts.ResumeContext != "" {
 		userMessage += "\n---\n\n" + opts.ResumeContext

--- a/internal/pilot/schedule.go
+++ b/internal/pilot/schedule.go
@@ -289,7 +289,7 @@ func wake(ctx context.Context, p *project.Project, cfg *config.Config, creds *co
 	deploymentMD, _ := project.ReadDeployment(p.Name)
 	recent := pilotRecentSummaries(p.Name, 3)
 
-	prompt := chat.BuildPilotContext(p.Name, contextMD, deploymentMD, recent, digests)
+	prompt := chat.BuildPilotContext(p.Name, contextMD, deploymentMD, recent, digests, cfg.Settings.Language)
 	model := config.ResolveModelForRole(creds, config.RoleOperator)
 	workdir := project.ProjectDir(p.Name)
 

--- a/web/src/routes/_app.settings.tsx
+++ b/web/src/routes/_app.settings.tsx
@@ -19,6 +19,8 @@ interface SettingsView {
     terminal?: string
     default_ide?: string
     require_binding?: boolean
+    /** AI output language: '' (auto), 'zh' (Simplified Chinese), 'en' (English) */
+    language?: string
   }
 }
 
@@ -273,6 +275,7 @@ function GlobalSection({
   const [terminal, setTerminal] = useState(view.terminal ?? '')
   const [defaultIDE, setDefaultIDE] = useState(view.default_ide ?? '')
   const [requireBinding, setRequireBinding] = useState(view.require_binding ?? false)
+  const [language, setLanguage] = useState(view.language ?? '')
   const [busy, setBusy] = useState(false)
   const [saveMsg, setSaveMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
@@ -289,6 +292,7 @@ function GlobalSection({
     setTerminal(view.terminal ?? '')
     setDefaultIDE(view.default_ide ?? '')
     setRequireBinding(view.require_binding ?? false)
+    setLanguage(view.language ?? '')
   }, [view])
 
   const dirty =
@@ -302,7 +306,8 @@ function GlobalSection({
     gitlabURL !== (view.gitlab_url ?? '') ||
     terminal !== (view.terminal ?? '') ||
     defaultIDE !== (view.default_ide ?? '') ||
-    requireBinding !== (view.require_binding ?? false)
+    requireBinding !== (view.require_binding ?? false) ||
+    language !== (view.language ?? '')
 
   const save = () => {
     setBusy(true); setSaveMsg(null)
@@ -321,6 +326,7 @@ function GlobalSection({
         terminal: terminal,
         default_ide: defaultIDE,
         require_binding: requireBinding,
+        language: language,
       }),
     })
       .then(async r => {
@@ -403,6 +409,17 @@ function GlobalSection({
           onChange={e => setRequireBinding(e.target.checked)}
           className="rounded border-border w-4 h-4"
         />
+      </Row>
+      <Row label="AI language" hint="Language for all AI-generated output: operator comments, chat replies, Pilot verdicts. 'Auto' mirrors user input, defaulting to Chinese.">
+        <select
+          value={language}
+          onChange={e => setLanguage(e.target.value)}
+          className="flex-1 text-sm px-2 py-1 border border-border rounded bg-background"
+        >
+          <option value="">Auto (match input, default Chinese)</option>
+          <option value="zh">中文 (Simplified Chinese)</option>
+          <option value="en">English</option>
+        </select>
       </Row>
 
       <div className="flex items-center gap-2 pt-2">


### PR DESCRIPTION
Fixes #198

## What changed

新增 `Settings.Language` 配置项（config.yaml），支持三个值：
- `""` (auto) — 默认行为：匹配用户输入语言，缺省回退中文
- `"zh"` — 所有 AI 输出均使用简体中文
- `"en"` — 所有 AI 输出均使用英文

语言指令在全局位置注入，所有当前和未来算子自动继承，无需修改单个 SKILL.md。

## AI 路径覆盖

| 路径 | 实现方式 |
|------|----------|
| Operator 注释 | `BuildSystemPrompt` 追加 `config.LanguageDirective(lang)` |
| Chat（issue/repo 级） | `BuildIssueContext` / `BuildRepoContext` 传入 lang → `prompts.LanguageRule(lang)` |
| Project Chat | `BuildProjectChatContext` 传入 lang |
| Pilot wake | `BuildPilotContext` 追加 lang rule |
| Doc update（context/testing/deployment.md） | `buildDocUpdatePrompt` 追加 LanguageDirective |
| 原生终端 chat spawn | chat 命令启动时读取 config，自动注入 |

## Settings UI

在 Settings → Global 新增 "AI language" 下拉选项（Auto / 中文 / English），与其他全局设置同存 config.yaml，Gist sync 时随之同步。

## 安全边界

- outcome marker（`<!-- clawflow:outcome=… -->`）、label 名称、结构化日志字段不受影响
- 语言指令明确说明代码标识符和 log 片段保持不变