### PR TITLE
fix(run): bound VCS scan phase with timeout + ctx propagation (#221)

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -183,6 +183,10 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 		fmt.Fprintf(os.Stderr, "\n⚠ clawflow run exceeded its overall budget %s — likely a hung git/network call.\n  Dumping goroutine stacks and exiting (issue #216 safeguard).\n", overall)
 		dumpGoroutineStacks(lg)
 		snapshot.ReleaseRunLock()
+		// os.Exit skips the deferred run/exit, so emit it here with the
+		// reason — this is the observable signature the watchdog path must
+		// leave behind (issue #221 acceptance: run/exit reason=timeout).
+		lg.Info("run/exit", "pid", os.Getpid(), "reason", "timeout", "budget", overall.String())
 		os.Exit(1)
 	})
 	defer selfWatchdog.Stop()
@@ -285,6 +289,18 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 	// and queue the (issue × first-matching-operator) pairs that are
 	// eligible to run. Issues locked by another process (local lockfile)
 	// are skipped at queue time.
+	// Bound the whole scan/poll phase with its own deadline. Each VCS call
+	// is already capped at 30s by the HTTP client, but the phase issues one
+	// ListSubIssues per open issue across every repo — when GitHub throttles,
+	// N sequential 30s calls amplify into hours of "silent" hang after
+	// run/reconcile and before the first run/lock (issue #221). The scan
+	// context is propagated into the HTTP layer so in-flight requests abort
+	// when the budget expires, well before the overall-run watchdog.
+	scanBudget := scanPhaseBudget(timeout)
+	scanCtx, cancelScan := context.WithTimeout(ctx, scanBudget)
+	defer cancelScan()
+	lg.Info("run/scan_phase", "pid", os.Getpid(), "repos", len(allRepos), "budget", scanBudget.String())
+
 	var pending []snapshot.PendingEntry
 	var jobs []*runJob
 	for fullName, repoCfg := range allRepos {
@@ -301,7 +317,7 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 			continue
 		}
 		executeHere := onlyRepo == "" || onlyRepo == fullName
-		repoPending, repoJobs, err := scanRepoOnce(reg, fullName, repoCfg, executeHere, onlyIssue, &globalIssues)
+		repoPending, repoJobs, err := scanRepoOnce(scanCtx, reg, fullName, repoCfg, executeHere, onlyIssue, &globalIssues)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error on %s: %v\n", fullName, err)
 		}
@@ -447,14 +463,25 @@ func deterministicSkipReason(op *operator.Operator, repoCfg config.Repo) string 
 // model) are stripped here before matching, so an issue that was left
 // labeled by a crashed run from an older binary cleanly re-enters the
 // pipeline without manual intervention.
