### PR TITLE
feat(web): repo 详情页元信息栏增加用

### DIFF
--- a/web/src/routes/_app.repos.$repoName.tsx
+++ b/web/src/routes/_app.repos.$repoName.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off } from 'lucide-react'
+import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off, FolderOpen } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
@@ -50,6 +50,7 @@ function RepoDetail() {
   const [binding, setBinding] = useState(false)
   const [allIssues, setAllIssues] = useState<IssueEntry[]>([])
   const [hostname, setHostname] = useState<string>('')
+  const [ideScheme, setIdeScheme] = useState('vscode://file/')
 
   const cloneNow = useCallback(() => {
     if (!repo || cloning) return
@@ -90,6 +91,16 @@ function RepoDetail() {
       setPending((Array.isArray(allPending) ? allPending : []).filter((p: PendingEntry) => p.repo === fullName))
       setAllIssues((Array.isArray(allIssuesData) ? allIssuesData : []).filter((i: IssueEntry) => i.repo === fullName))
       if (settings?.global?.hostname) setHostname(settings.global.hostname as string)
+      if (settings?.global?.default_ide) {
+        const ide = settings.global.default_ide as string
+        const schemeMap: Record<string, string> = {
+          vscode: 'vscode://file/',
+          cursor: 'cursor://file/',
+          qoder: 'qoder://file/',
+          'vscode-insiders': 'vscode-insiders://file/',
+        }
+        setIdeScheme(schemeMap[ide] ?? 'vscode://file/')
+      }
     })
   }, [fullName])
 
@@ -251,6 +262,18 @@ function RepoDetail() {
               >
                 <MessageSquare className="w-3 h-3" /> chat
               </button>
+              {repo.local_path && (
+                <>
+                  <span>·</span>
+                  <a
+                    href={`${ideScheme}${repo.local_path}?windowId=_blank`}
+                    title={`Open in IDE: ${repo.local_path}`}
+                    className="inline-flex items-center gap-0.5 hover:text-foreground hover:underline"
+                  >
+                    <FolderOpen className="w-3 h-3" /> open
+                  </a>
+                </>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
Fixes #214

## 改动说明

在 repo 详情页标题下方的元信息栏（`platform · base · view · chat` 这行）末尾新增"用 IDE 打开"入口，行为与 repos 列表页完全一致。

**修改文件：** `web/src/routes/_app.repos.$repoName.tsx`

- 新增 `ideScheme` state（默认 `vscode://file/`）
- 在 `refreshData` 里补读 `settings.global.default_ide`，通过 `schemeMap` 映射到对应的 URL scheme（vscode / cursor / qoder / vscode-insiders）
- 在元信息栏 `chat` 按钮之后插入条件渲染块：仅在 `repo.local_path` 存在时渲染 `<FolderOpen /> open` 链接，避免指向空路径的死链
- 新增 `FolderOpen` 到 lucide-react 导入

## 测试

- TypeScript 类型检查（`tsc --noEmit`）无报错
- 后端零改动，`/api/settings` 已返回 `default_ide`，`local_path` 已在 repos.json 中