### PR TITLE
fix(operator): capture claude stderr tail for diagnosable failures (#222)

### DIFF
--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -305,7 +305,14 @@ func runClaudeWithProvider(ctx context.Context, prompt, workdir, model, apiKey, 
 	cmd := exec.CommandContext(ctx, claude.Resolve(), args...)
 	cmd.Dir = workdir
 	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
-	cmd.Stderr = os.Stderr
+	// Tee claude's stderr: the user still sees it live on os.Stderr, but we
+	// also retain its tail so a non-zero exit carries claude's actual failure
+	// text (rate-limit / auth 403 / panic) instead of a bare "exit status 1".
+	// Without this, cmd.Wait yields no claude context, so meta.Error is
+	// undiagnosable AND the rate-limit/auth classifiers below — which only
+	// inspect err.Error()+stdout — never see the stderr message (issue #222).
+	tail := newStderrTail(4096)
+	cmd.Stderr = io.MultiWriter(os.Stderr, tail)
 	// Run claude as its own process-group leader so the deadline kill below
 	// can reap the entire subtree, not just the direct child (issue #213).
 	setProcessGroup(cmd)
@@ -337,12 +344,67 @@ func runClaudeWithProvider(ctx context.Context, prompt, workdir, model, apiKey, 
 	result, parseErr := parseClaudeStream(stdout, events)
 	close(pipeGuardDone)
 	if err := cmd.Wait(); err != nil {
-		return result, err
+		// cmd.Wait has joined the stderr copy goroutine, so the tail is
+		// complete and race-free to read here.
+		return result, annotateClaudeErr(err, tail.String(), apiKey)
 	}
 	if parseErr != nil {
 		return result, fmt.Errorf("parse stream: %w", parseErr)
 	}
 	return result, nil
+}
+
+// stderrTail is a bounded io.Writer that retains only the last `max` bytes
+// written to it. claude's stderr is tee'd through it so a non-zero exit can
+// fold the tail (rate-limit / auth / panic text) into the returned error —
+// otherwise cmd.Wait yields only "exit status 1" with no claude context, and
+// the rate-limit/auth classifiers (which inspect err.Error()) stay blind to
+// messages claude writes to stderr (issue #222). Only the os/exec stderr-copy
+// goroutine writes to it, and reads happen after cmd.Wait joins that
+// goroutine, so no locking is needed.
+type stderrTail struct {
+	buf []byte
+	max int
+}
+
+func newStderrTail(max int) *stderrTail { return &stderrTail{max: max} }
+
+func (t *stderrTail) Write(p []byte) (int, error) {
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > t.max {
+		t.buf = t.buf[len(t.buf)-t.max:]
+	}
+	return len(p), nil
+}
+
+func (t *stderrTail) String() string { return strings.TrimSpace(string(t.buf)) }
+
+// annotateClaudeErr folds the captured claude stderr tail into err so both the
+// downstream classifiers (IsRateLimitError / IsAuthError / isFailoverError) and
+// the persisted meta.Error / pilot/end log see claude's real failure text
+// rather than a bare "exit status 1" (issue #222). The tail is API-key-scrubbed
+// and clipped to its last few non-empty lines to stay readable.
+func annotateClaudeErr(err error, tail, apiKey string) error {
+	tail = scrubAPIKey(strings.TrimSpace(tail), apiKey)
+	tail = lastLines(tail, 5)
+	if tail == "" {
+		return err
+	}
+	return fmt.Errorf("%w; claude stderr: %s", err, tail)
+}
+
+// lastLines returns the last n non-empty, trimmed lines of s joined by " | ".
+func lastLines(s string, n int) string {
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, " | ")
 }
 
 // firstLineOf returns the first non-empty line of s, trimmed.
@@ -511,4 +573,3 @@ func parseClaudeStream(r io.Reader, events io.Writer) (string, error) {
 	}
 	return finalResult, nil
 }
-

--- a/internal/operator/claude_test.go
+++ b/internal/operator/claude_test.go
@@ -7,6 +7,69 @@ import (
 	"testing"
 )
 