-func scanRepoOnce(reg *operator.Registry, fullName string, repoCfg config.Repo, executeHere bool, onlyIssue int, allIssues *[]snapshot.IssueEntry) ([]snapshot.PendingEntry, []*runJob, error) {
+func scanRepoOnce(ctx context.Context, reg *operator.Registry, fullName string, repoCfg config.Repo, executeHere bool, onlyIssue int, allIssues *[]snapshot.IssueEntry) ([]snapshot.PendingEntry, []*runJob, error) {
+	scanStart := time.Now()
+	runLog.Info("run/scan", "repo", fullName, "phase", "start")
 	client, err := newVCSClient(repoCfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("vcs client: %w", err)
 	}
+	// Propagate the scan-phase deadline into the HTTP layer so a slow /
+	// rate-limited endpoint can't stretch this poll into hours; in-flight
+	// requests abort when the budget expires (issue #221).
+	if ctx != nil {
+		if rc, ok := client.(interface{ SetRequestContext(context.Context) }); ok {
+			rc.SetRequestContext(ctx)
+		}
+	}
 
 	issues, err := client.ListOpenIssues(fullName)
 	if err != nil {
+		runLog.Warn("run/scan", "repo", fullName, "phase", "list_issues_err", "elapsed", time.Since(scanStart).Round(time.Millisecond), "err", err.Error())
 		return nil, nil, fmt.Errorf("list open issues: %w", err)
 	}
 
@@ -467,6 +494,15 @@ func scanRepoOnce(reg *operator.Registry, fullName string, repoCfg config.Repo, 
 		seen[iss.Number] = true
 	}
 	for _, iss := range issues {
+		// Stop enriching once the scan budget is spent. Each ListSubIssues
+		// call is a separate request; under throttling they each burn the
+		// full 30s HTTP timeout, so without this guard N issues turn one
+		// slow repo into a multi-hour hang (issue #221). Remaining sub-issues
+		// are simply not discovered this pass and picked up on the next run.
+		if ctx != nil && ctx.Err() != nil {
+			runLog.Warn("run/scan", "repo", fullName, "phase", "subissue_budget_exceeded", "elapsed", time.Since(scanStart).Round(time.Millisecond), "err", ctx.Err().Error())
+			break
+		}
 		subs, subErr := client.ListSubIssues(fullName, iss.Number)
 		if subErr != nil {
 			debugf("[%s] list sub-issues of #%d: %v (skipping)", fullName, iss.Number, subErr)
@@ -598,6 +634,7 @@ func scanRepoOnce(reg *operator.Registry, fullName string, repoCfg config.Repo, 
 		fmt.Fprintf(os.Stderr, "[%s] snapshot list issues: %v\n", fullName, sErr)
 	}
 
+	runLog.Info("run/scan", "repo", fullName, "phase", "done", "issues", len(issues), "pending", len(pending), "jobs", len(jobs), "elapsed", time.Since(scanStart).Round(time.Millisecond))
 	return pending, jobs, nil
 }
 
@@ -1642,6 +1679,26 @@ func isGitLockError(output string) bool {
 // healthy multi-operator run never trips it. Kept strictly below
 // api.TriggerRun's watchdog so a slow run self-terminates (with a stack
 // dump) before the external process-level kill.
+// scanPhaseBudget bounds the VCS scan/poll phase (listing open issues +
+// enriching with sub-issues across every repo). The scan is normally a few
+// seconds; a slow or rate-limited endpoint is the pathological case. We give
+// it a generous fraction of the per-operator timeout so a healthy poll never
+// trips it, while still firing long before the overall-run watchdog so a hung
+// poll can't hold run.lock for hours (issue #221).
+func scanPhaseBudget(perOp time.Duration) time.Duration {
+	if perOp <= 0 {
+		perOp = 60 * time.Minute
+	}
+	b := perOp / 4
+	if b < 5*time.Minute {
+		b = 5 * time.Minute
+	}
+	if b > 15*time.Minute {
+		b = 15 * time.Minute
+	}
+	return b
+}
+
 func overallRunBudget(perOp time.Duration) time.Duration {
 	if perOp <= 0 {
 		perOp = 60 * time.Minute

--- a/cmd/clawflow/commands/run_watchdog_test.go
+++ b/cmd/clawflow/commands/run_watchdog_test.go
@@ -46,6 +46,46 @@ func TestOverallRunBudgetAlwaysExceedsPerOp(t *testing.T) {
 	}
 }
 
+// Issue #221: the VCS scan/poll phase (after run/reconcile, before the first
+// run/lock) had no bound of its own — one ListSubIssues per open issue, each
+// capped only by the 30s HTTP timeout, so a throttled endpoint amplified N
+// sequential calls into a multi-hour silent hang that held run.lock. The scan
+// phase now gets its own deadline; this verifies the budget math.
+func TestScanPhaseBudget(t *testing.T) {
+	cases := []struct {
+		name  string
+		perOp time.Duration
+		want  time.Duration
+	}{
+		// perOp/4, clamped to [5m, 15m].
+		{"default-hour", time.Hour, 15 * time.Minute},  // 15m hits the cap
+		{"two-hours", 2 * time.Hour, 15 * time.Minute}, // still capped at 15m
+		{"forty-min", 40 * time.Minute, 10 * time.Minute},
+		{"small-perop", 10 * time.Minute, 5 * time.Minute}, // floor
+		{"zero", 0, 15 * time.Minute},                      // falls back to 60m → cap
+		{"negative", -5 * time.Minute, 15 * time.Minute},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := scanPhaseBudget(c.perOp); got != c.want {
+				t.Errorf("scanPhaseBudget(%s) = %s, want %s", c.perOp, got, c.want)
+			}
+		})
+	}
+}
+
+func TestScanPhaseBudgetAlwaysBelowOverallBudget(t *testing.T) {
+	// The scan budget must always fire well before the overall-run watchdog,
+	// otherwise a hung poll could still pin run.lock until the hard kill.
+	for _, perOp := range []time.Duration{time.Minute, 30 * time.Minute, time.Hour, 3 * time.Hour} {
+		scan := scanPhaseBudget(perOp)
+		overall := overallRunBudget(perOp)
+		if scan >= overall {
+			t.Errorf("scanPhaseBudget(%s)=%s must be < overallRunBudget(%s)=%s", perOp, scan, perOp, overall)
+		}
+	}
+}
+
 func TestHardenedGitEnvDisablesPrompts(t *testing.T) {
 	env := hardenedGitEnv([]string{"PATH=/usr/bin"})
 

--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -3,6 +3,7 @@ package github
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,6 +20,23 @@ type Client struct {
 	token   string
 	baseURL string // default: https://api.github.com
 	http    *http.Client
+	ctx     context.Context // optional; bounds every request (see SetRequestContext)
+}
+
+// SetRequestContext binds ctx to every subsequent request so the caller's
+// deadline / cancellation can abort in-flight HTTP calls. Without it a slow or
+// rate-limited GitHub endpoint is only bounded by the 30s client timeout, and
+// the scan phase issues one request per open issue (ListSubIssues) — N
+// sequential 30s calls amplify into hours of "silent" hang after run/reconcile
+// (issue #221). The run-scan budget is propagated through here so the poll
+// phase respects the run timeout and can be cancelled.
+func (c *Client) SetRequestContext(ctx context.Context) { c.ctx = ctx }
+
+func (c *Client) reqContext() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
 }
 
 // New returns a GitHub client. baseURL is optional (for GHE); pass "" for github.com.
@@ -42,7 +60,7 @@ func (c *Client) do(method, path string, body any) ([]byte, int, error) {
 		}
 		r = bytes.NewReader(b)
 	}
-	req, err := http.NewRequest(method, c.baseURL+path, r)
+	req, err := http.NewRequestWithContext(c.reqContext(), method, c.baseURL+path, r)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/vcs/github/client_test.go
+++ b/internal/vcs/github/client_test.go
@@ -1,10 +1,12 @@
 package github_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs/github"
@@ -204,5 +206,37 @@ func TestInitLabels_SkipsExisting(t *testing.T) {
 	}
 	if len(created) != 1 || created[0] != "new-label" {
 		t.Errorf("expected only 'new-label' created, got %v", created)
+	}
+}
+
+// TestSetRequestContextCancelsHangingCall is the issue #221 regression: a slow
+// / hung VCS endpoint must abort when the scan-phase context expires, rather
+// than blocking up to the 30s HTTP client timeout (and, across N issues,
+// amplifying into a multi-hour silent hang). Binding a short-deadline context
+// via SetRequestContext makes the in-flight request return promptly.
+func TestSetRequestContextCancelsHangingCall(t *testing.T) {
+	// Handler hangs until the client aborts the request. When the client's
+	// context deadline fires it drops the connection, the server-side request
+	// context is cancelled, and the handler returns — so srv.Close() during
+	// cleanup never blocks on an in-flight request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	client := github.New("test-token", srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	client.SetRequestContext(ctx)
+
+	start := time.Now()
+	_, err := client.ListOpenIssues("owner/repo")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a context-deadline error from a hung endpoint, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("request did not abort on context deadline: took %s (expected ~150ms)", elapsed)
 	}
 }

