### PR TITLE
fix(web): add Host/Origin/CSRF guard to local web server

### DIFF
--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -25,6 +25,7 @@ import (
 	clog "github.com/zhoushoujianwork/clawflow/internal/log"
 	ptyserver "github.com/zhoushoujianwork/clawflow/internal/pty"
 	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+	"github.com/zhoushoujianwork/clawflow/internal/webguard"
 )
 
 // webLog is the package-level web.log handle, set by NewWebCmd's RunE
@@ -338,9 +339,22 @@ here — run 'clawflow run' first if you want fresh data.`,
 				_, _ = w.Write(indexHTML)
 			})
 
+			// Harden the server against browser-borne attacks that
+			// loopback binding does NOT stop: DNS-rebinding (Host-header
+			// validation on every request) and cross-site CSRF (Origin
+			// validation on state-changing methods). The /ws/pty upgrader
+			// reuses the exact same whitelist via ConfigureOriginGuard, so
+			// the WS path can't drift looser than the HTTP path.
+			guard := webguard.New(host, port)
+			ptyserver.ConfigureOriginGuard(host, port)
+			if webguard.IsWildcardHost(host) {
+				fmt.Fprintf(os.Stderr, "⚠ binding %s exposes the dashboard beyond loopback; Host-header rebinding protection is disabled for this bind (Origin/CSRF checks still apply)\n", addr)
+				lg.Warn("web/host_unguarded", "host", host, "port", port)
+			}
+
 			srv := &http.Server{
 				Addr:              addr,
-				Handler:           mux,
+				Handler:           guard.Middleware(mux),
 				ReadHeaderTimeout: 5 * time.Second,
 			}
 

--- a/internal/pty/server.go
+++ b/internal/pty/server.go
@@ -13,10 +13,37 @@ import (
 	creackpty "github.com/creack/pty"
 	"github.com/gorilla/websocket"
 	"github.com/zhoushoujianwork/clawflow/internal/chat"
+	"github.com/zhoushoujianwork/clawflow/internal/webguard"
 )
 
+// originGuard, when non-nil, restricts which Origins may open a /ws/pty
+// WebSocket. /ws/pty spawns a Bash-capable `clawflow chat`, so an
+// unrestricted CheckOrigin let any cross-origin page open a shell —
+// ConfigureOriginGuard installs the same whitelist the HTTP layer uses.
+// Until configured it stays nil and CheckOrigin is permissive, preserving
+// behavior for embedders that don't set up a guard.
+var originGuard *webguard.Guard
+
+// ConfigureOriginGuard pins the /ws/pty Origin whitelist to the same
+// host:port-derived set the `clawflow web` HTTP middleware enforces. Call
+// once at server startup, before any WebSocket can arrive.
+func ConfigureOriginGuard(host string, port int) {
+	originGuard = webguard.New(host, port)
+}
+
 var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: checkOrigin,
+}
+
+// checkOrigin rejects WebSocket upgrades from origins outside the
+// configured whitelist. A missing Origin (non-browser client) is allowed
+// for parity with the HTTP guard; browsers always attach Origin on WS
+// handshakes, so cross-site pages are reliably caught.
+func checkOrigin(r *http.Request) bool {
+	if originGuard == nil {
+		return true
+	}
+	return originGuard.OriginAllowed(r.Header.Get("Origin"))
 }
 
 // WebSocket close codes the browser uses to signal user intent.

--- a/internal/pty/server_test.go
+++ b/internal/pty/server_test.go
@@ -1,0 +1,43 @@
+package pty
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckOriginGuard(t *testing.T) {
+	// Reset package state after the test so other tests (and any future
+	// ones) see the default permissive guard.
+	orig := originGuard
+	t.Cleanup(func() { originGuard = orig })
+
+	// Unconfigured: permissive (backward compatible with embedders that
+	// don't install a guard).
+	originGuard = nil
+	req := httptest.NewRequest("GET", "/ws/pty", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	if !checkOrigin(req) {
+		t.Fatal("nil guard should allow any origin")
+	}
+
+	// Configured: only whitelisted origins may open the PTY WebSocket.
+	ConfigureOriginGuard("127.0.0.1", 8090)
+
+	good := httptest.NewRequest("GET", "/ws/pty", nil)
+	good.Header.Set("Origin", "http://127.0.0.1:8090")
+	if !checkOrigin(good) {
+		t.Error("same-origin WS handshake should be allowed")
+	}
+
+	bad := httptest.NewRequest("GET", "/ws/pty", nil)
+	bad.Header.Set("Origin", "http://evil.example.com")
+	if checkOrigin(bad) {
+		t.Error("cross-origin WS handshake must be rejected")
+	}
+
+	// Non-browser WS client without an Origin header is allowed.
+	noOrigin := httptest.NewRequest("GET", "/ws/pty", nil)
+	if !checkOrigin(noOrigin) {
+		t.Error("WS handshake without Origin should be allowed")
+	}
+}

--- a/internal/webguard/webguard.go
+++ b/internal/webguard/webguard.go
@@ -1,0 +1,185 @@
+// Package webguard hardens the local `clawflow web` HTTP server against
+// two browser-borne attacks that loopback binding alone does NOT stop:
+//
+//   - DNS-rebinding: a malicious page whose domain resolves back to
+//     127.0.0.1 can reach this server despite the loopback bind. Defended
+//     by validating the Host header against a whitelist derived from the
+//     bind address — a rebinding request carries the attacker's hostname,
+//     not ours, and is rejected.
+//   - Cross-site request forgery (CSRF): a page on any origin can fire a
+//     "simple" POST (Content-Type: text/plain) that skips the CORS
+//     preflight and reaches a state-changing handler (token write, chat
+//     spawn, self-update). Defended by validating the Origin header on
+//     state-changing methods.
+//
+// The same whitelist is reused by internal/pty for the /ws/pty WebSocket
+// upgrader so HTTP and WS can never drift out of sync.
+package webguard
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// TrustedHostsEnv extends the Host/Origin whitelist with extra entries
+// (comma-separated, "host" or "host:port"). The escape hatch for reverse
+// proxies that rewrite the Host header to something the bind address
+// can't predict.
+const TrustedHostsEnv = "CLAWFLOW_WEB_TRUSTED_HOSTS"
+
+// Guard validates inbound Host and Origin headers against a whitelist
+// derived from the server's bind address. The zero value is not usable;
+// construct with New.
+type Guard struct {
+	// enforceHost is false for wildcard binds (0.0.0.0 / ::) where the
+	// user has explicitly opted into LAN exposure — there's no single
+	// canonical Host to pin, so we only warn at startup and let requests
+	// through. Origin/CSRF checks still apply regardless.
+	enforceHost bool
+	hosts       map[string]struct{} // allowed Host header values (host:port)
+	origins     map[string]struct{} // allowed Origin header values (scheme://host:port)
+}
+
+// New builds a Guard for a server bound to host:port. The whitelist
+// always covers the loopback forms {127.0.0.1, localhost, [::1]} at the
+// given port, plus the configured host when it is a concrete address,
+// plus any entries in CLAWFLOW_WEB_TRUSTED_HOSTS.
+func New(host string, port int) *Guard {
+	g := &Guard{
+		enforceHost: !IsWildcardHost(host),
+		hosts:       map[string]struct{}{},
+		origins:     map[string]struct{}{},
+	}
+	p := strconv.Itoa(port)
+
+	// Loopback variants are always trusted: the dashboard's own requests
+	// arrive as one of these regardless of which --host was bound.
+	for _, h := range []string{"127.0.0.1", "localhost", "::1"} {
+		g.addHostPort(h, p)
+	}
+	// A concrete --host (e.g. a LAN IP) joins the set so visiting the
+	// dashboard at that address is same-origin and passes both checks.
+	if host != "" && !IsWildcardHost(host) {
+		g.addHostPort(host, p)
+	}
+	// Reverse-proxy / custom-domain escape hatch.
+	for _, entry := range parseTrustedHosts(os.Getenv(TrustedHostsEnv)) {
+		g.addTrusted(entry, p)
+	}
+	return g
+}
+
+// addHostPort registers a bare host + port, bracketing IPv6 literals via
+// net.JoinHostPort, and the matching http/https origins.
+func (g *Guard) addHostPort(host, port string) {
+	hp := net.JoinHostPort(host, port)
+	g.hosts[hp] = struct{}{}
+	g.origins["http://"+hp] = struct{}{}
+	g.origins["https://"+hp] = struct{}{}
+}
+
+// addTrusted registers an entry from CLAWFLOW_WEB_TRUSTED_HOSTS. Accepts
+// "host", "host:port", or a full "scheme://host[:port]" — the scheme is
+// stripped since we match Host (no scheme) and synthesize both origins.
+func (g *Guard) addTrusted(entry, defaultPort string) {
+	entry = strings.TrimSpace(entry)
+	entry = strings.TrimPrefix(entry, "https://")
+	entry = strings.TrimPrefix(entry, "http://")
+	entry = strings.TrimSuffix(entry, "/")
+	if entry == "" {
+		return
+	}
+	if _, _, err := net.SplitHostPort(entry); err == nil {
+		// Already carries an explicit port — trust it verbatim.
+		g.hosts[entry] = struct{}{}
+		g.origins["http://"+entry] = struct{}{}
+		g.origins["https://"+entry] = struct{}{}
+		return
+	}
+	// No port: trust both the bind-port form and the bare host (the
+	// latter covers proxies terminating on standard 80/443).
+	g.addHostPort(entry, defaultPort)
+	g.hosts[entry] = struct{}{}
+	g.origins["http://"+entry] = struct{}{}
+	g.origins["https://"+entry] = struct{}{}
+}
+
+// HostAllowed reports whether the Host header may be served. Wildcard
+// binds always pass. A missing Host is rejected when enforcing — HTTP/1.1
+// requires it and browsers always send it, so absence signals a crafted
+// request.
+func (g *Guard) HostAllowed(host string) bool {
+	if !g.enforceHost {
+		return true
+	}
+	if host == "" {
+		return false
+	}
+	_, ok := g.hosts[host]
+	return ok
+}
+
+// OriginAllowed reports whether a cross-origin-capable request may
+// proceed. An empty Origin is allowed: non-browser clients (curl, CLI
+// scripts) omit it, and browsers attach it on exactly the cross-site
+// requests we care about. A present Origin must match the whitelist.
+func (g *Guard) OriginAllowed(origin string) bool {
+	if origin == "" {
+		return true
+	}
+	_, ok := g.origins[origin]
+	return ok
+}
+
+// Middleware wraps next with the Host (all requests) and Origin
+// (state-changing requests only) checks.
+func (g *Guard) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !g.HostAllowed(r.Host) {
+			http.Error(w, "forbidden: Host header not in whitelist (possible DNS-rebinding)", http.StatusForbidden)
+			return
+		}
+		if isStateChanging(r.Method) && !g.OriginAllowed(r.Header.Get("Origin")) {
+			http.Error(w, "forbidden: cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isStateChanging is true for HTTP methods that mutate server state, the
+// ones a CSRF attack would target. Safe methods (GET/HEAD/OPTIONS) skip
+// the Origin check so same-origin asset loads and DNS-rebinding-blocked
+// reads aren't affected by it (Host check still guards them).
+func isStateChanging(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsWildcardHost reports whether host is an all-interfaces bind, where
+// no single canonical Host can be pinned for rebinding protection.
+func IsWildcardHost(host string) bool {
+	return host == "" || host == "0.0.0.0" || host == "::"
+}
+
+// parseTrustedHosts splits a comma-separated env value into trimmed,
+// non-empty entries.
+func parseTrustedHosts(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/webguard/webguard_test.go
+++ b/internal/webguard/webguard_test.go
@@ -1,0 +1,174 @@
+package webguard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newGuard builds the default loopback guard used by `clawflow web` on
+// its 127.0.0.1:8090 default.
+func newGuard() *Guard { return New("127.0.0.1", 8090) }
+
+// serve runs a request through guard.Middleware wrapping a handler that
+// records whether it was reached, and returns (statusCode, reached).
+func serve(t *testing.T, g *Guard, req *http.Request) (int, bool) {
+	t.Helper()
+	reached := false
+	h := g.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Code, reached
+}
+
+func TestSameOriginPostAllowed(t *testing.T) {
+	g := newGuard()
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8090/api/run", nil)
+	req.Host = "127.0.0.1:8090"
+	req.Header.Set("Origin", "http://127.0.0.1:8090")
+	if code, reached := serve(t, g, req); !reached || code != http.StatusOK {
+		t.Fatalf("same-origin POST: want pass-through 200, got code=%d reached=%v", code, reached)
+	}
+}
+
+func TestSameOriginLocalhostVariantAllowed(t *testing.T) {
+	g := newGuard()
+	// Dashboard opened at localhost:8090 instead of 127.0.0.1.
+	req := httptest.NewRequest(http.MethodPost, "/api/run", nil)
+	req.Host = "localhost:8090"
+	req.Header.Set("Origin", "http://localhost:8090")
+	if code, reached := serve(t, g, req); !reached || code != http.StatusOK {
+		t.Fatalf("localhost variant: want 200, got code=%d reached=%v", code, reached)
+	}
+}
+
+func TestCrossOriginPostRejected(t *testing.T) {
+	g := newGuard()
+	// Malicious page firing a text/plain "simple" POST.
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/spawn", nil)
+	req.Host = "127.0.0.1:8090"
+	req.Header.Set("Origin", "http://evil.example.com")
+	if code, reached := serve(t, g, req); reached || code != http.StatusForbidden {
+		t.Fatalf("cross-origin POST: want 403 blocked, got code=%d reached=%v", code, reached)
+	}
+}
+
+func TestHostMismatchRejected(t *testing.T) {
+	g := newGuard()
+	// DNS-rebinding: the attacker's domain resolved to 127.0.0.1, so the
+	// connection lands here but carries the attacker's Host.
+	req := httptest.NewRequest(http.MethodGet, "/api/settings/reveal", nil)
+	req.Host = "attacker.example.com"
+	if code, reached := serve(t, g, req); reached || code != http.StatusForbidden {
+		t.Fatalf("rebinding Host: want 403 blocked, got code=%d reached=%v", code, reached)
+	}
+}
+
+func TestEmptyHostRejectedWhenEnforcing(t *testing.T) {
+	g := newGuard()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = ""
+	if code, reached := serve(t, g, req); reached || code != http.StatusForbidden {
+		t.Fatalf("empty Host: want 403 blocked, got code=%d reached=%v", code, reached)
+	}
+}
+
+func TestNoOriginCurlAllowed(t *testing.T) {
+	g := newGuard()
+	// curl / CLI scripts: valid Host, no Origin header → must pass.
+	req := httptest.NewRequest(http.MethodPost, "/api/run", nil)
+	req.Host = "127.0.0.1:8090"
+	if code, reached := serve(t, g, req); !reached || code != http.StatusOK {
+		t.Fatalf("no-Origin curl: want 200 pass-through, got code=%d reached=%v", code, reached)
+	}
+}
+
+func TestLANHostAllowed(t *testing.T) {
+	g := New("192.168.1.50", 8090)
+	req := httptest.NewRequest(http.MethodPost, "/api/run", nil)
+	req.Host = "192.168.1.50:8090"
+	req.Header.Set("Origin", "http://192.168.1.50:8090")
+	if code, reached := serve(t, g, req); !reached || code != http.StatusOK {
+		t.Fatalf("LAN host same-origin: want 200, got code=%d reached=%v", code, reached)
+	}
+	// Loopback still trusted even when bound to a LAN IP.
+	if !g.HostAllowed("127.0.0.1:8090") {
+		t.Fatal("LAN bind should still trust loopback Host")
+	}
+}
+
+func TestWildcardHostDisablesHostCheck(t *testing.T) {
+	g := New("0.0.0.0", 8090)
+	if g.enforceHost {
+		t.Fatal("0.0.0.0 bind must not enforce Host whitelist")
+	}
+	// Any Host passes...
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Host = "whatever.example.com"
+	if code, reached := serve(t, g, req); !reached || code != http.StatusOK {
+		t.Fatalf("wildcard bind GET: want 200, got code=%d reached=%v", code, reached)
+	}
+	// ...but Origin/CSRF is still enforced on writes.
+	req2 := httptest.NewRequest(http.MethodPost, "/api/run", nil)
+	req2.Host = "whatever.example.com"
+	req2.Header.Set("Origin", "http://evil.example.com")
+	if code, reached := serve(t, g, req2); reached || code != http.StatusForbidden {
+		t.Fatalf("wildcard bind cross-origin POST: want 403, got code=%d reached=%v", code, reached)
+	}
+}
+
+func TestIPv6LoopbackOriginAllowed(t *testing.T) {
+	g := newGuard()
+	if !g.OriginAllowed("http://[::1]:8090") {
+		t.Fatal("IPv6 loopback origin should be whitelisted (bracketed)")
+	}
+	if !g.HostAllowed("[::1]:8090") {
+		t.Fatal("IPv6 loopback Host should be whitelisted (bracketed)")
+	}
+}
+
+func TestTrustedHostsEnv(t *testing.T) {
+	t.Setenv(TrustedHostsEnv, "proxy.internal, dash.example.com:9000")
+	g := New("127.0.0.1", 8090)
+
+	// Bare host gets both the bind port and the bare form.
+	if !g.HostAllowed("proxy.internal:8090") {
+		t.Error("trusted bare host should match at bind port")
+	}
+	if !g.HostAllowed("proxy.internal") {
+		t.Error("trusted bare host should match without port (80/443 proxy)")
+	}
+	// Explicit host:port trusted verbatim.
+	if !g.HostAllowed("dash.example.com:9000") {
+		t.Error("trusted host:port should match verbatim")
+	}
+	if !g.OriginAllowed("https://dash.example.com:9000") {
+		t.Error("trusted host should accept https origin")
+	}
+	// Unrelated host still rejected.
+	if g.HostAllowed("other.example.com:8090") {
+		t.Error("untrusted host must stay blocked")
+	}
+}
+
+func TestWSOriginCheckLogic(t *testing.T) {
+	// Mirrors the /ws/pty CheckOrigin path: whitelist via OriginAllowed.
+	g := newGuard()
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{"http://127.0.0.1:8090", true},
+		{"http://localhost:8090", true},
+		{"http://evil.example.com", false},
+		{"", true}, // non-browser WS client
+	}
+	for _, c := range cases {
+		if got := g.OriginAllowed(c.origin); got != c.want {
+			t.Errorf("OriginAllowed(%q) = %v, want %v", c.origin, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #219

## 背景

`clawflow web` 运行期间对所有 `/api/*` 与 `/ws/pty` 端点零 Host/Origin/CSRF 校验，可被任意恶意网页通过 CSRF（text/plain simple POST 绕预检）与 DNS-rebinding 组合利用，构成 RCE 级暴露（`/ws/pty` 会拉起带 Bash 的 chat）。

## 改动

新增 `internal/webguard` 包，提供从 `host:port` 推导白名单的中间件：

1. **防 DNS-rebinding —— Host 头校验（所有请求）**：白名单 = `{127.0.0.1, localhost, [::1], <配置host>}:port` + `CLAWFLOW_WEB_TRUSTED_HOSTS` 逃生口（IPv6 经 `net.JoinHostPort` 正确加方括号）。不匹配返回 403。
2. **防跨域 CSRF —— Origin 头校验（仅 POST/PUT/DELETE/PATCH）**：`Origin` 存在则必须匹配 dashboard 自身 origin；缺失则放行（保 curl/脚本/CLI）。
3. **`/ws/pty`**：`internal/pty` 暴露 `ConfigureOriginGuard(host, port)`，把 `server.go` 的 `CheckOrigin: return true` 换成复用同一份 Origin 白名单。

边界处理：
- `--host 0.0.0.0` / `::`（用户主动放弃 loopback）：**不强加 Host 白名单**，仅启动打 warning + 记日志；Origin/CSRF 校验仍生效。
- 反向代理改写 Host：用 `CLAWFLOW_WEB_TRUSTED_HOSTS` 环境变量扩展白名单（支持 `host` 或 `host:port`）。
- HTTP 与 WS 两条路径共用同一份白名单，不会出现 HTTP 拦住、WS 漏过的不对称。

## 兼容性

默认 loopback 场景正常用户零感知：dashboard 所有请求同源（Host/Origin 均匹配），curl 无 Origin 放行，`--host <LAN-IP>` 自动纳入白名单。

## 测试

`internal/webguard/webguard_test.go` 覆盖验收清单 6 个 case（同源放行 / 跨域 Origin 拒绝 / Host 不匹配拒绝 / 无 Origin 的 curl 放行 / LAN host 放行 / wildcard 仅警告）+ IPv6、trusted-hosts env；`internal/pty/server_test.go` 验证 WS Origin 校验生效。

```
go test ./internal/webguard/... ./internal/pty/...   # ok
go build ./cmd/... && go vet ./cmd/...               # ok（需先构建 web/dist）
```

> 运行时验证说明：testing.md 的端到端 SOP 针对算子链路，本改动是 Web 服务入站校验中间件，已用 httptest 覆盖中间件全部准入分支；浏览器端同源 dashboard 行为不变（仅新增对跨域/rebinding 的拒绝），未做真机浏览器跑测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)