### PR TITLE
fix(pilot): surface auth errors loudly; add consecutive-failure alerting

### DIFF
--- a/internal/pilot/schedule.go
+++ b/internal/pilot/schedule.go
@@ -346,7 +346,16 @@ func wake(ctx context.Context, p *project.Project, cfg *config.Config, creds *co
 	}
 
 	if err != nil {
-		meta.Status = "failed"
+		// Distinguish auth errors (403 / "request not allowed") from
+		// generic failures. Auth errors are not transient — retrying
+		// immediately will reproduce the same error — so they deserve a
+		// distinct status and a louder log level. This mirrors the
+		// operator runner path fixed in issue #204.
+		if operator.IsAuthError(err, output) {
+			meta.Status = "auth-error"
+		} else {
+			meta.Status = "failed"
+		}
 		meta.Error = err.Error()
 		// When the top-level deadline fires, resultLine is empty because
 		// claude never emitted a PILOT-RESULT. Fill it with a diagnostic
@@ -388,15 +397,58 @@ func wake(ctx context.Context, p *project.Project, cfg *config.Config, creds *co
 		meta.Usage = u
 	}
 	_ = snapshot.WritePilotRunMeta(runDir, meta)
-	lg.Info("pilot/end",
+
+	// Use the appropriate log level so patrol grep -E "ERROR|WARN" catches
+	// failures. Previously all outcomes used lg.Info, making auth failures
+	// and generic failures invisible to standard log scanning (issue #209).
+	endLogKV := []any{
 		"project", p.Name,
 		"status", meta.Status,
 		"duration", endedAt.Sub(startedAt).Round(time.Second),
 		"result", resultLine,
-	)
+	}
+	if meta.Error != "" {
+		endLogKV = append(endLogKV, "error", meta.Error)
+	}
+	switch meta.Status {
+	case "auth-error":
+		lg.Error("pilot/end", endLogKV...)
+		fmt.Fprintf(os.Stderr, "[pilot] %s: auth error 403 (check session/API key — subprocess cannot inherit interactive credentials): %v\n", p.Name, err)
+	case "failed":
+		lg.Warn("pilot/end", endLogKV...)
+	default:
+		lg.Info("pilot/end", endLogKV...)
+	}
 
 	if _, ierr := snapshot.WritePilotRunsIndex(20); ierr != nil {
 		fmt.Fprintf(os.Stderr, "[pilot] %s: snapshot pilot-runs index: %v\n", p.Name, ierr)
+	}
+
+	// Consecutive failure threshold alerting: when the last N wakes (including
+	// this one) all ended in failure, emit an ERROR so patrol grep surfaces it.
+	// De-bounced to log at exactly the threshold and then every threshold
+	// increment (e.g. 3, 6, 9, …) to avoid spamming the log on prolonged outages.
+	if meta.Status == "failed" || meta.Status == "auth-error" {
+		const consecutiveFailThreshold = 3
+		recentN := pilotRecentSummaries(p.Name, consecutiveFailThreshold*3)
+		consecutive := 0
+		for _, s := range recentN {
+			if s.Status == "failed" || s.Status == "auth-error" {
+				consecutive++
+			} else {
+				break
+			}
+		}
+		if consecutive >= consecutiveFailThreshold && consecutive%consecutiveFailThreshold == 0 {
+			lg.Error("pilot/consecutive_failures",
+				"project", p.Name,
+				"count", consecutive,
+				"last_status", meta.Status,
+				"last_error", meta.Error,
+			)
+			fmt.Fprintf(os.Stderr, "[pilot] %s: ALERT: %d consecutive pilot failure(s) (last status=%s) — check credentials and project automation config\n",
+				p.Name, consecutive, meta.Status)
+		}
 	}
 
 	if resultLine != "" {

--- a/internal/pilot/schedule_auth_test.go
+++ b/internal/pilot/schedule_auth_test.go
@@ -1,0 +1,79 @@
+package pilot
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/operator"
+)
+
+// TestIsAuthError_Patterns verifies that IsAuthError correctly identifies
+// the error patterns that appear in 403 / authentication-failure responses
+// from the claude CLI — the same patterns that caused issue #209 where
+// pilot wakes silently failed with "API Error: 403 Request not allowed".
+func TestIsAuthError_Patterns(t *testing.T) {
+	authPatterns := []struct {
+		name   string
+		err    error
+		output string
+	}{
+		{"403 in err", errors.New("exit status 1"), "API Error: 403 Request not allowed"},
+		{"request not allowed in output", errors.New("exit status 1"), "Request not allowed"},
+		{"failed to authenticate in output", errors.New("exit status 1"), "Failed to authenticate"},
+		{"authentication failed in output", errors.New("exit status 1"), "authentication failed — please login again"},
+		{"403 in err string", errors.New("claude: exit status 1: 403"), ""},
+	}
+	for _, tc := range authPatterns {
+		t.Run(tc.name, func(t *testing.T) {
+			if !operator.IsAuthError(tc.err, tc.output) {
+				t.Errorf("IsAuthError(%v, %q) = false, want true", tc.err, tc.output)
+			}
+		})
+	}
+}
+
+// TestIsAuthError_NilErr verifies that IsAuthError returns false when err is nil.
+func TestIsAuthError_NilErr(t *testing.T) {
+	if operator.IsAuthError(nil, "403 error in output") {
+		t.Error("IsAuthError(nil, ...) = true, want false — nil err means success")
+	}
+}
+
+// TestIsAuthError_NonAuthError verifies that unrelated errors are not
+// misclassified as auth errors.
+func TestIsAuthError_NonAuthError(t *testing.T) {
+	nonAuthCases := []struct {
+		err    error
+		output string
+	}{
+		{errors.New("exit status 1"), "You've hit your limit"},
+		{errors.New("exit status 1"), "rate limit exceeded"},
+		{errors.New("exit status 1"), "network timeout"},
+		{errors.New("connection refused"), ""},
+	}
+	for _, tc := range nonAuthCases {
+		if operator.IsAuthError(tc.err, tc.output) {
+			t.Errorf("IsAuthError(%v, %q) = true, want false — should not be classified as auth error", tc.err, tc.output)
+		}
+	}
+}
+
+// TestErrAuthError_WrappedByRunClaude verifies that the ErrAuthError sentinel
+// is wrapped (not replaced) so errors.Is works correctly in callers that need
+// to distinguish auth errors from other failures.
+func TestErrAuthError_WrappedByRunClaude(t *testing.T) {
+	// ErrAuthError is what RunClaude wraps when IsAuthError matches.
+	// Check that the sentinel itself is distinct from ErrRateLimit.
+	if errors.Is(operator.ErrAuthError, operator.ErrRateLimit) {
+		t.Error("ErrAuthError must not be the same as ErrRateLimit")
+	}
+	if errors.Is(operator.ErrRateLimit, operator.ErrAuthError) {
+		t.Error("ErrRateLimit must not be the same as ErrAuthError")
+	}
+
+	// Simulate the wrapped error RunClaude produces.
+	wrapped := errors.Join(operator.ErrAuthError, errors.New("claude: exit status 1"))
+	if !errors.Is(wrapped, operator.ErrAuthError) {
+		t.Error("errors.Is(wrapped, ErrAuthError) = false — callers rely on this for auth-error detection")
+	}
+}


### PR DESCRIPTION
Fixes #209

## 问题

Pilot wake 遭遇 403 / auth 失败时，日志一律用 `lg.Info("pilot/end")` 写入，`grep -E "ERROR|WARN"` 永远无命中。连续 5 次失败静默 6 小时，操作者完全无感知。

## 根本原因

`internal/pilot/schedule.go` 的失败处理路径未复用 #204 在 operator runner 已修复的 `IsAuthError` 逻辑——典型的「修了 operator 路径，漏了 pilot 路径」。

## 改动

**`internal/pilot/schedule.go`**
1. **区分错误类型**：调用 `operator.IsAuthError(err, output)` 检测 403/auth 失败，记录为 `status="auth-error"`（对齐 run.go 的处理，不计入熔断器）
2. **分级日志**：
   - `auth-error` → `lg.Error("pilot/end")` + 明确的 stderr 提示
   - `failed` → `lg.Warn("pilot/end")`（其他失败仍可被 patrol grep 捕获）
   - `success` → `lg.Info("pilot/end")`（不变）
3. **连续失败告警**：达到阈值（≥3）且为阈值倍数（3/6/9…）时，额外写 `lg.Error("pilot/consecutive_failures", "count", n)`，去抖避免刷屏

**`internal/pilot/schedule_auth_test.go`**（新增）
- 覆盖 IsAuthError 各 pattern 变体（403/request not allowed/failed to authenticate）
- nil err 守护、非 auth 错误不误判
- ErrAuthError vs ErrRateLimit sentinel 独立性验证

## 测试

```
ok  github.com/zhoushoujianwork/clawflow/internal/pilot  （全部通过）
ok  github.com/zhoushoujianwork/clawflow/internal/operator
```

修复后，`grep -E "ERROR|WARN" ~/.clawflow/logs/pilot.log` 在 auth 失败时会捕获到 `pilot/end status=auth-error`，连续 3 次后还会出现 `pilot/consecutive_failures count=3`。