--- a/internal/vcs/gitlab/client.go
+++ b/internal/vcs/gitlab/client.go
@@ -4,6 +4,7 @@ package gitlab
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,6 +21,20 @@ type Client struct {
 	token   string
 	baseURL string // e.g. https://gitlab.company.com/api/v4
 	http    *http.Client
+	ctx     context.Context // optional; bounds every request (see SetRequestContext)
+}
+
+// SetRequestContext binds ctx to every subsequent request so the caller's
+// deadline / cancellation can abort in-flight HTTP calls. Without it a slow or
+// rate-limited endpoint is only bounded by the 30s client timeout, letting the
+// scan phase amplify into hours of silent hang (issue #221).
+func (c *Client) SetRequestContext(ctx context.Context) { c.ctx = ctx }
+
+func (c *Client) reqContext() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
 }
 
 // New returns a GitLab client. baseURL should be the GitLab instance root,
@@ -43,7 +58,7 @@ func (c *Client) do(method, path string, body url.Values) ([]byte, int, error) {
 	if body != nil {
 		r = strings.NewReader(body.Encode())
 	}
-	req, err := http.NewRequest(method, c.baseURL+path, r)
+	req, err := http.NewRequestWithContext(c.reqContext(), method, c.baseURL+path, r)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -69,7 +84,7 @@ func (c *Client) doJSON(method, path string, body any) ([]byte, int, error) {
 		}
 		r = bytes.NewReader(b)
 	}
