### PR TITLE
fix(worktree): prune orphaned analysis worktrees and validate local_path origin

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -225,6 +226,16 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 	} else {
 		fmt.Fprintf(os.Stderr, "⚠ reconcile stale runs: %v\n", err)
 		lg.Warn("run/reconcile", "err", err.Error())
+	}
+
+	// GC analysis worktrees for repos that are no longer in config. When a
+	// repo is removed from clawflow config the persistent analysis worktree
+	// it created would otherwise remain registered in the source clone's
+	// .git/worktrees/ forever (issue #211). This is cheap (just a directory
+	// scan) and idempotent.
+	if n := pruneOrphanedAnalysisWorktrees(cfg); n > 0 {
+		fmt.Fprintf(os.Stderr, "✓ pruned %d orphaned analysis worktree(s)\n", n)
+		lg.Info("run/prune_analysis_worktrees", "pruned", n)
 	}
 
 	// Snapshot the static state so the dashboard can render it even if no
@@ -1216,6 +1227,177 @@ func getAnalysisWorktreeLock(slug, base string) *sync.Mutex {
 	return v.(*sync.Mutex)
 }
 
+// validateLocalPathOrigin checks that the git repository at localPath has an
+// origin remote whose URL resolves to fullName (owner/repo). This prevents
+// cross-project contamination: if local_path accidentally points at a
+// different repo's clone, git would register the analysis worktree entry
+// inside the wrong repository's .git/worktrees/ (issue #211).
+//
+// The check is best-effort: if we cannot determine the origin URL (no git,
+// offline, custom setup) we log a warning and allow the operation to proceed
+// rather than blocking the operator entirely.
+func validateLocalPathOrigin(localPath, fullName string) error {
+	out, err := exec.Command("git", "-C", localPath, "remote", "get-url", "origin").Output()
+	if err != nil {
+		// Can't validate (no remote, offline, non-git dir) — allow with warning.
+		fmt.Fprintf(os.Stderr, "  ⚠ cannot verify local_path origin for %s (get-url failed: %v); proceeding\n", fullName, err)
+		return nil
+	}
+	remoteURL := strings.TrimSpace(string(out))
+	parsed := extractOwnerRepo(remoteURL)
+	if parsed == "" {
+		// Unrecognised URL format — allow with warning.
+		fmt.Fprintf(os.Stderr, "  ⚠ cannot parse origin URL %q for %s; proceeding without validation\n", remoteURL, fullName)
+		return nil
+	}
+	if !strings.EqualFold(parsed, fullName) {
+		return fmt.Errorf(
+			"local_path %q origin is %q (parsed: %q), expected %q — "+
+				"local_path is misconfigured or shared across repos; "+
+				"fix local_path in your clawflow config to avoid cross-project worktree contamination (issue #211)",
+			localPath, remoteURL, parsed, fullName,
+		)
+	}
+	return nil
+}
+
+// extractOwnerRepo parses owner/repo out of common git remote URL formats:
+//   - https://github.com/owner/repo
+//   - https://github.com/owner/repo.git
+//   - git@github.com:owner/repo.git
+//   - https://gitlab.company.com/owner/repo
+//
+// Returns "" if the format is not recognised.
+func extractOwnerRepo(rawURL string) string {
+	rawURL = strings.TrimSuffix(rawURL, ".git")
+
+	// SSH: git@host:owner/repo
+	if strings.HasPrefix(rawURL, "git@") {
+		// git@github.com:owner/repo → owner/repo
+		if idx := strings.Index(rawURL, ":"); idx >= 0 {
+			return rawURL[idx+1:]
+		}
+		return ""
+	}
+
+	// HTTPS / HTTP
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	// path is "/owner/repo" — strip leading slash and take exactly two segments
+	parts := strings.SplitN(strings.TrimPrefix(u.Path, "/"), "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
+}
+
+// pruneOrphanedAnalysisWorktrees scans ~/.clawflow/worktrees/*/analysis-* and
+// removes any analysis worktree whose slug no longer corresponds to a
+// configured + enabled repo. This GC runs during each `clawflow run` reconcile
+// pass so that repos removed from config don't leave permanent git worktree
+// entries cluttering the source clone (issue #211).
+//
+// The approach:
+//  1. Build the set of active slugs from cfg.
+//  2. Scan ~/.clawflow/worktrees/* for slug dirs that are NOT in the active set.
+//  3. For each orphaned slug dir, remove any analysis-* subdirs via
+//     removeAnalysisWorktree.
+//
+// Returns the number of worktrees removed.
+func pruneOrphanedAnalysisWorktrees(cfg *config.Config) int {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0
+	}
+	wtRoot := filepath.Join(home, ".clawflow", "worktrees")
+
+	// Build set of active slug directories from current config.
+	activeSlugs := make(map[string]struct{}, len(cfg.Repos))
+	for fullName, repoCfg := range cfg.Repos {
+		if !repoCfg.Enabled {
+			continue
+		}
+		activeSlugs[strings.ReplaceAll(fullName, "/", "__")] = struct{}{}
+	}
+
+	slugDirs, err := os.ReadDir(wtRoot)
+	if err != nil {
+		return 0 // worktrees dir not yet created
+	}
+
+	removed := 0
+	for _, slugEntry := range slugDirs {
+		if !slugEntry.IsDir() {
+			continue
+		}
+		slug := slugEntry.Name()
+		if _, active := activeSlugs[slug]; active {
+			continue // still in use — keep it
+		}
+		// Orphaned slug: remove all analysis-* worktrees inside it.
+		slugDir := filepath.Join(wtRoot, slug)
+		analysisEntries, err := os.ReadDir(slugDir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range analysisEntries {
+			if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "analysis-") {
+				continue
+			}
+			wtPath := filepath.Join(slugDir, entry.Name())
+			if removeAnalysisWorktree(wtPath) {
+				fmt.Fprintf(os.Stderr, "  ✓ pruned orphaned analysis worktree: %s\n", wtPath)
+				removed++
+			}
+		}
+	}
+	return removed
+}
+
+// removeAnalysisWorktree removes a single analysis worktree directory along
+// with its git registration. It reads the .git pointer file inside the
+// worktree to locate the owning repository, then calls
+// `git worktree remove --force` so the .git/worktrees/<name> metadata is also
+// cleaned up. Falls back to `os.RemoveAll` if the git step fails.
+//
+// Returns true if any cleanup was performed.
+func removeAnalysisWorktree(wtPath string) bool {
+	// Read the .git pointer file to find the owning clone's git dir.
+	// Format: "gitdir: /path/to/clone/.git/worktrees/<name>\n"
+	gitFile := filepath.Join(wtPath, ".git")
+	data, err := os.ReadFile(gitFile)
+	if err == nil {
+		line := strings.TrimSpace(string(data))
+		if after, ok := strings.CutPrefix(line, "gitdir:"); ok {
+			// mainGitWorktreesEntry = /path/to/clone/.git/worktrees/<name>
+			mainGitWorktreesEntry := strings.TrimSpace(after)
+			// mainGitDir = /path/to/clone/.git
+			mainGitDir := filepath.Dir(filepath.Dir(mainGitWorktreesEntry))
+			// mainRepoPath = /path/to/clone
+			mainRepoPath := filepath.Dir(mainGitDir)
+			rm := exec.Command("git", "-C", mainRepoPath, "worktree", "remove", "--force", wtPath)
+			rm.Stdout = os.Stderr
+			rm.Stderr = os.Stderr
+			if rmErr := rm.Run(); rmErr == nil {
+				// git worktree remove already deleted the directory.
+				return true
+			}
+			// git step failed — fall through to os.RemoveAll and manual prune.
+		}
+	}
+
+	// Fallback: delete the directory directly.
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		if removeErr := os.RemoveAll(wtPath); removeErr != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ could not remove analysis worktree dir %s: %v\n", wtPath, removeErr)
+			return false
+		}
+	}
+	return true
+}
+
 // ensureAnalysisWorktree provisions or refreshes a persistent read-only
 // analysis worktree at ~/.clawflow/worktrees/<slug>/analysis-<base>.
 //
