### PR TITLE
feat(branch): 新增分支分析管理 CLI，清理已合并的本地/远程分支

### DIFF
--- a/cmd/clawflow/commands/branch.go
+++ b/cmd/clawflow/commands/branch.go
@@ -1,0 +1,221 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/branch"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+// NewBranchCmd groups branch hygiene subcommands: analyze and clean up branches
+// that have already been merged into the repo's base branch.
+func NewBranchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "branch",
+		Short: "Analyze and clean up merged local/remote branches",
+		Long: `Scan a configured repo's local clone for branches that have already been
+merged into the base branch (e.g. leftover fix/issue-* branches) and clean
+them up. 'list' is read-only; 'delete' defaults to a dry-run preview and only
+removes branches when --yes is passed.`,
+	}
+	cmd.AddCommand(newBranchListCmd())
+	cmd.AddCommand(newBranchDeleteCmd())
+	return cmd
+}
+
+// resolveBranchContext loads config, resolves the local clone path and base
+// branch, and optionally fetches+prunes so the remote-tracking view is fresh.
+func resolveBranchContext(repo string, fetch bool) (localPath, base string, err error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return "", "", err
+	}
+	repoCfg, ok := cfg.Repos[repo]
+	if !ok {
+		return "", "", fmt.Errorf("repo %q not found in config", repo)
+	}
+	localPath, err = resolveLocalPath(cfg, repo, repoCfg)
+	if err != nil {
+		return "", "", err
+	}
+	base = repoCfg.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+	// Fetching matters most when we report on remote-tracking branches; for a
+	// local-only view it is best-effort and a failure should not abort.
+	if fetch {
+		if ferr := branch.Fetch(localPath); ferr != nil {
+			fmt.Fprintf(os.Stderr, "warn: fetch failed, using cached refs: %v\n", ferr)
+		}
+	}
+	return localPath, base, nil
+}
+
+func newBranchListCmd() *cobra.Command {
+	var repo string
+	var includeRemote bool
+	var noFetch bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List merged branches eligible for cleanup",
+		Example: `  # Merged local branches
+  clawflow branch list --repo owner/repo
+
+  # Include merged remote-tracking branches
+  clawflow branch list --repo owner/repo --remote`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			localPath, base, err := resolveBranchContext(repo, !noFetch && includeRemote)
+			if err != nil {
+				return err
+			}
+			branches, err := branch.ListMerged(localPath, base, includeRemote)
+			if err != nil {
+				return err
+			}
+			if len(branches) == 0 {
+				fmt.Printf("no merged branches to clean up (base: %s)\n", base)
+				return nil
+			}
+			printBranches(cmd.OutOrStdout(), branches)
+			fmt.Printf("\n%d merged branch(es) eligible for cleanup (base: %s)\n", len(branches), base)
+			fmt.Println("run 'clawflow branch delete --repo " + repo + "' to preview deletion")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
+	cmd.Flags().BoolVar(&includeRemote, "remote", false, "also list merged remote-tracking branches")
+	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "skip 'git fetch --prune' before analyzing remote branches")
+	_ = cmd.MarkFlagRequired("repo")
+	return cmd
+}
+
+func newBranchDeleteCmd() *cobra.Command {
+	var repo string
+	var includeRemote bool
+	var apply bool
+	var force bool
+	var staleDays int
+	var noFetch bool
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete merged branches (dry-run unless --yes)",
+		Long: `Delete branches that are merged into the base branch. Without --yes this is
+a dry-run that only previews what would be deleted. Local branches are removed
+via 'git branch -d' (use --force for -D); remote branches are removed via the
+VCS API. The base branch and protected branches (main/master/develop) are
+never touched.`,
+		Example: `  # Preview which merged local branches would be deleted
+  clawflow branch delete --repo owner/repo
+
+  # Actually delete merged local branches
+  clawflow branch delete --repo owner/repo --yes
+
+  # Delete merged local + remote branches older than 30 days
+  clawflow branch delete --repo owner/repo --remote --stale 30 --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			localPath, base, err := resolveBranchContext(repo, !noFetch && includeRemote)
+			if err != nil {
+				return err
+			}
+			branches, err := branch.ListMerged(localPath, base, includeRemote)
+			if err != nil {
+				return err
+			}
+
+			// Apply scope and staleness filters.
+			cutoff := time.Time{}
+			if staleDays > 0 {
+				cutoff = time.Now().AddDate(0, 0, -staleDays)
+			}
+			var targets []branch.Branch
+			for _, b := range branches {
+				if staleDays > 0 && (b.LastCommit.IsZero() || b.LastCommit.After(cutoff)) {
+					continue
+				}
+				targets = append(targets, b)
+			}
+
+			if len(targets) == 0 {
+				fmt.Printf("no branches match the cleanup criteria (base: %s)\n", base)
+				return nil
+			}
+
+			printBranches(cmd.OutOrStdout(), targets)
+
+			if !apply {
+				fmt.Printf("\n%d branch(es) would be deleted — re-run with --yes to apply\n", len(targets))
+				return nil
+			}
+
+			var client interface {
+				DeleteBranch(repo, branch string) error
+			}
+			if includeRemote {
+				c, _, cerr := newVCSClientForRepo(repo)
+				if cerr != nil {
+					return cerr
+				}
+				client = c
+			}
+
+			deleted, failed := 0, 0
+			for _, b := range targets {
+				if b.Remote {
+					if client == nil {
+						continue
+					}
+					if derr := client.DeleteBranch(repo, b.Name); derr != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "warn: delete remote %s: %v\n", b.Name, derr)
+						failed++
+						continue
+					}
+					fmt.Printf("deleted remote: %s\n", b.Name)
+					deleted++
+					continue
+				}
+				if derr := branch.DeleteLocal(localPath, b.Name, force); derr != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "warn: delete local %s: %v\n", b.Name, derr)
+					failed++
+					continue
+				}
+				fmt.Printf("deleted local: %s\n", b.Name)
+				deleted++
+			}
+			fmt.Printf("\n%d deleted, %d failed (base: %s)\n", deleted, failed, base)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
+	cmd.Flags().BoolVar(&includeRemote, "remote", false, "also delete merged remote branches (via VCS API)")
+	cmd.Flags().BoolVar(&apply, "yes", false, "actually delete (default is a dry-run preview)")
+	cmd.Flags().BoolVar(&force, "force", false, "use 'git branch -D' for local branches (force-delete)")
+	cmd.Flags().IntVar(&staleDays, "stale", 0, "only branches whose last commit is older than N days")
+	cmd.Flags().BoolVar(&noFetch, "no-fetch", false, "skip 'git fetch --prune' before analyzing remote branches")
+	_ = cmd.MarkFlagRequired("repo")
+	return cmd
+}
+
+func printBranches(w io.Writer, branches []branch.Branch) {
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "SCOPE\tBRANCH\tMERGED\tLAST COMMIT")
+	for _, b := range branches {
+		last := "unknown"
+		if !b.LastCommit.IsZero() {
+			last = b.LastCommit.Format("2006-01-02")
+		}
+		merged := "no"
+		if b.Merged {
+			merged = "yes"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", b.Scope(), b.Name, merged, last)
+	}
+	_ = tw.Flush()
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -43,6 +43,7 @@ entirely in VCS labels and comments. Run 'clawflow run' once, or schedule it.`,
 	root.AddCommand(NewRespawnCmd())
 	// Helpers retained for operator use (invoked from SKILL.md bodies):
 	root.AddCommand(NewWorktreeCmd())
+	root.AddCommand(NewBranchCmd())
 	root.AddCommand(NewStatusCmd())
 	root.AddCommand(NewPRCheckCmd())
 	root.AddCommand(NewLangCmd())

--- a/internal/branch/branch.go
+++ b/internal/branch/branch.go
@@ -1,0 +1,169 @@
+// Package branch provides read-only enumeration and merge-status analysis of
+// local and remote-tracking git branches, plus helpers to delete them. It is
+// intentionally side-effect-light: ListMerged only reads, and the delete
+// helpers each touch a single branch so callers (CLI, future Pilot duty) can
+// drive confirmation/preview around them.
+//
+// Merge detection is done entirely against the local clone via
+// `git for-each-ref --merged=<commit>`, which uses ancestry. This is exact for
+// normal merge commits. NOTE: squash-merged or rebase-merged branches do not
+// share ancestry with the base tip, so they are NOT reported as merged here —
+// detecting those requires cross-referencing the platform's merged-PR list and
+// is left to a later increment.
+package branch
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Branch describes a single branch and its merge/age status.
+type Branch struct {
+	Name       string    // short name without any "origin/" prefix, e.g. "fix/issue-226"
+	Remote     bool      // true if this is a remote-tracking branch (origin/*)
+	LastCommit time.Time // committer date of the branch tip (zero if unknown)
+	Merged     bool      // merged into the base branch (by ancestry)
+}
+
+// Scope renders "remote" or "local" for display.
+func (b Branch) Scope() string {
+	if b.Remote {
+		return "remote"
+	}
+	return "local"
+}
+
+// protectedNames are branch names that are never eligible for deletion,
+// regardless of merge status.
+var protectedNames = map[string]bool{
+	"main":    true,
+	"master":  true,
+	"develop": true,
+	"HEAD":    true,
+}
+
+// IsProtected reports whether a (short) branch name must never be deleted.
+// The configured base branch is always protected.
+func IsProtected(name, base string) bool {
+	if name == "" || name == base || name == "origin" {
+		return true
+	}
+	return protectedNames[name]
+}
+
+// refFormat asks `git for-each-ref` for "<short-name>\x00<committerdate-unix>".
+// A NUL separator avoids ambiguity with branch names containing spaces/slashes.
+const refFormat = "%(refname:short)%00%(committerdate:unix)"
+
+// parseRefLines parses the NUL-delimited output of `git for-each-ref` using
+// refFormat. Any "origin/" prefix is stripped from the name. It is exported
+// indirectly via ListMerged but kept package-private and unit-tested directly.
+func parseRefLines(out string, remote bool) []Branch {
+	var branches []Branch
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\x00", 2)
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			continue
+		}
+		var ts time.Time
+		if len(parts) == 2 {
+			if unix, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64); err == nil && unix > 0 {
+				ts = time.Unix(unix, 0)
+			}
+		}
+		name = strings.TrimPrefix(name, "origin/")
+		branches = append(branches, Branch{Name: name, Remote: remote, LastCommit: ts})
+	}
+	return branches
+}
+
+func gitOut(dir string, args ...string) (string, error) {
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	out, err := c.Output()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return string(out), nil
+}
+
+// Fetch updates remote-tracking refs and prunes deleted ones so the
+// remote-tracking view is accurate before analysis. Failure is returned to the
+// caller, which may choose to proceed with cached refs.
+func Fetch(localPath string) error {
+	c := exec.Command("git", "fetch", "--prune", "origin")
+	c.Dir = localPath
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("git fetch --prune origin: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// ListMerged returns local (and, when includeRemote is set, remote-tracking)
+// branches that are merged into base. The base branch itself, HEAD, and
+// protected branches are excluded. Results are sorted by LastCommit ascending
+// (oldest first) so the most stale, safest-to-delete branches surface first.
+func ListMerged(localPath, base string, includeRemote bool) ([]Branch, error) {
+	if base == "" {
+		base = "main"
+	}
+
+	var result []Branch
+
+	localOut, err := gitOut(localPath, "for-each-ref", "--merged="+base, "--format="+refFormat, "refs/heads/")
+	if err != nil {
+		return nil, err
+	}
+	for _, b := range parseRefLines(localOut, false) {
+		if IsProtected(b.Name, base) {
+			continue
+		}
+		b.Merged = true
+		result = append(result, b)
+	}
+
+	if includeRemote {
+		remoteOut, err := gitOut(localPath, "for-each-ref", "--merged=origin/"+base, "--format="+refFormat, "refs/remotes/origin/")
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range parseRefLines(remoteOut, true) {
+			if IsProtected(b.Name, base) {
+				continue
+			}
+			b.Merged = true
+			result = append(result, b)
+		}
+	}
+
+	sort.SliceStable(result, func(i, j int) bool {
+		return result[i].LastCommit.Before(result[j].LastCommit)
+	})
+	return result, nil
+}
+
+// DeleteLocal removes a local branch. When force is false it uses `git branch
+// -d` (refuses unmerged branches); force switches to `-D`. Deleting the
+// currently checked-out branch or one held by a worktree fails with git's own
+// error, which is returned verbatim.
+func DeleteLocal(localPath, name string, force bool) error {
+	flag := "-d"
+	if force {
+		flag = "-D"
+	}
+	c := exec.Command("git", "branch", flag, name)
+	c.Dir = localPath
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("git branch %s %s: %w\n%s", flag, name, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/branch/branch_test.go
+++ b/internal/branch/branch_test.go
@@ -1,0 +1,177 @@
+package branch
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRefLines(t *testing.T) {
+	cases := []struct {
+		name     string
+		out      string
+		remote   bool
+		wantLen  int
+		wantName string // expected name of first parsed branch
+		wantTS   bool   // whether first branch has a non-zero timestamp
+	}{
+		{
+			name:     "local with timestamp",
+			out:      "fix/issue-226\x001700000000\n",
+			remote:   false,
+			wantLen:  1,
+			wantName: "fix/issue-226",
+			wantTS:   true,
+		},
+		{
+			name:     "remote prefix stripped",
+			out:      "origin/fix/issue-221\x001699999999\n",
+			remote:   true,
+			wantLen:  1,
+			wantName: "fix/issue-221",
+			wantTS:   true,
+		},
+		{
+			name:     "missing timestamp ok",
+			out:      "feature-x\x00\n",
+			remote:   false,
+			wantLen:  1,
+			wantName: "feature-x",
+			wantTS:   false,
+		},
+		{
+			name:     "blank and whitespace lines skipped",
+			out:      "\n   \nfix/a\x001\n\n",
+			remote:   false,
+			wantLen:  1,
+			wantName: "fix/a",
+			wantTS:   true,
+		},
+		{
+			name:    "empty output",
+			out:     "",
+			remote:  false,
+			wantLen: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseRefLines(tc.out, tc.remote)
+			if len(got) != tc.wantLen {
+				t.Fatalf("got %d branches, want %d (%v)", len(got), tc.wantLen, got)
+			}
+			if tc.wantLen == 0 {
+				return
+			}
+			if tc.wantName != "" && got[0].Name != tc.wantName {
+				t.Errorf("name = %q, want %q", got[0].Name, tc.wantName)
+			}
+			if got[0].Remote != tc.remote {
+				t.Errorf("remote = %v, want %v", got[0].Remote, tc.remote)
+			}
+			if hasTS := !got[0].LastCommit.IsZero(); hasTS != tc.wantTS {
+				t.Errorf("hasTimestamp = %v, want %v", hasTS, tc.wantTS)
+			}
+		})
+	}
+}
+
+func TestIsProtected(t *testing.T) {
+	cases := []struct {
+		name string
+		base string
+		want bool
+	}{
+		{"main", "main", true},
+		{"master", "main", true},
+		{"develop", "main", true},
+		{"HEAD", "main", true},
+		{"", "main", true},
+		{"origin", "main", true},
+		{"main", "develop", true},    // base differs but main still protected
+		{"develop", "develop", true}, // base itself protected
+		{"fix/issue-226", "main", false},
+		{"feature-x", "main", false},
+	}
+	for _, tc := range cases {
+		if got := IsProtected(tc.name, tc.base); got != tc.want {
+			t.Errorf("IsProtected(%q, %q) = %v, want %v", tc.name, tc.base, got, tc.want)
+		}
+	}
+}
+
+// TestListMergedIntegration builds a throwaway git repo, merges one branch and
+// leaves another unmerged, and asserts ListMerged reports only the merged one
+// (and never the base branch). git is available in CI per project SOP.
+func TestListMergedIntegration(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		c.Env = append(c.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	run("init", "-b", "main")
+	write("a.txt", "1")
+	run("add", ".")
+	run("commit", "-m", "init")
+
+	// merged-branch: commit then merge back into main (creates ancestry).
+	run("checkout", "-b", "merged-branch")
+	write("b.txt", "2")
+	run("add", ".")
+	run("commit", "-m", "feature")
+	run("checkout", "main")
+	run("merge", "--no-ff", "-m", "merge feature", "merged-branch")
+
+	// unmerged-branch: a commit that never lands on main.
+	run("checkout", "-b", "unmerged-branch")
+	write("c.txt", "3")
+	run("add", ".")
+	run("commit", "-m", "wip")
+	run("checkout", "main")
+
+	got, err := ListMerged(dir, "main", false)
+	if err != nil {
+		t.Fatalf("ListMerged: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, b := range got {
+		names[b.Name] = true
+		if b.Remote {
+			t.Errorf("unexpected remote branch %q for local-only list", b.Name)
+		}
+		if b.LastCommit.IsZero() {
+			t.Errorf("branch %q missing LastCommit", b.Name)
+		}
+	}
+	if !names["merged-branch"] {
+		t.Errorf("expected merged-branch to be reported, got %v", names)
+	}
+	if names["unmerged-branch"] {
+		t.Errorf("unmerged-branch should not be reported")
+	}
+	if names["main"] {
+		t.Errorf("base branch main must never be reported")
+	}
+}


### PR DESCRIPTION
Fixes #229

## 变更内容

按 issue 评估建议的 MVP 范围落地：**核心层 `internal/branch` 包 + CLI `clawflow branch list|delete`**（默认 dry-run + `--yes` 确认）。Pilot duty 与 web UI 留作后续增量。

### 核心层 `internal/branch`
- `ListMerged(localPath, base, includeRemote)`：基于本地 clone 的 `git for-each-ref --merged=<commit>` 做祖先合并判定，枚举本地分支（`refs/heads/`）与 remote-tracking 分支（`refs/remotes/origin/`），带最后提交时间，按最旧优先排序。
- `Fetch`：`git fetch --prune` 刷新 remote-tracking 视图。
- `DeleteLocal`：`git branch -d/-D`。
- `IsProtected`：`main`/`master`/`develop`/`HEAD` 及 base 分支永不删除。

### CLI
- `clawflow branch list --repo owner/repo [--remote] [--no-fetch]`：只读列出可清理分支（SCOPE/BRANCH/MERGED/LAST COMMIT 表格）。
- `clawflow branch delete --repo owner/repo`：**默认 dry-run 预览**，需 `--yes` 才真正删除。支持 `--remote`（经现有 VCS API `DeleteBranch` 删远程）、`--force`（`-D`）、`--stale N`（仅删 N 天前的分支）、`--no-fetch`。

复用 `clone.EnsureLocalClone` 解析本地路径、`internal/vcs` 现有 `DeleteBranch`，沿用 `worktree.go` 的 `exec.Command("git", ...)` 范式，不新增 VCS 接口方法。

## 测试
- `internal/branch`：单元测试覆盖 `parseRefLines`（NUL 分隔解析、origin/ 前缀剥离、缺失时间戳、空白行跳过）与 `IsProtected`；新增真实临时 git 仓库的集成测试，验证已合并分支被识别、未合并分支与 base 分支不被识别。`go test ./internal/branch/...` 全绿。
- `go test ./cmd/clawflow/commands/...` 全绿；`go build ./...` 通过；CLI `--help` 输出已人工核对。
- 注：完整 build 依赖 `web/dist`（前端 `pnpm build` 产物），本次未触及前端。

## 已知限制
- **squash-merge / rebase-merge 的分支不会被识别为已合并**——它们与 base tip 无祖先关系，单靠 `git for-each-ref --merged` 会漏判。精确识别需结合平台已合并 PR 列表，留作后续增量（评估的 Risks 一节已点明）。
- 删除当前 checkout 分支或被 worktree 占用的分支会被 git 拒绝，错误会原样上报、不中断其余删除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)