-	req, err := http.NewRequest(method, c.baseURL+path, r)
+	req, err := http.NewRequestWithContext(c.reqContext(), method, c.baseURL+path, r)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
Fixes #221

## 问题
`clawflow run` 在 `run/reconcile` 之后、首个 `run/lock` 之前的 **VCS 扫描/轮询阶段** 挂死数小时，导致 run.lock 长期被占、全量算子停摆。

根因：`scanRepoOnce` 对每个 open issue 串行调用一次 `ListSubIssues`，唯一保护是 HTTP client 的 30s 超时。GitHub 限流时每次调用耗满 30s，N 个 issue × 多仓 → 线性累加成数小时的「静默假死」，且进程级 timeout 从不约束扫描阶段的网络调用。

## 修改
- **scan 阶段独立预算**：新增 `scanPhaseBudget`（perOp/4，clamp 到 [5m,15m]），用 `context.WithTimeout` 包住整个仓库扫描循环。
- **ctx 透传到 HTTP**：github/gitlab client 新增 `SetRequestContext`，`do`/`doJSON` 改用 `http.NewRequestWithContext`——在途请求在预算到点时被取消，不再死等 30s。
- **削减串行放大**：sub-issue 富集循环在预算耗尽时停止并 WARN。
- **可观测进度日志**：`run/scan repo=... phase=start|done issues=N pending=N jobs=N elapsed=...`。
- **watchdog 输出 run/exit reason=timeout**：os.Exit 前补一条日志，留下验收签名。

注意：自看门狗（#216）源码本就存在，但部署的二进制未构建——本 PR 合并并重新发布即可让其生效。本 PR 在其之外补上 scan 阶段的精确预算（远早于 2h 看门狗触发），是真正的根因修复。

## 测试
- github 包新增 `TestSetRequestContextCancelsHangingCall`：注入挂起端点，验证绑定短 deadline 的请求 ~150ms 内中止（对应验收「注入 hang 的 VCS 端点」）。
- commands 包新增 `TestScanPhaseBudget` / `TestScanPhaseBudgetAlwaysBelowOverallBudget`。
- `go test ./...` 全绿，`go vet` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)