@@ -1241,6 +1423,16 @@ func ensureAnalysisWorktree(repoCfg config.Repo, fullName string) (worktreeResul
 	slug := strings.ReplaceAll(fullName, "/", "__")
 	localPath := repoCfg.LocalPath
 	wtPath := filepath.Join(home, ".clawflow", "worktrees", slug, "analysis-"+base)
+
+	// Validate that localPath's git origin matches fullName before we
+	// register any worktree against it. A misconfigured local_path (e.g.
+	// pointing at the wrong clone, or shared across repos) would cause
+	// git to register the worktree entry inside the wrong repository's
+	// .git/worktrees/, producing the cross-project contamination described
+	// in issue #211.
+	if err := validateLocalPathOrigin(localPath, fullName); err != nil {
+		return worktreeResult{}, func() {}, err
+	}
 
 	// Serialize setup/refresh within this process so concurrent analysis
 	// operators on the same repo don't race on fetch+reset.

--- a/cmd/clawflow/commands/run_test.go
+++ b/cmd/clawflow/commands/run_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -174,6 +175,119 @@ func TestRunGitWithRetry_LockErrorSucceedsOnRetry(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Errorf("expected 2 calls (1 lock failure + 1 success), got %d", calls)
+	}
+}
+
+// TestExtractOwnerRepo verifies that extractOwnerRepo parses various git
+// remote URL formats into "owner/repo", handling .git suffixes, SSH, HTTPS,
+// and self-hosted GitLab instances (issue #211).
+func TestExtractOwnerRepo(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "HTTPS GitHub with .git",
+			url:  "https://github.com/owner/repo.git",
+			want: "owner/repo",
+		},
+		{
+			name: "HTTPS GitHub without .git",
+			url:  "https://github.com/owner/repo",
+			want: "owner/repo",
+		},
+		{
+			name: "SSH GitHub",
+			url:  "git@github.com:owner/repo.git",
+			want: "owner/repo",
+		},
+		{
+			name: "SSH without .git suffix",
+			url:  "git@github.com:owner/repo",
+			want: "owner/repo",
+		},
+		{
+			name: "self-hosted GitLab HTTPS",
+			url:  "https://gitlab.company.com/owner/repo.git",
+			want: "owner/repo",
+		},
+		{
+			name: "self-hosted GitLab SSH",
+			url:  "git@gitlab.company.com:owner/repo.git",
+			want: "owner/repo",
+		},
+		{
+			name: "HTTPS with nested group (GitLab subgroup, returns first two segments)",
+			url:  "https://gitlab.com/owner/repo/subgroup.git",
+			want: "owner/repo",
+		},
+		{
+			name: "empty string",
+			url:  "",
+			want: "",
+		},
+		{
+			name: "unrecognised format",
+			url:  "not-a-url",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractOwnerRepo(tc.url)
+			if got != tc.want {
+				t.Errorf("extractOwnerRepo(%q) = %q, want %q", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPruneOrphanedAnalysisWorktrees verifies that pruneOrphanedAnalysisWorktrees
+// removes analysis-* directories only for slugs not present in the active
+// config, leaving active-repo worktrees untouched (issue #211).
+func TestPruneOrphanedAnalysisWorktrees(t *testing.T) {
+	// Create a temporary worktrees root to isolate the test from real state.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp) // pruneOrphanedAnalysisWorktrees uses os.UserHomeDir
+
+	wtRoot := tmp + "/.clawflow/worktrees"
+
+	// active repo: owner__active  →  analysis-main should survive
+	activeSlugDir := wtRoot + "/owner__active"
+	_ = os.MkdirAll(activeSlugDir+"/analysis-main", 0o755)
+
+	// orphaned repo: owner__gone  →  analysis-main should be removed
+	orphanSlugDir := wtRoot + "/owner__gone"
+	_ = os.MkdirAll(orphanSlugDir+"/analysis-main", 0o755)
+
+	// non-analysis dir inside orphaned slug: must NOT be touched
+	_ = os.MkdirAll(orphanSlugDir+"/issue-42-2025-01-01T00-00-00Z", 0o755)
+
+	cfg := &config.Config{
+		Repos: map[string]config.Repo{
+			"owner/active": {Enabled: true, LocalPath: "/tmp/active"},
+		},
+	}
+
+	n := pruneOrphanedAnalysisWorktrees(cfg)
+	if n != 1 {
+		t.Errorf("expected 1 worktree pruned, got %d", n)
+	}
+
+	// Active repo worktree must still exist.
+	if _, err := os.Stat(activeSlugDir + "/analysis-main"); err != nil {
+		t.Errorf("active analysis worktree was incorrectly removed: %v", err)
+	}
+
+	// Orphaned analysis dir must be gone.
+	if _, err := os.Stat(orphanSlugDir + "/analysis-main"); !os.IsNotExist(err) {
+		t.Errorf("orphaned analysis worktree was not removed (stat err: %v)", err)
+	}
+
+	// Non-analysis issue dir must be untouched.
+	if _, err := os.Stat(orphanSlugDir + "/issue-42-2025-01-01T00-00-00Z"); err != nil {
+		t.Errorf("non-analysis dir was unexpectedly removed: %v", err)
 	}
 }
 

--- a/cmd/clawflow/commands/worktree.go
+++ b/cmd/clawflow/commands/worktree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ func NewWorktreeCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newWorktreeCreateCmd())
 	cmd.AddCommand(newWorktreeRemoveCmd())
+	cmd.AddCommand(newWorktreePruneCmd())
 	return cmd
 }
 
@@ -132,6 +134,88 @@ func newWorktreeRemoveCmd() *cobra.Command {
 	cmd.Flags().IntVar(&issue, "issue", 0, "issue number (required)")
 	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("issue")
+	return cmd
+}
+
+func newWorktreePruneCmd() *cobra.Command {
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove persistent analysis worktrees left over from past runs",
+		Long: `Scans ~/.clawflow/worktrees/*/analysis-* and removes analysis worktrees
+that are no longer needed. By default every found analysis worktree is removed;
+use --dry-run to preview what would be deleted without making any changes.
+
+Analysis worktrees are persistent by design (they are reused across runs for
+performance), but they can accumulate over time and remain registered in the
+source clone's .git/worktrees/ indefinitely. Run 'clawflow worktree prune'
+to clean them up.`,
+		Example: `  # Preview what would be removed
+  clawflow worktree prune --dry-run
+
+  # Remove all analysis worktrees
+  clawflow worktree prune`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("home dir: %w", err)
+			}
+			wtRoot := filepath.Join(home, ".clawflow", "worktrees")
+
+			slugDirs, err := os.ReadDir(wtRoot)
+			if err != nil {
+				if os.IsNotExist(err) {
+					fmt.Println("no worktrees directory found — nothing to prune")
+					return nil
+				}
+				return fmt.Errorf("read worktrees dir: %w", err)
+			}
+
+			found := 0
+			removed := 0
+			for _, slugEntry := range slugDirs {
+				if !slugEntry.IsDir() {
+					continue
+				}
+				slugDir := filepath.Join(wtRoot, slugEntry.Name())
+				entries, err := os.ReadDir(slugDir)
+				if err != nil {
+					continue
+				}
+				for _, entry := range entries {
+					if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "analysis-") {
+						continue
+					}
+					wtPath := filepath.Join(slugDir, entry.Name())
+					found++
+					if dryRun {
+						fmt.Printf("would remove: %s\n", wtPath)
+						continue
+					}
+					if removeAnalysisWorktree(wtPath) {
+						fmt.Printf("removed: %s\n", wtPath)
+						removed++
+					} else {
+						fmt.Fprintf(cmd.ErrOrStderr(), "warn: could not remove %s\n", wtPath)
+					}
+				}
+			}
+
+			if found == 0 {
+				fmt.Println("no analysis worktrees found")
+				return nil
+			}
+			if dryRun {
+				fmt.Printf("\n%d analysis worktree(s) would be removed (re-run without --dry-run to apply)\n", found)
+			} else {
+				fmt.Printf("\n%d/%d analysis worktree(s) removed\n", removed, found)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview removals without making any changes")
 	return cmd
 }
 


