### PR TITLE
feat: support --image attachments on issue create/comment

### DIFF
--- a/cmd/clawflow/commands/issue.go
+++ b/cmd/clawflow/commands/issue.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -158,8 +160,48 @@ func printSearchHits(hits []searchHit, jsonOutput bool, query string) error {
 	return nil
 }
 
+// imageExts is the set of attachment extensions accepted by --image.
+var imageExts = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+}
+
+// appendImageMarkdown validates each --image path, uploads it via the VCS
+// client, and appends the returned image markdown to body. On any failure
+// (missing file, unsupported type, upload error) it aborts and returns the
+// error rather than silently degrading to text-only — so the user never
+// believes an image was attached when it wasn't. GitHub returns
+// vcs.ErrNotSupported (no public attachment API); that is wrapped into a
+// friendly hint pointing users to the web UI.
+func appendImageMarkdown(client vcs.Client, repo, body string, images []string) (string, error) {
+	for _, img := range images {
+		ext := strings.ToLower(filepath.Ext(img))
+		if !imageExts[ext] {
+			return "", fmt.Errorf("unsupported image type %q (supported: png, jpg, jpeg, gif): %s", ext, img)
+		}
+		if fi, err := os.Stat(img); err != nil {
+			return "", fmt.Errorf("cannot read image %q: %w", img, err)
+		} else if fi.IsDir() {
+			return "", fmt.Errorf("image path %q is a directory", img)
+		}
+		md, err := client.UploadAttachment(repo, img)
+		if err != nil {
+			if errors.Is(err, vcs.ErrNotSupported) {
+				return "", fmt.Errorf("GitHub does not support CLI image attachments — paste the image in the web UI instead (file: %s)", img)
+			}
+			return "", fmt.Errorf("upload image %q: %w", img, err)
+		}
+		if body == "" {
+			body = md
+		} else {
+			body = body + "\n\n" + md
+		}
+	}
+	return body, nil
+}
+
 func newIssueCreateCmd() *cobra.Command {
 	var repo, title, body string
+	var images []string
 
 	cmd := &cobra.Command{
 		Use:     "create",
@@ -167,6 +209,10 @@ func newIssueCreateCmd() *cobra.Command {
 		Example: "  clawflow issue create --repo owner/repo --title \"bug: something broken\" --body \"details...\"",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _, err := newVCSClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			body, err = appendImageMarkdown(client, repo, body, images)
 			if err != nil {
 				return err
 			}
@@ -181,6 +227,7 @@ func newIssueCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
 	cmd.Flags().StringVar(&title, "title", "", "issue title (required)")
 	cmd.Flags().StringVar(&body, "body", "", "issue body")
+	cmd.Flags().StringArrayVar(&images, "image", nil, "local image to attach (png/jpg/jpeg/gif; repeatable; GitLab only)")
 	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("title")
 	return cmd
@@ -286,13 +333,18 @@ func newIssueListCmd() *cobra.Command {
 func newIssueCommentCmd() *cobra.Command {
 	var repo, body string
 	var issue int
+	var images []string
 
 	cmd := &cobra.Command{
 		Use:     "comment",
 		Short:   "Post a comment on an issue",
-		Example: "  clawflow issue comment --repo owner/repo --issue 7 --body \"looks good\"",
+		Example: "  clawflow issue comment --repo owner/repo --issue 7 --body \"looks good\"\n  clawflow issue comment --repo owner/repo --issue 7 --body \"see screenshot\" --image bug.png",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _, err := newVCSClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			body, err = appendImageMarkdown(client, repo, body, images)
 			if err != nil {
 				return err
 			}
@@ -305,10 +357,16 @@ func newIssueCommentCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
 	cmd.Flags().IntVar(&issue, "issue", 0, "issue number (required)")
-	cmd.Flags().StringVar(&body, "body", "", "comment body (required)")
+	cmd.Flags().StringVar(&body, "body", "", "comment body (required unless --image is given)")
+	cmd.Flags().StringArrayVar(&images, "image", nil, "local image to attach (png/jpg/jpeg/gif; repeatable; GitLab only)")
 	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("issue")
-	_ = cmd.MarkFlagRequired("body")
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if body == "" && len(images) == 0 {
+			return fmt.Errorf("at least one of --body or --image is required")
+		}
+		return nil
+	}
 	return cmd
 }
 

--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -975,6 +975,14 @@ func (c *Client) GetIssue(repo string, number int) (*vcs.Issue, error) {
 	return &vcs.Issue{ID: raw.ID, Number: raw.Number, Title: raw.Title, State: raw.State}, nil
 }
 
+// UploadAttachment is not supported on GitHub: the REST API v3 has no public
+// endpoint for uploading issue/comment attachments (the web UI uses an
+// undocumented session-authenticated upload flow that does not accept PAT /
+// Bearer tokens). Callers should fall back to pasting images in the web UI.
+func (c *Client) UploadAttachment(repo string, filePath string) (string, error) {
+	return "", vcs.ErrNotSupported
+}
+
 func splitRepo(repo string) (owner, name string, err error) {
 	parts := strings.SplitN(repo, "/", 2)
 	if len(parts) != 2 {

--- a/internal/vcs/gitlab/client.go
+++ b/internal/vcs/gitlab/client.go
@@ -8,8 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -764,4 +767,67 @@ func (c *Client) ListSubIssues(repo string, issueNumber int) ([]vcs.Issue, error
 
 func (c *Client) GetParentIssue(repo string, issueNumber int) (*vcs.Issue, error) {
 	return nil, vcs.ErrNotSupported
+}
+
+// UploadAttachment uploads a local file to the project's attachment storage via
+// POST /projects/:id/uploads and returns the ready-to-embed markdown GitLab
+// generates (e.g. "![file](/uploads/<hash>/file.png)"). The returned path is
+// project-relative, so it only renders inside issues/comments of the same
+// project — which is the only scope clawflow uses it for.
+func (c *Client) UploadAttachment(repo string, filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open attachment %q: %w", filePath, err)
+	}
+	defer f.Close()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", filepath.Base(filePath))
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(part, f); err != nil {
+		return "", err
+	}
+	if err := mw.Close(); err != nil {
+		return "", err
+	}
+
+	path := fmt.Sprintf("/projects/%s/uploads", projectID(repo))
+	req, err := http.NewRequestWithContext(c.reqContext(), "POST", c.baseURL+path, &buf)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("PRIVATE-TOKEN", c.token)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != 201 && resp.StatusCode != 200 {
+		return "", fmt.Errorf("gitlab upload attachment: HTTP %d: %s", resp.StatusCode, data)
+	}
+	var out struct {
+		Markdown string `json:"markdown"`
+		URL      string `json:"url"`
+		Alt      string `json:"alt"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return "", err
+	}
+	if out.Markdown != "" {
+		return out.Markdown, nil
+	}
+	// Fallback: synthesize markdown if the instance omits the field.
+	if out.URL != "" {
+		return fmt.Sprintf("![%s](%s)", out.Alt, out.URL), nil
+	}
+	return "", fmt.Errorf("gitlab upload attachment: response missing markdown/url: %s", data)
 }

--- a/internal/vcs/gitlab/client_test.go
+++ b/internal/vcs/gitlab/client_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
@@ -229,5 +231,67 @@ func TestInitLabels_SkipsExisting(t *testing.T) {
 	}
 	if len(created) != 1 || created[0] != "new-label" {
 		t.Errorf("expected only 'new-label' created, got %v", created)
+	}
+}
+
+func TestUploadAttachment(t *testing.T) {
+	var gotContentType, gotFormName, gotFileName string
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"POST " + projectPath + "/uploads": func(w http.ResponseWriter, r *http.Request) {
+			gotContentType = r.Header.Get("Content-Type")
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				t.Fatalf("parse multipart: %v", err)
+			}
+			for name, fhs := range r.MultipartForm.File {
+				gotFormName = name
+				if len(fhs) > 0 {
+					gotFileName = fhs[0].Filename
+				}
+			}
+			jsonResp(w, 201, map[string]string{
+				"alt":      "shot",
+				"url":      "/uploads/abc123/shot.png",
+				"markdown": "![shot](/uploads/abc123/shot.png)",
+			})
+		},
+	})
+
+	dir := t.TempDir()
+	imgPath := dir + "/shot.png"
+	if err := os.WriteFile(imgPath, []byte("\x89PNG fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	md, err := client.UploadAttachment("ns/group/repo", imgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if md != "![shot](/uploads/abc123/shot.png)" {
+		t.Errorf("unexpected markdown: %q", md)
+	}
+	if !strings.HasPrefix(gotContentType, "multipart/form-data") {
+		t.Errorf("expected multipart request, got Content-Type %q", gotContentType)
+	}
+	if gotFormName != "file" {
+		t.Errorf("expected form field 'file', got %q", gotFormName)
+	}
+	if gotFileName != "shot.png" {
+		t.Errorf("expected filename 'shot.png', got %q", gotFileName)
+	}
+}
+
+func TestUploadAttachmentServerError(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"POST " + projectPath + "/uploads": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "file too big", http.StatusRequestEntityTooLarge)
+		},
+	})
+	dir := t.TempDir()
+	imgPath := dir + "/big.png"
+	if err := os.WriteFile(imgPath, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.UploadAttachment("ns/group/repo", imgPath); err == nil {
+		t.Fatal("expected error on HTTP 413, got nil")
 	}
 }

--- a/internal/vcs/interface.go
+++ b/internal/vcs/interface.go
@@ -132,6 +132,15 @@ type Client interface {
 	// ErrNotSupported / nil if there is no parent.
 	GetParentIssue(repo string, issueNumber int) (*Issue, error)
 
+	// Attachments (GitLab native; GitHub returns ErrNotSupported).
+	// UploadAttachment uploads the local file at filePath to the repo's
+	// attachment storage and returns the ready-to-embed image markdown
+	// (e.g. "![file](/uploads/<hash>/file.png)"). GitHub has no public
+	// issue-attachment upload API, so its implementation returns
+	// ErrNotSupported — callers should tell the user to paste images via
+	// the web UI.
+	UploadAttachment(repo string, filePath string) (markdown string, err error)
+
 	// Labels
 	GetIssueLabels(repo string, issueNumber int) ([]string, error)
 	AddLabel(repo string, issueNumber int, labels ...string) error


### PR DESCRIPTION
Fixes #232

## 变更内容
为 `clawflow issue create` 与 `issue comment` 增加可重复的 `--image <path>` 参数，支持上传本地截图并自动嵌入正文/评论。

- **接口层** `internal/vcs/interface.go`：新增 `UploadAttachment(repo, filePath) (markdown, error)`，沿用 sub-issues 的平台不对等注释风格。
- **GitLab** `gitlab/client.go`：新增 multipart 请求辅助逻辑，对接 `POST /projects/:id/uploads`，取响应的 `markdown` 字段（缺失时用 `url`/`alt` 兜底合成）。
- **GitHub** `github/client.go`：直接返回 `vcs.ErrNotSupported`（REST v3 无公开 issue 附件 API），复用既有不支持模式。
- **命令层** `cmd/clawflow/commands/issue.go`：新增共享 `appendImageMarkdown` helper——校验文件存在 + 类型（png/jpg/jpeg/gif）→ 逐个上传 → 失败立即中止（不静默降级为纯文本）→ markdown 追加到 body 末尾。GitHub 路径上把 `ErrNotSupported` 包成「请在网页端粘贴图片」的友好提示。`comment` 命令放宽 `--body` 必填：`--body` 或 `--image` 至少有一个即可。

## 决策对齐（见 issue Comment 3）
- 失败语义：中止报错，不降级。
- 类型限制：png/jpg/jpeg/gif；alt text 默认文件名。
- 本期仅 CLI 直用，不动算子 outcome marker 协议。

## 测试
- 新增 `gitlab/client_test.go`：`TestUploadAttachment`（httptest mock uploads 端点，断言 multipart 请求、form 字段名、文件名、markdown 解析）+ `TestUploadAttachmentServerError`（HTTP 413 时报错）。
- `go test ./internal/vcs/... ./cmd/clawflow/commands/...` 全绿，`go vet` 无警告。
- 未在真实 GitLab 实例上端到端验证上传（无测试实例），逻辑以 httptest mock 覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)