### PR TITLE
fix(web): Issue digest 摘要按 markdown 渲染，折叠残留硬换行

### DIFF
--- a/web/src/routes/_app.projects.$name.tsx
+++ b/web/src/routes/_app.projects.$name.tsx
@@ -972,9 +972,14 @@ function ProjectDetail() {
                       </span>
                     </div>
                     {latestWakeWithDuties.duties.issue_digest.summary && (
-                      <div className="text-xs text-foreground/85 whitespace-pre-wrap leading-relaxed">
+                      // Render through Markdown so a single `\n` collapses to a
+                      // soft wrap (space) and the prose reflows to the container
+                      // width, instead of `whitespace-pre-wrap` faithfully
+                      // displaying every stray hard newline left over from
+                      // terminal-column wrapping. See issue #231.
+                      <Markdown className="text-xs text-foreground/85">
                         {latestWakeWithDuties.duties.issue_digest.summary}
-                      </div>
+                      </Markdown>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
Fixes #231

## 问题
Issue digest 面板用 `whitespace-pre-wrap` 渲染 Pilot 生成的 `summary` 纯文本，会原样保留并显示文本里每个 `\n`。当摘要含终端列宽排版残留的硬换行时，正文在约 40 中文字符 / 80 列处硬断行，不按容器宽度 reflow。

## 修复
将 `web/src/routes/_app.projects.$name.tsx` 中摘要的渲染节点从 `<div whitespace-pre-wrap>` 改为复用现有的 `Markdown` 组件（`react-markdown` + `remark-gfm`，已在文件顶部 import）。`react-markdown` 默认把单个 `\n` 折叠为软换行（空格），只有空行才分段，文本按容器宽度重排——符合 issue 期望的 markdown 规则；同时还能正确渲染摘要里可能出现的列表/强调。

采用评估建议的方案 A（复用组件，无新依赖）。数据侧（Pilot digest 生成）未改动：前端归一化已根治该现象，且无法保证 LLM 不再输出换行，前端是正确的根治点。

## 测试
- `npm run typecheck`（`tsc --noEmit`）通过
- `npm run build`（`vite build` + `tsc --noEmit`）通过

注：web/ 当前无单元测试框架（package.json scripts 仅 dev/build/preview/typecheck），故未新增单测。视觉验证需在 `clawflow web` 下打开含残留 `\n` 的 Pilot wake 项目详情页确认，留待人工复核。

🤖 Generated with [Claude Code](https://claude.com/claude-code)