### PR TITLE
fix: keep clawflow on PATH after install/update

### DIFF
--- a/cmd/clawflow/commands/update.go
+++ b/cmd/clawflow/commands/update.go
@@ -33,10 +33,12 @@ func NewUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update the clawflow binary to the latest release",
-		Long: `Fetches the latest release from GitHub and replaces the clawflow binary
-at ~/.clawflow/bin/clawflow. Built-in operators ship inside the binary, so
-there is nothing else to sync. User operators in ~/.clawflow/skills/ are
-untouched.
+		Long: `Fetches the latest release from GitHub and replaces the currently
+running clawflow binary in place — wherever it lives (/usr/local/bin,
+~/.local/bin, ~/.clawflow/bin, ...) — so the updated binary stays on your
+PATH and no stale second copy is left behind. Built-in operators ship inside
+the binary, so there is nothing else to sync. User operators in
+~/.clawflow/skills/ are untouched.
 
 Use --from-source to rebuild from a local repo clone instead (dev flow).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -171,9 +173,29 @@ func rebuildFromSource(repoDir string) error {
 	return nil
 }
 
+// binaryPath returns the path of the binary that `clawflow update` should
+// replace. It resolves the currently-running executable (following symlinks)
+// so an update lands in the same location the user originally installed to —
+// /usr/local/bin, ~/.local/bin, or ~/.clawflow/bin — keeping it on PATH and
+// avoiding a second, stale copy. The legacy ~/.clawflow/bin/clawflow path is
+// only used as a fallback when the executable path can't be resolved.
 func binaryPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".clawflow", "bin", "clawflow")
+	exe, err := os.Executable()
+	if err != nil {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".clawflow", "bin", "clawflow")
+	}
+	return resolveBinaryPath(exe)
+}
+
+// resolveBinaryPath follows symlinks for exe so we replace the real binary,
+// not a symlink that points at it (common when /usr/local/bin/clawflow is a
+// link into ~/.clawflow/bin). Falls back to the raw path if EvalSymlinks fails.
+func resolveBinaryPath(exe string) string {
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		return resolved
+	}
+	return exe
 }
 
 // atomicReplace writes src to dest via a temp file, then renames — avoids
@@ -185,6 +207,9 @@ func atomicReplace(dest string, src io.Reader) error {
 	tmp := dest + ".tmp"
 	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 	if err != nil {
+		if os.IsPermission(err) {
+			return permissionDeniedErr(dest, err)
+		}
 		return err
 	}
 	if _, err := io.Copy(f, src); err != nil {
@@ -196,6 +221,9 @@ func atomicReplace(dest string, src io.Reader) error {
 
 	if err := os.Rename(tmp, dest); err != nil {
 		os.Remove(tmp)
+		if os.IsPermission(err) {
+			return permissionDeniedErr(dest, err)
+		}
 		return err
 	}
 	if err := codesignIfDarwin(dest); err != nil {
@@ -206,6 +234,17 @@ func atomicReplace(dest string, src io.Reader) error {
 	}
 	fmt.Printf("  [ok] binary updated → %s\n", dest)
 	return nil
+}
+
+// permissionDeniedErr wraps a write-permission failure with an actionable
+// hint. This is the common case when clawflow was installed into a
+// system-owned directory like /usr/local/bin and the user runs `clawflow
+// update` without elevated privileges.
+func permissionDeniedErr(dest string, cause error) error {
+	return fmt.Errorf("no write permission for %s (%w)\n"+
+		"      clawflow lives in a directory that needs elevated privileges.\n"+
+		"      Re-run with sudo, e.g.:\n"+
+		"        sudo clawflow update", dest, cause)
 }
 
 // codesignIfDarwin ad-hoc signs `path` on macOS so Gatekeeper doesn't

--- a/cmd/clawflow/commands/update_test.go
+++ b/cmd/clawflow/commands/update_test.go
@@ -1,6 +1,11 @@
 package commands
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 // IsNewerVersion is load-bearing for `clawflow update`'s "skip if already at
 // latest" short-circuit — one wrong case and users either re-download the
@@ -46,5 +51,59 @@ func TestIsNewerVersion(t *testing.T) {
 				t.Errorf("IsNewerVersion(%q, %q) = %v, want %v", c.current, c.latest, got, c.want)
 			}
 		})
+	}
+}
+
+// resolveBinaryPath underpins the issue #230 fix: `clawflow update` must
+// replace the binary at its REAL location (following symlinks), not a symlink
+// pointing at it, so the update stays on PATH and doesn't leave a stale copy.
+func TestResolveBinaryPath(t *testing.T) {
+	dir := t.TempDir()
+
+	real := filepath.Join(dir, "clawflow")
+	if err := os.WriteFile(real, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The canonical path of the real file — on macOS the temp dir itself sits
+	// under a /tmp -> /private/tmp symlink, so normalize via EvalSymlinks
+	// rather than comparing against the raw path.
+	want, err := filepath.EvalSymlinks(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A plain regular file resolves to its canonical self.
+	if got := resolveBinaryPath(real); got != want {
+		t.Errorf("resolveBinaryPath(regular) = %q, want %q", got, want)
+	}
+
+	// A symlink resolves to its target — this is the /usr/local/bin/clawflow
+	// -> ~/.clawflow/bin/clawflow case we must follow on update.
+	link := filepath.Join(dir, "clawflow-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	if resolved := resolveBinaryPath(link); resolved != want {
+		t.Errorf("resolveBinaryPath(symlink) = %q, want %q", resolved, want)
+	}
+
+	// An unresolvable (nonexistent) path falls back to the raw input rather
+	// than erroring out.
+	missing := filepath.Join(dir, "does-not-exist")
+	if resolved := resolveBinaryPath(missing); resolved != missing {
+		t.Errorf("resolveBinaryPath(missing) = %q, want %q", resolved, missing)
+	}
+}
+
+// permissionDeniedErr must surface the destination path and an actionable
+// sudo hint so users who installed into /usr/local/bin know how to recover.
+func TestPermissionDeniedErr(t *testing.T) {
+	err := permissionDeniedErr("/usr/local/bin/clawflow", os.ErrPermission)
+	msg := err.Error()
+	if !strings.Contains(msg, "/usr/local/bin/clawflow") {
+		t.Errorf("error message missing destination path: %q", msg)
+	}
+	if !strings.Contains(msg, "sudo clawflow update") {
+		t.Errorf("error message missing sudo hint: %q", msg)
 	}
 }

--- a/install.sh
+++ b/install.sh
@@ -124,20 +124,54 @@ if [[ -n "$CREATE_LABELS_REPO" ]]; then
   fi
 fi
 
+# ---------- 6. ensure ~/.clawflow/bin is on PATH ----------
+# install.sh always builds into ~/.clawflow/bin, which is NOT a standard PATH
+# directory. Mirror get.sh's behavior: idempotently append an export line to
+# the user's shell rc so `clawflow` works in new shells without manual setup.
+NEED_SOURCE=""
+PATH_MANUAL=""
+if ! printf ':%s:' "$PATH" | grep -q ":$CLAWFLOW_HOME/bin:"; then
+  PATH_LINE='export PATH="$HOME/.clawflow/bin:$PATH"'
+  SHELL_RC=""
+  case "${SHELL:-}" in
+    */zsh)  SHELL_RC="$HOME/.zshrc" ;;
+    */bash) SHELL_RC="$HOME/.bashrc" ;;
+  esac
+
+  if [[ -n "$SHELL_RC" ]] && ! grep -q '.clawflow/bin' "$SHELL_RC" 2>/dev/null; then
+    printf '\n# ClawFlow\n%s\n' "$PATH_LINE" >> "$SHELL_RC"
+    echo "  [ok]   PATH added to $SHELL_RC"
+    NEED_SOURCE="$SHELL_RC"
+  else
+    # Couldn't detect a known rc file (or it already mentions the dir) — tell
+    # the user how to do it manually.
+    PATH_MANUAL="$PATH_LINE"
+  fi
+fi
+
 # ---------- done ----------
 cat <<MSG
 
 Done. ClawFlow is installed.
 
 Next steps:
-  1. Add CLI to PATH (bash/zsh):
-       export PATH="\$HOME/.clawflow/bin:\$PATH"
-  2. Store a VCS token:
+MSG
+
+if [[ -n "$NEED_SOURCE" ]]; then
+  echo "  0. Reload your shell so clawflow is on PATH:"
+  echo "       source $NEED_SOURCE"
+elif [[ -n "$PATH_MANUAL" ]]; then
+  echo "  0. Add CLI to PATH (then restart your shell):"
+  echo "       echo '$PATH_MANUAL' >> ~/.zshrc   # or your shell's rc file"
+fi
+
+cat <<MSG
+  1. Store a VCS token:
        clawflow config set-token <ghp_...>         # GitHub
        clawflow config set-gitlab-token <glpat_..> # GitLab
-  3. Register a repo to monitor:
+  2. Register a repo to monitor:
        clawflow repo add <owner/repo | URL | local path>
-  4. Run the operator loop:
+  3. Run the operator loop:
        clawflow run
 
 Built-in operators:


### PR DESCRIPTION
Fixes #230

## 问题
- `install.sh` 把二进制装到 `~/.clawflow/bin/`,该目录默认不在 `$PATH`,仅口头提示用户手动 export,新终端 `clawflow` 报 `command not found`。
- `clawflow update` 的 `binaryPath()` 硬编码写入 `~/.clawflow/bin/clawflow`,无视原始安装位置(`/usr/local/bin`、`~/.local/bin`),更新后脱离 PATH,并与 PATH 中旧二进制共存造成版本错乱。

## 改动
1. **`cmd/clawflow/commands/update.go`**
   - `binaryPath()` 改为基于 `os.Executable()` 解析当前运行二进制的真实路径(`resolveBinaryPath` 跟随 symlink),就地替换。这样无论最初装在哪,更新后都留在原目录、仍在 PATH 中,也不再产生重复二进制。解析失败时回退到旧的 `~/.clawflow/bin/clawflow`。
   - `atomicReplace` 在写入/重命名遇到权限不足时,通过 `permissionDeniedErr` 给出 `sudo clawflow update` 的可执行提示(覆盖 `/usr/local/bin` 这类系统目录场景)。

2. **`install.sh`**
   - 复用 `get.sh` 的 PATH-into-rc 逻辑:检测 `$SHELL` 对应的 rc(`.zshrc`/`.bashrc`),幂等追加 `export PATH="$HOME/.clawflow/bin:$PATH"`,结尾提示 `source`。无法识别 rc 时打印手动写法。

## 测试
- `go test ./cmd/clawflow/commands/ -run 'TestResolveBinaryPath|TestPermissionDeniedErr|TestIsNewerVersion'` 通过(新增 `resolveBinaryPath` symlink 解析与 `permissionDeniedErr` 提示内容两个单测)。
- 隔离环境验证 `install.sh` 的 PATH 写入逻辑幂等(重复运行不重复追加)、`.zshrc` 中 `.clawflow/bin` 仅出现一次。
- `bash -n install.sh` 语法校验通过。

> 未跑完整 `install.sh`/`clawflow update` 端到端(会覆盖本机真实安装),核心逻辑已分别用单测与隔离脚本验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)