+func TestStderrTailRetainsLastBytes(t *testing.T) {
+	tail := newStderrTail(8)
+	if _, err := tail.Write([]byte("0123456789ABCDEF")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := tail.String(); got != "89ABCDEF" {
+		t.Fatalf("got %q, want last 8 bytes %q", got, "89ABCDEF")
+	}
+
+	// Multiple writes across the cap boundary keep only the tail.
+	tail = newStderrTail(4)
+	tail.Write([]byte("ab"))
+	tail.Write([]byte("cdef"))
+	if got := tail.String(); got != "cdef" {
+		t.Fatalf("got %q, want %q", got, "cdef")
+	}
+}
+
+func TestAnnotateClaudeErr(t *testing.T) {
+	base := errors.New("exit status 1")
+
+	t.Run("folds stderr tail into error", func(t *testing.T) {
+		err := annotateClaudeErr(base, "API error: 403\nrequest not allowed", "")
+		msg := err.Error()
+		if !strings.Contains(msg, "exit status 1") {
+			t.Fatalf("lost original error: %q", msg)
+		}
+		if !strings.Contains(msg, "403") || !strings.Contains(msg, "request not allowed") {
+			t.Fatalf("stderr tail not folded in: %q", msg)
+		}
+		// errors.Is must still see the wrapped sentinel through %w.
+		if !errors.Is(err, base) {
+			t.Fatalf("errors.Is broken after annotation")
+		}
+	})
+
+	t.Run("classifiers now see stderr-only auth message", func(t *testing.T) {
+		// Before #222 the auth text lived only on stderr, so IsAuthError(err,"")
+		// returned false. Folding it into err makes the classifier fire.
+		annotated := annotateClaudeErr(base, "Error: api error: 403", "")
+		if !IsAuthError(annotated, "") {
+			t.Fatalf("auth message on stderr not classified")
+		}
+		rl := annotateClaudeErr(base, "You've hit your limit", "")
+		if !IsRateLimitError(rl, "") {
+			t.Fatalf("rate-limit message on stderr not classified")
+		}
+	})
+
+	t.Run("scrubs api key", func(t *testing.T) {
+		err := annotateClaudeErr(base, "auth failed for sk-secret-123", "sk-secret-123")
+		if strings.Contains(err.Error(), "sk-secret-123") {
+			t.Fatalf("api key leaked: %q", err.Error())
+		}
+	})
+
+	t.Run("empty tail returns original error unchanged", func(t *testing.T) {
+		if got := annotateClaudeErr(base, "   \n  ", ""); got != base {
+			t.Fatalf("empty tail should return original error, got %v", got)
+		}
+	})
+}
+
 // buildAssistantEvent returns a stream-json line for an "assistant" event
 // carrying a single text content block.
 func buildAssistantEvent(text string) string {
@@ -234,10 +297,10 @@ func TestIsAuthError(t *testing.T) {
 
 func TestIsRateLimitError(t *testing.T) {
 	cases := []struct {
-		name    string
-		err     error
-		output  string
-		want    bool
+		name   string
+		err    error
+		output string
+		want   bool
 	}{
 		{
 			name:   "nil error",


### PR DESCRIPTION
Fixes #222 (问题②).

## 问题
`internal/operator/claude.go` 的 `cmd.Stderr = os.Stderr` 把 claude 子进程 stderr 直接转发、从不捕获，`cmd.Wait()` 失败时只剩裸 `exit status 1`。更隐蔽的是 `IsRateLimitError` / `IsAuthError` / `isFailoverError` 三个分类器只检查 `err.Error() + stdout`，而 claude 的限流/认证文本恰恰写在 **stderr**——导致瞬时故障被误判为永久失败、失效转移失灵。

## 改动
- 新增 `stderrTail`（有界环形缓冲，留尾部 4KB），`io.MultiWriter(os.Stderr, tail)` tee：用户照常看到实时 stderr，同时保留尾部。
- 新增 `annotateClaudeErr`：失败时把 API-key 脱敏后、裁到最后 5 行的 stderr 尾部折进返回 error（`%w` 包裹，`errors.Is` 不破）。
- 一处改动同时让 `meta.Error` / `pilot/end` 可区分 rate-limit / auth-403 / 挂死，并让三个分类器在「仅 stderr 有消息」时也能触发。

## 测试
- `TestStderrTailRetainsLastBytes` + `TestAnnotateClaudeErr`（errors.Is 保持 / stderr-only 分类生效 / key 脱敏 / 空尾部不改原错误）
- `go test ./internal/operator/` 全绿，`go vet` / `gofmt` 干净

## 范围说明
本 PR 仅覆盖 #222 的问题②。问题①（扫描阶段挂死 / 1h timeout）是部署滞后，对症修复 #223 已在 main，需重新部署而非改码。