### PR TITLE
feat(web): real-time operator stage transitions on dashboard

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -795,12 +795,29 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		IssueState:  j.sub.State,
 		StartedAt:   startedAt.UTC(),
 		Status:      "running",
+		Stage:       "lock-acquired",
 	}
 	if err := snapshot.WriteRunMeta(runDir, runningMeta); err != nil {
 		fmt.Fprintf(os.Stderr, "%s ✗ initial run meta: %v\n", prefix, err)
 	}
 	if _, err := snapshot.WriteRunsIndex(50); err != nil {
 		fmt.Fprintf(os.Stderr, "%s ⚠ snapshot runs index (running): %v\n", prefix, err)
+	}
+
+	// emitStage persists a fine-grained lifecycle transition while the run is
+	// still in flight: it advances runningMeta.Stage and rewrites BOTH meta.json
+	// AND runs.json. Rewriting runs.json on every stage is the crux of issue
+	// #199 — the dashboard polls runs.json (not meta.json), so without this the
+	// frontend was frozen on the start-of-run snapshot and intermediate stages
+	// were invisible. Status stays "running" throughout; Stage is advisory.
+	emitStage := func(stage string) {
+		runningMeta.Stage = stage
+		if err := snapshot.WriteRunMeta(runDir, runningMeta); err != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ stage meta (%s): %v\n", prefix, stage, err)
+		}
+		if _, err := snapshot.WriteRunsIndex(50); err != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ snapshot runs index (%s): %v\n", prefix, stage, err)
+		}
 	}
 
 	// Fetch comments before resolveWorkdir so we can parse the
@@ -889,6 +906,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		EventWriter:   eventsFile,
 		ResumeContext: resumeCtx,
 		Language:      j.language,
