### PR TITLE
fix(operator): detect 403 auth errors separately, stop retrying and log WARN

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -836,6 +836,13 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	// the caller so it can abort the remaining job queue.
 	isRateLimit := runErr != nil && errors.Is(runErr, operator.ErrRateLimit)
 
+	// Detect auth errors (403 / "request not allowed"). These are distinct
+	// from rate limits and generic failures: retrying immediately won't help —
+	// the session token or account permission needs human intervention.
+	// We do NOT count auth errors toward the circuit breaker to avoid
+	// auto-labeling agent-failed on a configuration problem (issue #204).
+	isAuthError := runErr != nil && errors.Is(runErr, operator.ErrAuthError)
+
 	// Detect no-marker failures: claude produced output but omitted the
 	// outcome marker. operator.Run now returns ErrNoOutcomeMarker for this
 	// case so we can route it through the circuit breaker (status="failed")
@@ -846,6 +853,10 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	if runErr != nil {
 		if isRateLimit {
 			fmt.Fprintf(os.Stderr, "%s ✗ claude rate limited (will retry next pass): %v\n", prefix, runErr)
+		} else if isAuthError {
+			// Use Warn-level so patrol grep -E "ERROR|WARN" catches this.
+			runLog.Warn("run/auth_error", "repo", j.repo, "issue", j.sub.Number, "op", j.op.Name, "err", runErr.Error())
+			fmt.Fprintf(os.Stderr, "%s ✗ claude auth error 403 (check session/API key, NOT retrying): %v\n", prefix, runErr)
 		} else if isNoMarker {
 			fmt.Fprintf(os.Stderr, "%s ✗ claude produced no outcome marker (will count toward circuit breaker): %v\n", prefix, runErr)
 		} else {
@@ -871,6 +882,14 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		// and ConsecutiveFailures doesn't count this toward the circuit breaker.
 		rm.Status = "rate-limited"
 		rm.Error = runErr.Error()
+	case isAuthError:
+		// Record as "auth-error" — distinct from "failed" so the dashboard
+		// can surface the specific cause. Does NOT count toward circuit breaker
+		// since agent-failed would be misleading (the issue itself is fine;
+		// the credentials are broken). Operator should investigate the session
+		// or configure an independent API key provider (issue #204).
+		rm.Status = "auth-error"
+		rm.Error = runErr.Error()
 	case isNoMarker:
 		// No-marker runs are recorded as "no-marker" (distinct from generic
 		// "failed") so the dashboard can surface the specific cause. They DO
@@ -894,9 +913,9 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	// Conditional cleanup: only remove the worktree on success/skip.
 	// On failure, preserve it so the next run can resume from the
 	// partial work instead of starting from scratch.
-	// skipped-empty and no-marker have no partial work worth resuming,
-	// so clean up to avoid accumulating stale worktrees.
-	if rm.Status == "success" || rm.Status == "skipped-empty" || rm.Status == "no-marker" {
+	// skipped-empty, no-marker, and auth-error have no partial work worth
+	// resuming, so clean up to avoid accumulating stale worktrees.
+	if rm.Status == "success" || rm.Status == "skipped-empty" || rm.Status == "no-marker" || rm.Status == "auth-error" {
 		cleanup()
 	} else {
 		fmt.Fprintf(os.Stderr, "%s → preserving worktree for resume on next run: %s\n", prefix, workdir)
@@ -908,7 +927,13 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	if err := snapshot.WriteRunMeta(runDir, rm); err != nil {
 		fmt.Fprintf(os.Stderr, "%s ⚠ run meta: %v\n", prefix, err)
 	}
-	runLog.Info("run/end",
+	// Upgrade to WARN for non-success statuses so deployment.md patrol's
+	// "grep -E ERROR|WARN" actively catches failures (issue #204).
+	logFn := runLog.Info
+	if rm.Status == "failed" || rm.Status == "auth-error" {
+		logFn = runLog.Warn
+	}
+	logFn("run/end",
 		"repo", j.repo,
 		"issue", j.sub.Number,
 		"op", j.op.Name,
@@ -930,6 +955,12 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	case "rate-limited":
 		// Signal the caller to abort the queue; do NOT call checkCircuitBreaker.
 		return false, true
+	case "auth-error":
+		// Do NOT signal queue abort (unlike rate-limit, other issues may still
+		// succeed with the same session). Do NOT call checkCircuitBreaker —
+		// agent-failed would be misleading for a credential problem.
+		fmt.Printf("%s ✗ auth error (check session/API key)\n", prefix)
+		return false, false
 	case "no-marker":
 		fmt.Printf("%s ✗ no outcome marker (circuit breaker counting)\n", prefix)
 		checkCircuitBreaker(j, prefix)

--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -22,6 +22,25 @@ import (
 // stop processing the current queue and let the next scheduled run retry.
 var ErrRateLimit = errors.New("claude rate limit")
 
+// ErrAuthError is returned by RunClaude when the claude CLI exits with a
+// 403 / authentication-failure response. Unlike rate limits this is NOT
+// transient in the same way — retrying immediately will reproduce the same
+// error. Callers should stop retrying and surface the failure loudly (WARN
+// log + a distinct outcome label) so operators can investigate the session
+// or API-key configuration rather than burning quota on an infinite loop.
+var ErrAuthError = errors.New("claude auth error")
+
+// authErrorPatterns are substrings (case-insensitive) that identify a
+// 403 / authentication-failure response from the claude CLI. Matching any
+// one of them triggers ErrAuthError rather than the generic failure path.
+var authErrorPatterns = []string{
+	"403",
+	"request not allowed",
+	"failed to authenticate",
+	"authentication failed",
+	"api error: 403",
+}
+
 // rateLimitPatterns are substrings (case-insensitive) that identify a
 // transient rate-limit / quota response from the claude CLI. The list covers:
 //   - Claude Code CLI English output: "You've hit your limit"
@@ -53,6 +72,23 @@ func IsRateLimitError(err error, output string) bool {
 	}
 	combined := strings.ToLower(err.Error() + " " + output)
 	for _, pat := range rateLimitPatterns {
+		if strings.Contains(combined, strings.ToLower(pat)) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsAuthError reports whether err or the captured claude output text indicates
+// a 403 / authentication-failure response. Both are checked because the claude
+// CLI writes the human-readable message to stdout while the Go error only
+// carries "exit status 1".
+func IsAuthError(err error, output string) bool {
+	if err == nil {
+		return false
+	}
+	combined := strings.ToLower(err.Error() + " " + output)
+	for _, pat := range authErrorPatterns {
 		if strings.Contains(combined, strings.ToLower(pat)) {
 			return true
 		}
@@ -135,6 +171,16 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 				fmt.Fprintf(os.Stderr, "  ✓ provider %q succeeded (after %d failed attempt(s))\n", p.name, i)
 			}
 			return output, nil
+		}
+
+		// Auth errors (403 / "request not allowed") are distinct from both
+		// failover and rate-limit: retrying immediately or switching provider
+		// won't help — the session token or account permission is the issue.
+		// Return ErrAuthError immediately so the caller can surface a loud
+		// warning and stop retrying without counting toward the circuit breaker.
+		if IsAuthError(err, output) {
+			wrapped := fmt.Errorf("claude: %w", err)
+			return output, fmt.Errorf("%w: %w", ErrAuthError, wrapped)
 		}
 
 		// Determine whether this is a provider-level failure (failover) or

--- a/internal/operator/claude_test.go
+++ b/internal/operator/claude_test.go
@@ -160,6 +160,78 @@ func TestParseClaudeStream_MultipleMarkerTurns_LastWins(t *testing.T) {
 	}
 }
 
+func TestIsAuthError(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		output string
+		want   bool
+	}{
+		{
+			name:   "nil error",
+			err:    nil,
+			output: "",
+			want:   false,
+		},
+		{
+			name:   "generic exit status 1 no auth pattern",
+			err:    errors.New("claude: exit status 1"),
+			output: "some unrelated error",
+			want:   false,
+		},
+		{
+			name:   "403 in output",
+			err:    errors.New("claude: exit status 1"),
+			output: "Failed to authenticate. API Error: 403 Request not allowed",
+			want:   true,
+		},
+		{
+			name:   "request not allowed case-insensitive",
+			err:    errors.New("claude: exit status 1"),
+			output: "REQUEST NOT ALLOWED",
+			want:   true,
+		},
+		{
+			name:   "failed to authenticate in output",
+			err:    errors.New("claude: exit status 1"),
+			output: "Failed to authenticate with the API",
+			want:   true,
+		},
+		{
+			name:   "api error 403 in output",
+			err:    errors.New("claude: exit status 1"),
+			output: "api error: 403 forbidden",
+			want:   true,
+		},
+		{
+			name:   "authentication failed in output",
+			err:    errors.New("claude: exit status 1"),
+			output: "Authentication failed: invalid session",
+			want:   true,
+		},
+		{
+			name:   "rate limit 429 should not match auth",
+			err:    errors.New("claude: exit status 1"),
+			output: "HTTP 429 Too Many Requests",
+			want:   false,
+		},
+		{
+			name:   "rate limit hit your limit should not match auth",
+			err:    errors.New("claude: exit status 1"),
+			output: "You've hit your limit",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsAuthError(tc.err, tc.output)
+			if got != tc.want {
+				t.Errorf("IsAuthError(%v, %q) = %v, want %v", tc.err, tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsRateLimitError(t *testing.T) {
 	cases := []struct {
 		name    string


### PR DESCRIPTION
Fixes #204

## 变更说明

当 `claude -p` 以 403 / "Request not allowed" 退出时，之前的代码将其当作普通失败处理，导致：
1. circuit breaker 累计计数 → 最终打上 `agent-failed`（对凭证问题毫无意义）
2. `run/end` 仅 INFO 级别日志 → patrol `grep ERROR|WARN` 完全看不到
3. 每次人工移除 `agent-failed` 重试，均以 403 失败，形成无效循环

## 修复内容

### `internal/operator/claude.go`
- 新增 `ErrAuthError` sentinel 错误
- 新增 `authErrorPatterns`（匹配 `403`、`request not allowed`、`failed to authenticate`、`authentication failed`、`api error: 403`）
- 新增 `IsAuthError(err, output)` 函数
- 在 `RunClaude` 的 failover 循环中，**优先**检查 auth error（在 failover 和 rate-limit 之前），命中即立即返回 `ErrAuthError`，不切换 provider，不触发退避重试

### `cmd/clawflow/commands/run.go`
- 检测 `isAuthError := errors.Is(runErr, operator.ErrAuthError)`
- `rm.Status = "auth-error"`（独立状态，dashboard 可区分）
- **不调用** `checkCircuitBreaker` — 避免给凭证问题打 `agent-failed`
- worktree 清理（无需保留，auth 错误不涉及部分工作）
- 立即输出 `runLog.Warn("run/auth_error", ...)` — patrol grep 主动可见
- `run/end` 在 `status=failed` 或 `status=auth-error` 时升级为 WARN 级

### `internal/operator/claude_test.go`
- 新增 `TestIsAuthError` 含 9 个测试用例，覆盖正向匹配、大小写不敏感、负向（rate-limit 不误匹配）

## 测试

```
go test ./internal/operator/... -v -run "TestIsAuthError|TestIsRateLimitError"
# 全部 PASS
```

（`cmd/clawflow/commands` 包因 `web/dist` 未构建而跳过，为 pre-existing 环境问题，与本 PR 无关）