### PR DESCRIPTION
Fixes #211

## 问题

Issue #211 报告了两个相关缺陷：

1. **analysis worktree 永不清理**：`ensureAnalysisWorktree` 故意返回 no-op cleanup（#130 设计），但没有任何 GC 路径，导致 `analysis-main` worktree 永久挂在源仓库上。
2. **跨项目路径污染**：`git -C <localPath> worktree add` 会把 worktree 注册进 `localPath` 所指克隆的 `.git/worktrees/`，但代码从未校验 `localPath` 的 origin 是否匹配当前 `owner/repo`。一旦 `local_path` 配错或被多仓库共用，就会出现 `crm-skill` 仓库里显示 `xops-infra__xsyctl/analysis-main` 的错配。

## 修复内容

### 1. `local_path` origin 校验（`run.go`）

在 `ensureAnalysisWorktree` 运行任何 git 操作前，新增 `validateLocalPathOrigin`：
- `git -C <localPath> remote get-url origin` 取得 remote URL
- 用 `extractOwnerRepo` 解析出 `owner/repo`（支持 HTTPS / SSH / 自托管 GitLab）
- 不匹配则返回明确错误，fail fast 并阻止 worktree 被注册进错误的仓库

### 2. 孤儿 worktree GC（`run.go`）

新增 `pruneOrphanedAnalysisWorktrees(cfg)`：
- 扫 `~/.clawflow/worktrees/*/analysis-*`
- 只清理 slug 不在当前 config 的 worktree（已移除配置的仓库）
- 每次 `clawflow run` 的 reconcile 阶段调用，轻量且幂等

新增 `removeAnalysisWorktree(wtPath)`：
- 读 `.git` pointer 文件定位 owning clone
- `git worktree remove --force` 清理 git 元数据
- 失败则 fallback 到 `os.RemoveAll`

### 3. `clawflow worktree prune` 子命令（`worktree.go`）

手动清理所有 `~/.clawflow/worktrees/*/analysis-*`：
```
clawflow worktree prune             # 删除所有 analysis worktree
clawflow worktree prune --dry-run   # 预览，不实际删除
```

### 新增测试

- `TestExtractOwnerRepo`：覆盖 HTTPS/SSH/自托管/子组/边界情况共 9 个 case
- `TestPruneOrphanedAnalysisWorktrees`：验证孤儿 worktree 被删、活跃 worktree 保留、非 analysis 目录不受影响

## 测试

```
go test ./... ✓ 全部通过
```