### PR TITLE
fix: 已 closed 的 issue 在 Web UI 仍显示为 DONE/success 状态 (#202)

### DIFF
--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -829,10 +829,35 @@ type IssueEntry struct {
 }
 
 // WriteIssues writes data/issues.json with all issues from monitored repos.
+//
+// Closed issues are kept sticky: if the previous snapshot contained a closed
+// issue that is absent from `entries` (because the GitHub API only returns
+// ~100 results sorted by updated_at and the issue fell out of the window),
+// it is merged back in. "Closed" is a terminal state that never reverts, so
+// once an issue is known closed it must not silently disappear from the
+// snapshot — otherwise the dashboard would infer it is open and mis-classify
+// it as DONE rather than Closed.
 func WriteIssues(entries []IssueEntry) error {
 	if entries == nil {
 		entries = []IssueEntry{}
 	}
+
+	// Merge in previously-known closed issues missing from the new batch.
+	newKeys := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		newKeys[fmt.Sprintf("%s#%d", e.Repo, e.IssueNumber)] = true
+	}
+	if data, err := os.ReadFile(filepath.Join(DataDir(), "issues.json")); err == nil {
+		var old []IssueEntry
+		if json.Unmarshal(data, &old) == nil {
+			for _, e := range old {
+				if e.State == "closed" && !newKeys[fmt.Sprintf("%s#%d", e.Repo, e.IssueNumber)] {
+					entries = append(entries, e)
+				}
+			}
+		}
+	}
+
 	sort.Slice(entries, func(i, j int) bool {
 		if entries[i].Repo != entries[j].Repo {
 			return entries[i].Repo < entries[j].Repo

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -989,3 +989,127 @@ func TestCleanupLegacyDashboardDir_RefusesNonEmptyDataSubdir(t *testing.T) {
 	}
 }
 
+// TestWriteIssues_StickyClosedIssues verifies that WriteIssues merges back
+// previously-known closed issues that are absent from the new batch.
+//
+// Scenario: The GitHub API returns at most ~100 items. An older closed issue
+// (#92) was written in the previous snapshot but is now absent because it
+// fell out of the 100-item window. WriteIssues must preserve it so the
+// dashboard can correctly classify it as Closed rather than assuming it is open.
+func TestWriteIssues_StickyClosedIssues(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, ".clawflow", "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	earlier := now.Add(-24 * time.Hour)
+
+	// Simulate the previous snapshot: contains closed issue #92 plus open #200.
+	prev := []IssueEntry{
+		{Repo: "owner/repo", IssueNumber: 92, IssueTitle: "old bug", State: "closed", CapturedAt: earlier},
+		{Repo: "owner/repo", IssueNumber: 200, IssueTitle: "open issue", State: "open", CapturedAt: earlier},
+	}
+	if err := WriteIssues(prev); err != nil {
+		t.Fatalf("first WriteIssues: %v", err)
+	}
+
+	// Simulate the next API refresh: #92 is absent (fell out of the window),
+	// only #200 (now closed) and a new #205 are returned.
+	fresh := []IssueEntry{
+		{Repo: "owner/repo", IssueNumber: 200, IssueTitle: "open issue", State: "closed", CapturedAt: now},
+		{Repo: "owner/repo", IssueNumber: 205, IssueTitle: "new issue", State: "open", CapturedAt: now},
+	}
+	if err := WriteIssues(fresh); err != nil {
+		t.Fatalf("second WriteIssues: %v", err)
+	}
+
+	// Read back and verify.
+	data, err := os.ReadFile(filepath.Join(tmp, ".clawflow", "data", "issues.json"))
+	if err != nil {
+		t.Fatalf("read issues.json: %v", err)
+	}
+	var got []IssueEntry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	byNum := make(map[int]IssueEntry)
+	for _, e := range got {
+		byNum[e.IssueNumber] = e
+	}
+
+	// #92 must be preserved (sticky closed).
+	e92, ok := byNum[92]
+	if !ok {
+		t.Fatal("issue #92 was lost — closed issues must be preserved across refreshes")
+	}
+	if e92.State != "closed" {
+		t.Errorf("#92 state=%q, want closed", e92.State)
+	}
+
+	// #200 must reflect the new closed state from the fresh batch.
+	e200, ok := byNum[200]
+	if !ok {
+		t.Fatal("issue #200 missing")
+	}
+	if e200.State != "closed" {
+		t.Errorf("#200 state=%q, want closed", e200.State)
+	}
+
+	// #205 must be present (new open issue).
+	e205, ok := byNum[205]
+	if !ok {
+		t.Fatal("issue #205 missing")
+	}
+	if e205.State != "open" {
+		t.Errorf("#205 state=%q, want open", e205.State)
+	}
+
+	// Total: 3 entries.
+	if len(got) != 3 {
+		t.Errorf("got %d entries, want 3 (92, 200, 205)", len(got))
+	}
+}
+
+// TestWriteIssues_StickyDoesNotDuplicateClosedInBatch verifies that closed
+// issues already present in the new batch are NOT duplicated by the sticky merge.
+func TestWriteIssues_StickyDoesNotDuplicateClosedInBatch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, ".clawflow", "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	earlier := now.Add(-1 * time.Hour)
+
+	prev := []IssueEntry{
+		{Repo: "owner/repo", IssueNumber: 10, State: "closed", CapturedAt: earlier},
+	}
+	if err := WriteIssues(prev); err != nil {
+		t.Fatalf("first WriteIssues: %v", err)
+	}
+
+	// Same closed #10 is in the fresh batch — must NOT be duplicated.
+	fresh := []IssueEntry{
+		{Repo: "owner/repo", IssueNumber: 10, State: "closed", CapturedAt: now},
+	}
+	if err := WriteIssues(fresh); err != nil {
+		t.Fatalf("second WriteIssues: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(tmp, ".clawflow", "data", "issues.json"))
+	var got []IssueEntry
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %d entries, want 1 (no duplicates)", len(got))
+	}
+	// The fresh entry (newer CapturedAt) should win.
+	if !got[0].CapturedAt.Equal(now) {
+		t.Errorf("expected fresh CapturedAt to win; got %v", got[0].CapturedAt)
+	}
+}

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -66,7 +66,7 @@ export interface IssueGroup {
   runs: Run[]
   pending: PendingEntry[]
   labels?: string[]
-  state?: string // "open" | "closed"
+  state?: string // "open" | "closed" | "unknown" (unknown = run exists but no issues.json entry)
 }
 
 // SectionConfig parameterizes how groups bucket into headed sections.
@@ -124,7 +124,11 @@ export function useIssueGroups({
           runs: [],
           pending: [],
           labels: [],
-          state: 'open',
+          // 'unknown': issue not in issues.json snapshot — don't assume open.
+          // The backend's WriteIssues sticky-merge should prevent this for
+          // closed issues; 'unknown' acts as a safety net so they don't
+          // incorrectly land in the Done section.
+          state: 'unknown',
         }
         map.set(k, g)
       }
@@ -198,7 +202,10 @@ export function bucketize(
 export const REPO_SECTIONS: SectionConfig[] = [
   { title: 'Running', tone: 'blue', filter: g => g.state !== 'closed' && g.runs[0]?.status === 'running' },
   { title: 'Pending', tone: 'amber', filter: g => g.state !== 'closed' && g.pending.length > 0 },
-  { title: 'Done', tone: 'muted', filter: g => g.state !== 'closed' },
+  // Explicitly check state === 'open' so that issues with state 'unknown'
+  // (run exists but no issues.json entry — see useIssueGroups) or 'closed'
+  // are not incorrectly shown as Done.
+  { title: 'Done', tone: 'muted', filter: g => g.state === 'open' },
   { title: 'Closed', tone: 'gray', filter: g => g.state === 'closed', limit: 10 },
 ]
 
@@ -228,7 +235,7 @@ export const PROJECT_SECTIONS: SectionConfig[] = [
       return hasTrigger && !hasAgentLabel
     },
   },
-  { title: 'Done', tone: 'muted', filter: g => g.state !== 'closed', limit: 10 },
+  { title: 'Done', tone: 'muted', filter: g => g.state === 'open', limit: 10 },
   { title: 'Closed', tone: 'gray', filter: g => g.state === 'closed', limit: 10 },
 ]
 

--- a/web/src/routes/_app.repos.$repoName.tsx
+++ b/web/src/routes/_app.repos.$repoName.tsx
@@ -196,7 +196,9 @@ function RepoDetail() {
       if (g.state === 'closed') closed++
       else if (g.runs[0]?.status === 'running') running++
       else if (g.pending.length > 0) pendingI++
-      else done++
+      else if (g.state === 'open') done++
+      // state === 'unknown': run exists but no issues.json entry — not counted
+      // in any bucket to match the Done section's explicit state === 'open' filter.
     }
     return { running, pending: pendingI, done, closed }
   }, [issueGroups])