+		StageFunc:     emitStage,
 	})
 	runDur := time.Since(runStart).Round(time.Second)
 	if eventsFile != nil {
@@ -911,6 +929,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 			IssueState:  j.sub.State,
 			StartedAt:   startedAt.UTC(),
 			Status:      "finalizing",
+			Stage:       "finalizing",
 			Summary:     output,
 		}
 		if err := snapshot.WriteRunMeta(runDir, finalizingMeta); err != nil {

--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -244,6 +244,7 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/labels/remove", api.HandleRemoveLabel)
 			mux.HandleFunc("/api/run", api.HandleRun)
 			mux.HandleFunc("/api/run/status", api.HandleRunStatus)
+			mux.HandleFunc("/api/run/stream", api.HandleRunStream)
 			mux.HandleFunc("/api/run/pause", api.HandleRunPause)
 			mux.HandleFunc("/api/run/cancel", api.HandleRunCancel)
 			mux.HandleFunc("/api/version", api.HandleVersion)

--- a/internal/api/run_stream.go
+++ b/internal/api/run_stream.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+)
+
+// streamPollInterval is how often HandleRunStream re-reads runs.json to detect
+// changes. Declared as a var so tests can shrink it. 1s gives sub-second-feel
+// latency for the dashboard while keeping disk reads cheap (the file is a few
+// KB and only re-emitted when its bytes actually change).
+var streamPollInterval = time.Second
+
+// streamHeartbeatEvery controls how often an SSE comment ping is sent when the
+// data is unchanged, so idle connections survive proxy/idle timeouts.
+var streamHeartbeatEvery = 15 * time.Second
+
+// HandleRunStream is a Server-Sent Events endpoint (`GET /api/run/stream`) that
+// pushes the current runs index to the dashboard whenever it changes, so the
+// operator-status page reflects lifecycle stage transitions in real time
+// without manual refresh (issue #199).
+//
+// Cross-process design: `clawflow run` is a SEPARATE process from `clawflow
+// web` and communicates run state only through `~/.clawflow/data/runs.json`
+// (rewritten on every lifecycle stage — see cmd/clawflow/commands/run.go). The
+// web process therefore observes progress by polling that file on the server
+// side and fanning each change out to connected browsers over one long-lived
+// SSE stream. This needs no new dependency (no fsnotify) and is naturally
+// compatible with standalone runs: when no web server is up, nobody watches and
+// the next `clawflow web` simply reads the final runs.json.
+//
+// The browser keeps its existing JSON polling as a graceful fallback, so a
+// dropped stream never blanks the dashboard.
+func HandleRunStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// Disable proxy buffering (nginx) so frames flush immediately.
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	runsPath := filepath.Join(snapshot.DataDir(), "runs.json")
+	ctx := r.Context()
+
+	var last []byte
+	// send re-reads runs.json and emits a frame only when the compacted bytes
+	// changed. Returns true if a data frame was written.
+	send := func() bool {
+		data, err := readRunsCompact(runsPath)
+		if err != nil || bytes.Equal(data, last) {
+			return false
+		}
+		last = data
+		// Compacted to a single line, so a one-line SSE `data:` frame is safe.
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+		return true
+	}
+
+	// Emit the current snapshot immediately so a fresh connection paints right
+	// away instead of waiting for the first change.
+	send()
+
+	poll := time.NewTicker(streamPollInterval)
+	defer poll.Stop()
+	lastBeat := time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-poll.C:
+			if send() {
+				lastBeat = now
+				continue
+			}
+			// No change: keep the connection warm with a comment ping.
+			if now.Sub(lastBeat) >= streamHeartbeatEvery {
+				fmt.Fprint(w, ": ping\n\n")
+				flusher.Flush()
+				lastBeat = now
+			}
+		}
+	}
+}
+
+// readRunsCompact reads runs.json and returns its JSON compacted onto a single
+// line (no embedded newlines), which keeps the SSE `data:` framing trivial. A
+// missing file yields an empty JSON array so the stream still emits a valid
+// initial frame before any run exists.
+func readRunsCompact(path string) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return []byte("[]"), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		// Malformed/partial read (e.g. mid-rename) — skip this tick rather
+		// than push a broken frame; the next poll will pick up clean bytes.
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/api/run_stream_test.go
+++ b/internal/api/run_stream_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+)
+
+// plantRuns writes a runs.json under the (HOME-rooted) data dir so the stream
+// handler has something to emit.
+func plantRuns(t *testing.T, body string) {
+	t.Helper()
+	path := filepath.Join(snapshot.DataDir(), "runs.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir data dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write runs.json: %v", err)
+	}
+}
+
+// readFirstDataFrame reads SSE lines until the first `data:` payload, returning
+// the payload (without the prefix). Fails the test if the stream ends first.
+func readFirstDataFrame(t *testing.T, r *bufio.Reader) string {
+	t.Helper()
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read SSE stream: %v (last line %q)", err, line)
+		}
+		if strings.HasPrefix(line, "data: ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "data: "))
+		}
+	}
+}
+
+func TestRunStream_EmitsInitialSnapshot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	plantRuns(t, `[{"operator":"classify","status":"running","stage":"claude-started"}]`)
+
+	srv := httptest.NewServer(http.HandlerFunc(HandleRunStream))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	frame := readFirstDataFrame(t, bufio.NewReader(resp.Body))
+	if !strings.Contains(frame, "claude-started") {
+		t.Errorf("initial frame missing stage; got %q", frame)
+	}
+	if !strings.Contains(frame, "classify") {
+		t.Errorf("initial frame missing operator; got %q", frame)
+	}
+	// Compacted to a single line — no embedded newline should reach the client.
+	if strings.Contains(frame, "\n") {
+		t.Errorf("frame should be single-line JSON, got %q", frame)
+	}
+}
+
+func TestRunStream_PushesOnChange(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	plantRuns(t, `[{"operator":"classify","status":"running","stage":"lock-acquired"}]`)
+
+	// Speed up the poll so the test doesn't wait a full second per tick.
+	prev := streamPollInterval
+	streamPollInterval = 20 * time.Millisecond
+	defer func() { streamPollInterval = prev }()
+
+	srv := httptest.NewServer(http.HandlerFunc(HandleRunStream))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+	reader := bufio.NewReader(resp.Body)
+
+	// First frame = initial snapshot.
+	first := readFirstDataFrame(t, reader)
+	if !strings.Contains(first, "lock-acquired") {
+		t.Fatalf("first frame = %q, want lock-acquired", first)
+	}
+
+	// Advance the run's stage on disk; the handler should push a new frame.
+	plantRuns(t, `[{"operator":"classify","status":"running","stage":"applying-label"}]`)
+	second := readFirstDataFrame(t, reader)
+	if !strings.Contains(second, "applying-label") {
+		t.Errorf("second frame = %q, want applying-label", second)
+	}
+}
+
+func TestRunStream_MethodNotAllowed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	req := httptest.NewRequest(http.MethodPost, "/api/run/stream", nil)
+	rr := httptest.NewRecorder()
+	HandleRunStream(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rr.Code)
+	}
+}
+
+func TestRunStream_MissingFileYieldsEmptyArray(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// No runs.json planted — readRunsCompact must yield "[]" rather than error.
+	got, err := readRunsCompact(filepath.Join(snapshot.DataDir(), "runs.json"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "[]" {
+		t.Errorf("got %q, want []", string(got))
+	}
+}

--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -12,6 +12,18 @@ import (
 	"time"
 )
 
+// Lifecycle stages emitted via RunOptions.StageFunc as Run progresses. These
+// are fine-grained, observable phases WITHIN the runner's coarse "running"
+// status — they let the dashboard surface intermediate progress instead of a
+// frozen start-of-run snapshot (issue #199). Kept as exported consts so the
+// caller (cmd/clawflow/commands/run.go) and tests share one source of truth.
+const (
+	StageClaudeStarted  = "claude-started"
+	StageParsingOutcome = "parsing-outcome"
+	StagePostingComment = "posting-comment"
+	StageApplyingLabel  = "applying-label"
+)
+
 // ErrNoOutcomeMarker is returned by Run when claude produced non-empty output
 // but the output contained no <!-- clawflow:outcome=… --> marker. This is
 // treated as a recoverable failure (not a permanent one) so the circuit
@@ -107,6 +119,21 @@ type RunOptions struct {
 	// RunClaude; tests inject a fake that returns canned output without
 	// spawning a process.
 	RunFunc func(ctx context.Context, prompt, workdir string, timeout time.Duration, events io.Writer, role string, systemPrompt ...string) (string, error)
+
+	// StageFunc, if non-nil, is invoked at each lifecycle transition with a
+	// Stage* constant so the caller can persist intermediate progress (e.g.
+	// rewrite meta.json + runs.json for the dashboard). It runs synchronously
+	// on the runner's goroutine, so callers should keep it cheap and must not
+	// block. Nil is the common case for tests and non-dashboard callers.
+	StageFunc func(stage string)
+}
+
+// emitStage safely invokes a (possibly nil) stage callback. Centralizing the
+// nil-check keeps the call sites in Run/runWriteBack uncluttered.
+func emitStage(fn func(string), stage string) {
+	if fn != nil {
+		fn(stage)
+	}
 }
 
 // writeBackTimeout is the maximum time allowed for the post-claude VCS
@@ -132,6 +159,7 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 	if runFunc == nil {
 		runFunc = RunClaude
 	}
+	emitStage(opts.StageFunc, StageClaudeStarted)
 	output, err := runFunc(ctx, userMessage, opts.Workdir, opts.Timeout, opts.EventWriter, opts.Role, systemPrompt)
 	if err != nil {
 		// Failure path: do NOT pollute the issue with a comment. The
@@ -150,6 +178,7 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 		return trimmed, "", nil
 	}
 
+	emitStage(opts.StageFunc, StageParsingOutcome)
 	outcome, body := parseOutcome(trimmed)
 
 	// Guard: if the operator produced output but no outcome marker, the model
@@ -187,6 +216,9 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 		done <- runWriteBack(v, op, sub, opts, body, outcome)
 	}()
 
+	// Note: the write-back stages (posting-comment / applying-label) are
+	// emitted from inside runWriteBack so they reflect the actual VCS calls.
+
 	select {
 	case err := <-done:
 		if err != nil {
@@ -205,6 +237,7 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 // via a goroutine in Run.
 func runWriteBack(v VCS, op *Operator, sub *Subject, opts RunOptions, body, outcome string) error {
 	if body != "" {
+		emitStage(opts.StageFunc, StagePostingComment)
 		if err := v.PostIssueComment(opts.Repo, sub.Number, body); err != nil {
 			return fmt.Errorf("post result comment: %w", err)
 		}
@@ -212,6 +245,7 @@ func runWriteBack(v VCS, op *Operator, sub *Subject, opts RunOptions, body, outc
 	}
 
 	if outcome != "" {
+		emitStage(opts.StageFunc, StageApplyingLabel)
 		if !outcomeAllowed(op, outcome) {
 			fmt.Fprintf(os.Stderr,
 				"  ⚠ operator %q produced disallowed outcome %q (allowed: %v); skipping label add\n",

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -157,6 +157,68 @@ func TestRun_ClaudeFails_NoIssuePollution(t *testing.T) {
 	}
 }
 
+// TestRun_StageFunc_EmitsLifecycleStages locks the issue #199 contract: as Run
+// progresses through a successful operator invocation, StageFunc is invoked in
+// order with the fine-grained lifecycle markers. These feed the runner's
+// meta.json + runs.json rewrites that let the dashboard show intermediate
+// progress instead of a frozen start-of-run snapshot.
+func TestRun_StageFunc_EmitsLifecycleStages(t *testing.T) {
+	op := &Operator{
+		Name:      "test-op",
+		LockLabel: "agent-running",
+		Prompt:    "do the thing",
+		Outcomes:  []string{"agent-evaluated"},
+	}
+	sub := &Subject{Number: 7, Labels: []string{"bug"}}
+	v := newFakeVCS()
+
+	var stages []string
+	_, outcome, err := Run(context.Background(), op, sub, v, RunOptions{
+		Repo:    "acme/webapp",
+		Workdir: t.TempDir(),
+		Timeout: time.Second,
+		RunFunc: func(context.Context, string, string, time.Duration, io.Writer, string, ...string) (string, error) {
+			return "done\n<!-- clawflow:outcome=agent-evaluated -->", nil
+		},
+		StageFunc: func(s string) { stages = append(stages, s) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome != "agent-evaluated" {
+		t.Fatalf("outcome = %q, want agent-evaluated", outcome)
+	}
+
+	want := []string{
+		StageClaudeStarted,
+		StageParsingOutcome,
+		StagePostingComment,
+		StageApplyingLabel,
+	}
+	if !slices.Equal(stages, want) {
+		t.Errorf("stage sequence = %v, want %v", stages, want)
+	}
+}
+
+// TestRun_NilStageFunc_NoPanic confirms the nil callback (tests / non-dashboard
+// callers) is handled gracefully — emitStage must be a no-op, not a panic.
+func TestRun_NilStageFunc_NoPanic(t *testing.T) {
+	op := &Operator{Name: "x", LockLabel: "l", Prompt: "p", Outcomes: []string{"done"}}
+	sub := &Subject{Number: 1, Labels: []string{"bug"}}
+	v := newFakeVCS()
+
+	_, _, err := Run(context.Background(), op, sub, v, RunOptions{
+		Repo: "r",
+		RunFunc: func(context.Context, string, string, time.Duration, io.Writer, string, ...string) (string, error) {
+			return "ok\n<!-- clawflow:outcome=done -->", nil
+		},
+		// StageFunc intentionally left nil.
+	})
+	if err != nil {
+		t.Fatalf("unexpected error with nil StageFunc: %v", err)
+	}
+}
+
 func TestRun_EmptyClaudeOutput_NoComment(t *testing.T) {
 	op := &Operator{Name: "x", LockLabel: "running", Prompt: "p"}
 	sub := &Subject{Number: 1, Labels: []string{"bug"}}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -253,6 +253,14 @@ type RunMeta struct {
 	// the issue stays unlabeled and the circuit breaker counts this run.
 	// "skipped-empty" means claude produced empty output; same treatment.
 	Status  string `json:"status"`
+	// Stage is the fine-grained lifecycle phase WITHIN the coarse Status.
+	// While Status=="running" it advances through the operator lifecycle so
+	// the dashboard can show intermediate progress instead of a frozen
+	// start-of-run snapshot: "lock-acquired" → "claude-started" →
+	// "parsing-outcome" → "posting-comment" → "applying-label". It is purely
+	// advisory (the reconciler and circuit breaker key off Status, not Stage)
+	// and omitted from the wire when empty for back-compat with older runs.
+	Stage   string `json:"stage,omitempty"`
 	PRUrl   string `json:"pr_url,omitempty"`
 	Error   string `json:"error,omitempty"`
 	Summary string `json:"summary,omitempty"` // operator's final text output

--- a/web/src/routes/_app.dashboard.tsx
+++ b/web/src/routes/_app.dashboard.tsx
@@ -33,6 +33,9 @@ interface Run {
   started_at: string
   ended_at?: string
   status: 'success' | 'failed' | 'skipped' | 'running' | 'cancelled' | 'no-marker' | 'skipped-empty'
+  /** fine-grained lifecycle phase while status === 'running' (issue #199):
+   *  lock-acquired → claude-started → parsing-outcome → posting-comment → applying-label */
+  stage?: string
   summary?: string
   pr_url?: string
   error?: string
@@ -98,6 +101,18 @@ type ViewMode = 'run' | 'issue'
 /** Ordered list of known pipeline stages for badge display. Unknown operators
  *  are appended after these in discovery order. */
 const KNOWN_STAGES = ['classify', 'implement', 'evaluate-feat', 'evaluate-bug', 'reply-comment', 'decompose']
+
+/** Ordered lifecycle phases an operator passes through WHILE running (issue
+ *  #199). Distinct from KNOWN_STAGES (which lists *which operators* ran on an
+ *  issue) — this is the intra-run progress of a single operator, surfaced as a
+ *  stepper on live rows. `key` matches RunMeta.Stage emitted by the runner. */
+const LIFECYCLE_STAGES: { key: string; label: string }[] = [
+  { key: 'lock-acquired', label: 'lock' },
+  { key: 'claude-started', label: 'claude' },
+  { key: 'parsing-outcome', label: 'parse' },
+  { key: 'posting-comment', label: 'comment' },
+  { key: 'applying-label', label: 'label' },
+]
 
 interface IssueGroup {
   key: string       // `${repo}#${issueNumber}`
@@ -298,6 +313,33 @@ function Dashboard() {
       clearInterval(id)
     }
   }, [refreshTick])
+
+  // Real-time runs stream (issue #199). The server pushes the runs index over
+  // SSE whenever it changes — including mid-run lifecycle stage transitions —
+  // so the operator-status view updates without manual refresh and at far lower
+  // latency than the 5s poll above. The poll is intentionally KEPT as a
+  // graceful fallback: EventSource auto-reconnects on drop, and if SSE is
+  // unavailable entirely the dashboard still refreshes every 5s.
+  useEffect(() => {
+    if (typeof EventSource === 'undefined') return
+    let es: EventSource | null = null
+    try {
+      es = new EventSource('/api/run/stream')
+      es.onmessage = e => {
+        try {
+          const parsed = JSON.parse(e.data)
+          if (Array.isArray(parsed)) setRuns(parsed)
+        } catch {
+          /* ignore a malformed frame; next frame or the poll recovers */
+        }
+      }
+      // onerror: EventSource reconnects on its own; the 5s poll covers the gap.
+      es.onerror = () => {}
+    } catch {
+      /* SSE construction failed; polling fallback already covers updates */
+    }
+    return () => es?.close()
+  }, [])
 
   // Poll run status — also picks up the auto-run scheduler state
   // (interval, paused, next fire time) so we render everything in one
@@ -1140,6 +1182,38 @@ function IssueGroupRow({
   )
 }
 
+/** Live lifecycle stepper for a running operator (issue #199). Renders the
+ *  ordered LIFECYCLE_STAGES as dots: completed stages filled, the current one
+ *  pulsing, the rest dimmed — so the user sees intra-run progress instead of a
+ *  frozen "running" badge. Falls back to the first stage when `stage` is unset
+ *  (older runs / pre-claude window). */
+function StageStepper({ stage }: { stage?: string }) {
+  const idx = stage ? LIFECYCLE_STAGES.findIndex(s => s.key === stage) : -1
+  const current = idx < 0 ? 0 : idx
+  const label = LIFECYCLE_STAGES[current]?.label ?? ''
+  return (
+    <div
+      className="hidden md:flex items-center gap-1 shrink-0"
+      title={stage ? `stage: ${stage}` : 'starting…'}
+    >
+      {LIFECYCLE_STAGES.map((s, i) => (
+        <span
+          key={s.key}
+          className={cn(
+            'h-1.5 w-1.5 rounded-full transition-colors',
+            i < current
+              ? 'bg-blue-400'
+              : i === current
+                ? 'bg-blue-600 animate-pulse'
+                : 'bg-muted-foreground/25',
+          )}
+        />
+      ))}
+      <span className="text-[10px] text-blue-600 ml-1 font-mono">{label}</span>
+    </div>
+  )
+}
+
 function Row({
   r,
   repoMap,
@@ -1170,6 +1244,7 @@ function Row({
         <span className="text-sm text-foreground truncate flex-1" title={`${r.operator} · ${r.issue_title || '(no title)'}`}>
           {r.operator} · {r.issue_title || '(no title)'}
         </span>
+        {r.status === 'running' && <StageStepper stage={r.stage} />}
         {dur && <span className="text-xs text-muted-foreground shrink-0 tabular-nums w-14 text-right">{dur}</span>}
         <span className="text-xs text-muted-foreground shrink-0 w-16 text-right">{timeAgo(r.started_at)}</span>
         <ChevronRight className="w-4 h-4 text-muted-foreground/40 group-hover:text-muted-foreground shrink-0" />


### PR DESCRIPTION
Fixes #199

## 问题根因
前端轮询的是 `runs.json`，但它只在「运行开始 / 整轮结束 / 每分钟 reconcile」三处重写——算子执行期间 `meta.json` 的状态转换不会触发 `runs.json` 重写，所以中间阶段对前端完全不可见。就算上 SSE，没有中间写盘也没东西可推。

## 改动（三层）
- **数据层**：`RunMeta` 新增 `Stage` 字段；runner 在每次生命周期转换时同时重写 `meta.json` **和** `runs.json`（修根因）。
- **Runner 埋点**：新增 `RunOptions.StageFunc`，在 `lock-acquired → claude-started → parsing-outcome → posting-comment → applying-label` 各点回调。
- **Web SSE 桥**：新增 `GET /api/run/stream`，服务端轮询 `runs.json` 变化并通过 SSE fan-out 给浏览器。**无新依赖**（不引入 fsnotify），对 standalone `clawflow run` 天然兼容（无 web 进程则无人监听）。
- **前端**：`_app.dashboard.tsx` 用 `EventSource` 订阅实时更新 runs，**保留 5s 轮询作为优雅降级**；运行中行新增生命周期 stepper UI 展示完整阶段流转。

## 验收对照
1. ✅ 执行期间无需手动刷新即可看到阶段从 lock-acquired 流转到 success
2. ✅ 完整展示中间阶段（stepper），不只是首尾
3. ✅ SSE 断开时 EventSource 自动重连 + 5s 轮询兜底，不白屏
4. ✅ standalone run 不报错、不依赖 web 进程
5. ✅ 附带测试

## 测试
- `internal/operator`：阶段序列断言 + nil 回调不 panic
- `internal/api`：SSE 初始快照 / 变更推送 / 方法校验 / 缺文件回退（均经 `httptest.NewServer` 真实 HTTP）
- `go test ./...` 全绿；前端 `pnpm build`（vite + `tsc --noEmit`）通过

## 未覆盖
未做完整 `clawflow web` 浏览器实机走查（需本地配置 + 占端口）；SSE 端点已由 httptest 真实 HTTP 测试覆盖，前端经 tsc 类型检查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)