### PR TITLE
feat(pm): add Pilot Play 5 — dependency-unlock re-push

### DIFF
--- a/internal/chat/project_pilot.go
+++ b/internal/chat/project_pilot.go
@@ -340,6 +340,59 @@ Play 1 cleanup happens automatically — no separate ` + "`push --delete`" + ` n
   comment noting the recovery attempt failed and stop — do NOT keep
   hammering or force-push. A human or the next wake can pick it up.
 
+### Play 5 — Dependency-unlock re-push
+
+**Trigger:** a feat issue that ` + "`evaluate-feat`" + ` parked at ` + "`agent-skipped`" + `
+*because a prerequisite issue wasn't ready yet*, where those
+prerequisites have since landed. All of these must hold:
+- the issue carries ` + "`agent-skipped`" + ` (and is NOT carrying ` + "`agent-running`" + `), and
+- its most-recent ` + "`evaluate-feat`" + ` evaluation comment names a low
+  Confidence whose **primary/only blocker is unmet dependencies**, and
+  explicitly cites the blocking issue numbers (e.g. "硬依赖 #79/#81/#82
+  未就绪").
+
+This is the issue-side twin of Play 4: ` + "`evaluate-feat`" + ` skipped, its
+` + "`agent-skipped`" + ` exclusion label now blocks it from ever re-firing, and
+` + "`auto_approve`" + ` only reacts to ` + "`agent-evaluated`" + ` — so nobody re-checks
+whether the skip reason still holds once the dependencies merge. You are
+the backstop (issue #226; real case: bbclaw #80 skipped 6.3/10 on unmet
+` + "`#79/#81/#82`" + `, all later merged, then sat stuck until a human pulled the label).
+
+**Judgement (read before acting):**
+- Parse the cited dependency issue numbers from the latest evaluation
+  comment. Only same-repo ` + "`#N`" + ` references — a cross-repo
+  ` + "`owner/repo#N`" + ` dependency is "cannot auto-judge → leave alone".
+- ` + "`clawflow issue view --repo <r> --number <dep>`" + ` each cited dependency.
+  Re-push ONLY if **every** named dependency is closed/merged.
+- Scan the skip comment for **unresolved design / clarity items**. If the
+  skip mixed in any open design decision or "Clarity 待澄清"-class question
+  (e.g. bbclaw #83: "v1 总结策略留空 / ` + "`OnTurnDistill`" + ` hook 待定 / ADR
+  记忆落点冲突"), dependencies clearing is NOT enough — a human must settle
+  the design first. Leave ` + "`agent-skipped`" + ` in place; optionally post a
+  one-line "仍在等 X 设计决策" comment. Dependencies must be the **sole or
+  primary** blocker.
+
+**Action** (only when judgement passes):
+
+    clawflow label remove --repo <owner/repo> --number <n> agent-skipped
+
+Then post a one-line "依赖 #X/#Y 已合入，blocker 已解除，请求重评" comment so
+the next run's ` + "`evaluate-feat`" + ` re-scores against the latest base snapshot
+(dependencies now present → expected to clear threshold). Reuses the
+existing ` + "`clawflow label remove`" + ` authority — no Go change.
+
+**Bounds:**
+- **Max 1–2 dependency-unlock re-pushes per wake.** Cap blast radius.
+- Existing unresolved design/clarity item → do NOT touch the label; at
+  most post the "仍在等 X" note.
+- Re-push ONLY when **all** cited dependencies are closed/merged.
+- **No ping-pong with humans.** If there's any sign a human already
+  re-skipped or re-applied ` + "`agent-skipped`" + ` (a human comment after the
+  operator skip, a manual label action), leave it alone — default to NOT
+  re-pushing whenever human involvement is ambiguous. Only auto-re-push a
+  skip that was clearly machine-applied by ` + "`evaluate-feat`" + ` and never
+  previously re-pushed by Pilot.
+
 ## Hard rules
 
 You CAN, via Bash:
@@ -367,8 +420,13 @@ You CANNOT:
   read-only on member repo files.
 
 **Narrow exceptions, all already covered above:**
-- MAY remove (only remove) ` + "`agent-failed`" + ` / ` + "`agent-skipped`" + ` when the
-  underlying blocker has clearly cleared, with a one-line reason comment.
+- MAY remove (only remove) ` + "`agent-failed`" + ` when the underlying blocker
+  has clearly cleared, with a one-line reason comment.
+- MAY remove (only remove) ` + "`agent-skipped`" + ` ONLY during an active Play 5
+  dependency-unlock re-push — i.e. a feat issue ` + "`evaluate-feat`" + ` skipped
+  solely on unmet dependencies that have all since closed/merged, with no
+  unresolved design item and no human re-skip. One-line reason comment,
+  1–2 per wake. Outside Play 5, ` + "`agent-skipped`" + ` is read-only.
 - MAY ` + "`push --force-with-lease`" + ` to a PR's own head branch only
   during Play 2.
 - MAY ` + "`push --delete`" + ` a remote branch only during Play 1.

--- a/internal/chat/project_test.go
+++ b/internal/chat/project_test.go
@@ -322,6 +322,31 @@ func TestBuildPilotContext_StandardPlays(t *testing.T) {
 		t.Error("missing PATROL summary line format")
 	}
 
+	// Play 5 — dependency-unlock re-push
+	if !containsStr(prompt, "Dependency-unlock re-push") {
+		t.Error("missing Play 5 (dependency-unlock re-push) header")
+	}
+	if !containsStr(prompt, "label remove") || !containsStr(prompt, "agent-skipped") {
+		t.Error("missing agent-skipped label-remove action in Play 5")
+	}
+	if !containsStr(prompt, "named dependency is closed/merged") {
+		t.Error("missing all-dependencies-merged gate in Play 5")
+	}
+	if !containsStr(prompt, "unresolved design") {
+		t.Error("missing unresolved-design-item guard in Play 5 (must not auto-re-push on open design questions)")
+	}
+	if !containsStr(prompt, "ping-pong") {
+		t.Error("missing human ping-pong / re-skip guard in Play 5")
+	}
+	if !containsStr(prompt, "per wake") {
+		t.Error("missing per-wake cap on dependency-unlock re-pushes")
+	}
+
+	// Hard rules narrow exception converged onto Play 5
+	if !containsStr(prompt, "ONLY during an active Play 5") {
+		t.Error("missing Play 5-scoped narrow exception for agent-skipped removal in Hard rules")
+	}
+
 	// Hard rules updated to allow narrow Edit/push exceptions
 	if !containsStr(prompt, "Edit") || !containsStr(prompt, "ONLY inside an") {
 		t.Error("hard rules missing the active-play scope on Edit/Write")


### PR DESCRIPTION
Fixes #226

## 背景
与 #224（Play 4 auto-merge recovery）同主题：operator 流水线在某状态卡死后无人复推，Pilot 作为 backlog coherence 层兜底。本 PR 处理「因依赖未就绪被 `evaluate-feat` skip 的 feat issue」——依赖后来合入后 issue 仍卡在 `agent-skipped`，全靠人工移除标签才复推。

## 改动
纯 Pilot prompt 变更，单文件 `internal/chat/project_pilot.go`：

1. **新增 Play 5 — Dependency-unlock re-push**（接在 Play 4 后），按既有 Trigger / Judgement / Action / Bounds 三段式：
   - *Trigger*：issue 带 `agent-skipped`，最新 `evaluate-feat` 评论 skip 主因为「依赖未就绪」并点名了依赖 issue 编号。
   - *Judgement*：逐个 `clawflow issue view` 核对被点名依赖是否**全部** closed/merged；扫评论确认**无**未决设计/澄清项（写入 bbclaw #80 应复推 / #83 不该复推的正反样本）；只处理同仓库 `#N`，跨仓库引用归入「无法自动判定→不动」。
   - *Action*：`clawflow label remove agent-skipped` + 一条「依赖已解除，请求重评」评论，复用现有授权，无 Go 逻辑改动。
   - *Bounds*：每 wake 最多 1–2 个；存在未决设计项→只补评论不动标签；有人为 re-skip 迹象→不碰（防 ping-pong）。
2. **收敛 Hard rules 的 narrow exception**：把原本笼统的「MAY remove agent-skipped when blocker cleared」收紧为「仅在 active Play 5 内」，与 Play 1/2/4 写法对齐，不推翻 Pilot「不碰中段流水线」的设计。

## 测试
- `go test ./internal/chat/... ./internal/pilot/...` 全绿。
- 在 `TestBuildPilotContext_StandardPlays` 中新增 Play 5 关键词与边界断言（header、label remove action、全依赖合入 gate、未决设计 guard、ping-pong guard、per-wake 上限、Hard rules Play 5-scoped exception）。
- 本质为 prompt 字符串变更，无新增运行时逻辑可单测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)