### PR DESCRIPTION
Fixes #202

## 问题根因

两处叠加导致 closed issue 错误落入 DONE 分组：

1. **后端（主因）**：`WriteIssues` 调用 `ListIssues("all")` 只拿前 100 条（按 updated_at 倒序），较早被 closed 的 issue（如 #92）因为超出窗口而被丢弃，不再写入 `issues.json`。

2. **前端（次因）**：`useIssueGroups` 合并时，对只存在于 `runs.json` 而不在 `issues.json` 中的 issue 硬编码 `state: 'open'`，REPO_SECTIONS 的 Done 过滤器 `g.state !== 'closed'` 于是把它们全归到 Done。

## 修改内容

### `internal/snapshot/snapshot.go` — WriteIssues 粘性合并
写快照前先读旧 `issues.json`，把本轮 API 未返回、但旧快照中已知为 `closed` 的 issue 合并保留。closed 是终态，一旦写入就不因掉出 100 条窗口而丢失。

### `web/src/components/IssueList.tsx` — 去掉 run-only 分组的 open 假设
- run-only 分组（有 runs、无 issues.json 条目）的 `state` 从 `'open'` 改为 `'unknown'`
- `REPO_SECTIONS` 的 Done 过滤器从 `g.state !== 'closed'` 改为 `g.state === 'open'`，保证 `unknown` 分组不会错误落入 Done

### `web/src/routes/_app.repos.$repoName.tsx` — sectionCounts 与 Done 过滤器对齐
`done++` 改为 `else if (g.state === 'open') done++`，使统计数字与 Done section 的展示保持一致。

### `internal/snapshot/snapshot_test.go` — 补单测
- `TestWriteIssues_StickyClosedIssues`：验证旧快照的 closed issue #92 在新批次未出现时仍被保留
- `TestWriteIssues_StickyDoesNotDuplicateClosedInBatch`：验证已在新批次中的 closed issue 不被重复追加