### PR TITLE
fix(web): merge provider model select into one editable combobox

### DIFF
--- a/web/src/components/ProvidersSection.tsx
+++ b/web/src/components/ProvidersSection.tsx
@@ -437,6 +437,16 @@ function ProviderModal({ initial, onSave, onClose }: ProviderModalProps) {
             />
           </Field>
 
+          <div className="flex items-start gap-3">
+            <div className="w-28 shrink-0" />
+            <p className="flex-1 text-[10px] text-muted-foreground/70 leading-relaxed">
+              Type an alias (opus / sonnet / haiku) to always track that tier's
+              latest model; type a full model ID to pin that exact version;
+              custom providers can enter any model name they expose. Leave blank
+              to use the default shown above.
+            </p>
+          </div>
+
           <Field label="Enabled">
             <input
               type="checkbox"
@@ -481,6 +491,9 @@ function ProviderModal({ initial, onSave, onClose }: ProviderModalProps) {
   )
 }
 
+// ModelSelect is a single editable combobox (native <input list> +
+// <datalist>): pick an alias suggestion or type any custom model ID.
+// Empty value keeps the "inherit default" semantics the backend expects.
 function ModelSelect({
   value, onChange, defaultLabel, ariaLabel,
 }: {
@@ -489,31 +502,25 @@ function ModelSelect({
   defaultLabel: string
   ariaLabel: string
 }) {
-  const inPresets = (MODEL_PRESETS as readonly string[]).includes(value)
+  // Stable, unique datalist id per field so the three comboboxes don't
+  // share (and clobber) one another's suggestion list.
+  const listId = `model-presets-${ariaLabel.replace(/\s+/g, '-').toLowerCase()}`
   return (
     <div className="flex-1 flex flex-col gap-1">
-      <select
-        value={inPresets || value === '' ? value : '__custom__'}
-        onChange={e => { if (e.target.value !== '__custom__') onChange(e.target.value) }}
-        className="text-sm font-mono px-2 py-1 border border-border rounded bg-background"
-        aria-label={ariaLabel}
-      >
-        <option value="">(default — {defaultLabel})</option>
-        {value !== '' && !inPresets && (
-          <option value="__custom__">{value} (custom)</option>
-        )}
-        {MODEL_PRESETS.map(m => (
-          <option key={m} value={m}>{m}</option>
-        ))}
-      </select>
       <input
         type="text"
+        list={listId}
         value={value}
         onChange={e => onChange(e.target.value)}
-        placeholder="or type a custom model ID…"
-        className="text-xs font-mono px-2 py-1 border border-border rounded bg-background text-muted-foreground"
-        aria-label={`${ariaLabel} custom`}
+        placeholder={`default — ${defaultLabel}`}
+        className="text-sm font-mono px-2 py-1 border border-border rounded bg-background"
+        aria-label={ariaLabel}
       />
+      <datalist id={listId}>
+        {MODEL_PRESETS.map(m => (
+          <option key={m} value={m} />
+        ))}
+      </datalist>
     </div>
   )
 }

--- a/web/src/routes/_app.settings.tsx
+++ b/web/src/routes/_app.settings.tsx
@@ -873,30 +873,21 @@ function PasswordInput({
   )
 }
 
-// MODEL_PRESETS is the curated dropdown list. Empty value (the
-// default-marker option) means "inherit whatever DefaultChatModel /
-// DefaultEvalModel / DefaultOperatorModel resolves to". Three groups:
+// MODEL_PRESETS are the combobox suggestion entries (rendered into a
+// <datalist> by ModelSelect). We keep only the family aliases here:
+// they are the most portable (work on Anthropic direct, Kiro, cc-proxy)
+// and always resolve to the tier's latest model, so users default to the
+// newest version instead of pinning themselves to a stale dashed/dot ID.
 //
-//   - aliases: most portable (work on Anthropic direct, Kiro, cc-proxy)
-//   - dash form: Anthropic standard, pinned versions
-//   - dot form: Kiro proxy specific (matches its /v1/models verbatim,
-//     including the 1M-context Sonnet 4.6 it ships)
-//
-// A user typing in their own value (e.g. claude-haiku-4-5-20251001 to
-// pin to the dated release) still gets surfaced as a "(custom)" entry.
+// These are suggestions only — the combobox still accepts free input, so
+// users who need to pin a specific version (e.g. claude-opus-4-7) or
+// target a custom / non-Anthropic gateway can type any model ID. An empty
+// value keeps the "inherit default" semantics the backend expects.
 // Exported so ProvidersSection can reuse the same list.
 export const MODEL_PRESETS = [
-  // family aliases — recommended default
   'haiku',
   'sonnet',
   'opus',
-  // Anthropic dashed IDs — pin a specific version
-  'claude-haiku-4-5',
-  'claude-sonnet-4-6',
-  'claude-opus-4-7',
-  // Kiro proxy dot IDs — match its /v1/models listing
-  'claude-sonnet-4.6',
-  'claude-opus-4.6',
 ] as const
 
 


### PR DESCRIPTION
Fixes #217

## What changed
- `web/src/components/ProvidersSection.tsx` — `ModelSelect` 由"下拉框 + 文本框"双控件合并为单个可编辑 combobox（原生 `<input list>` + `<datalist>`）。每个字段生成唯一 `list` id 避免三个 datalist 冲突。保留 `value`/`onChange`/`defaultLabel` 接口不变，空值=继承默认档位的语义保留，placeholder 显示 `default — {tier}`。
- 在三个模型字段下方新增一行说明文字：别名自动跟随最新模型 / 完整 model ID 锁定版本 / 自定义 provider 自由输入 / 留空用默认。
- `web/src/routes/_app.settings.tsx` — `MODEL_PRESETS` 精简为仅家族别名 `haiku/sonnet/opus`，移除会过期的具体小版本号（dashed/dot form）。因 combobox 仍支持自由输入，需 pin 版本或自定义网关的用户可直接输入任意 model ID。

## 后端
零改动。model 字符串直接透传给 `claude --model`，别名→最新版本的解析由 claude CLI 完成。

## 设计决策
- **default 表达方式**：沿用现有"空值=默认"语义（placeholder + Field hint 已展示默认档位），未把字面 `default` 加入建议项，避免与空值产生二义状态（见 eval open question 的推荐方案）。
- **说明文字语言**：dashboard UI 通篇为英文（label/placeholder/按钮均英文），为保持一致性说明文字用英文撰写，语义与 issue 中文示例一致。

## 测试
- `cd web && npm run build`（vite build + `tsc --noEmit`）通过，无类型错误。
- 纯前端表现层改动，无 Go 改动；`web/dist` 由 CI 构建生成（gitignored），未提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)