### PR TITLE
feat(pm): Project 页面 Pilot 运行时动态状态徽标 (阶段一 MVP)

### DIFF
--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -303,6 +303,7 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/project/automation", api.HandleProjectAutomation)
 			mux.HandleFunc("/api/project/bind", api.HandleProjectBind)
 			mux.HandleFunc("/api/project/pilot/wake", api.HandlePilotWake)
+			mux.HandleFunc("/api/project/pilot/stream", api.HandlePilotStream)
 			mux.HandleFunc("/api/project/get", api.HandleProjectGet)
 			mux.HandleFunc("/api/project/update-doc", api.HandleProjectUpdateDoc)
 			mux.HandleFunc("/api/project/pilot-runs", api.HandleProjectPilotRuns)

--- a/internal/api/pilot_stream.go
+++ b/internal/api/pilot_stream.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+)
+
+// HandlePilotStream is a Server-Sent Events endpoint
+// (`GET /api/project/pilot/stream?project=<name>`) that pushes the latest
+// Pilot wake's meta.json to the project detail page whenever it changes, so
+// the top "Pilot" badge reflects the live `running / done / error` state
+// without manual refresh (issue #240).
+//
+// Design mirrors HandleRunStream exactly: `clawflow pilot wake` runs in a
+// SEPARATE process (inside `clawflow run` or cron) and communicates wake
+// state only through files under `~/.clawflow/data/pilot-runs/<project>/`.
+// The web process therefore observes progress by polling the latest run's
+// meta.json on the server side and fanning each change out over one
+// long-lived SSE stream — no new dependency (no fsnotify) needed.
+//
+// Only the coarse-grained meta.json is streamed (status / started_at /
+// ended_at / error); this MVP deliberately does NOT introduce per-stage
+// events. The browser keeps its existing pilot-runs JSON polling as a
+// graceful fallback, so a dropped stream never blanks the badge.
+func HandlePilotStream(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	project := strings.TrimSpace(r.URL.Query().Get("project"))
+	if project == "" {
+		http.Error(w, "project is required", http.StatusBadRequest)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	// Disable proxy buffering (nginx) so frames flush immediately.
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ctx := r.Context()
+
+	var last []byte
+	// send re-reads the latest pilot meta.json and emits a frame only when the
+	// compacted bytes changed. Returns true if a data frame was written.
+	send := func() bool {
+		data, err := readLatestPilotMetaCompact(project)
+		if err != nil || bytes.Equal(data, last) {
+			return false
+		}
+		last = data
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+		return true
+	}
+
+	// Emit the current snapshot immediately so a fresh connection paints right
+	// away instead of waiting for the first change.
+	send()
+
+	poll := time.NewTicker(streamPollInterval)
+	defer poll.Stop()
+	lastBeat := time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-poll.C:
+			if send() {
+				lastBeat = now
+				continue
+			}
+			// No change: keep the connection warm with a comment ping.
+			if now.Sub(lastBeat) >= streamHeartbeatEvery {
+				fmt.Fprint(w, ": ping\n\n")
+				flusher.Flush()
+				lastBeat = now
+			}
+		}
+	}
+}
+
+// readLatestPilotMetaCompact reads the most recent Pilot run's meta.json for a
+// project and returns its JSON compacted onto a single line (keeping the SSE
+// `data:` framing trivial). When no wake has happened yet it yields the JSON
+// literal `null` so the stream still emits a valid initial frame and the
+// client can distinguish "no runs" from a parse failure.
+func readLatestPilotMetaCompact(project string) ([]byte, error) {
+	path := snapshot.LatestPilotRunMetaPath(project)
+	if path == "" {
+		return []byte("null"), nil
+	}
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return []byte("null"), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		// Malformed/partial read (e.g. mid-write) — skip this tick rather
+		// than push a broken frame; the next poll picks up clean bytes.
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/api/pilot_stream_test.go
+++ b/internal/api/pilot_stream_test.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+)
+
+// plantPilotMeta writes a meta.json for a single Pilot run under
+// data/pilot-runs/<project>/<stamp>/. stamp must be the UTC-timestamp format
+// PilotRunDir uses so lexical ordering matches chronological ordering.
+func plantPilotMeta(t *testing.T, project, stamp, body string) {
+	t.Helper()
+	dir := filepath.Join(snapshot.DataDir(), "pilot-runs", project, stamp)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir pilot run dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write meta.json: %v", err)
+	}
+}
+
+func TestPilotStream_EmitsInitialSnapshot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	plantPilotMeta(t, "demo", "2026-06-01T17-14-55Z",
+		`{"project":"demo","status":"running","started_at":"2026-06-01T17:14:55Z"}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(HandlePilotStream))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"?project=demo", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Fatalf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	frame := readFirstDataFrame(t, bufio.NewReader(resp.Body))
+	if !strings.Contains(frame, `"running"`) {
+		t.Errorf("initial frame missing running status; got %q", frame)
+	}
+	if strings.Contains(frame, "\n") {
+		t.Errorf("frame should be single-line JSON, got %q", frame)
+	}
+}
+
+func TestPilotStream_PushesOnChange(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stamp := "2026-06-01T17-14-55Z"
+	plantPilotMeta(t, "demo", stamp,
+		`{"project":"demo","status":"running","started_at":"2026-06-01T17:14:55Z"}`)
+
+	prev := streamPollInterval
+	streamPollInterval = 20 * time.Millisecond
+	defer func() { streamPollInterval = prev }()
+
+	srv := httptest.NewServer(http.HandlerFunc(HandlePilotStream))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"?project=demo", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer resp.Body.Close()
+	reader := bufio.NewReader(resp.Body)
+
+	first := readFirstDataFrame(t, reader)
+	if !strings.Contains(first, `"running"`) {
+		t.Fatalf("first frame = %q, want running", first)
+	}
+
+	// The wake finishes: meta.json for the SAME run is rewritten with the
+	// terminal status. The handler should push the new frame.
+	plantPilotMeta(t, "demo", stamp,
+		`{"project":"demo","status":"success","started_at":"2026-06-01T17:14:55Z","ended_at":"2026-06-01T17:15:30Z"}`)
+	second := readFirstDataFrame(t, reader)
+	if !strings.Contains(second, `"success"`) {
+		t.Errorf("second frame = %q, want success", second)
+	}
+}
+
+func TestPilotStream_MethodNotAllowed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	req := httptest.NewRequest(http.MethodPost, "/api/project/pilot/stream?project=demo", nil)
+	rr := httptest.NewRecorder()
+	HandlePilotStream(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rr.Code)
+	}
+}
+
+func TestPilotStream_MissingProject(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	req := httptest.NewRequest(http.MethodGet, "/api/project/pilot/stream", nil)
+	rr := httptest.NewRecorder()
+	HandlePilotStream(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestPilotStream_NoRunsYieldsNull(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	got, err := readLatestPilotMetaCompact("demo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != "null" {
+		t.Errorf("got %q, want null", string(got))
+	}
+}
+
+func TestPilotStream_PicksLatestRunDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	plantPilotMeta(t, "demo", "2026-06-01T10-00-00Z",
+		`{"project":"demo","status":"success","started_at":"2026-06-01T10:00:00Z"}`)
+	plantPilotMeta(t, "demo", "2026-06-01T17-14-55Z",
+		`{"project":"demo","status":"running","started_at":"2026-06-01T17:14:55Z"}`)
+
+	got, err := readLatestPilotMetaCompact("demo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(got), `"running"`) {
+		t.Errorf("got %q, want the latest (running) run", string(got))
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1679,6 +1679,33 @@ func LastPilotRunSummaries(projectName string, n int) []PilotRunMeta {
 	return out
 }
 
+// LatestPilotRunMetaPath returns the filesystem path to the most recent
+// Pilot run's meta.json for a project, or "" if none exists. Run directories
+// are named with a UTC timestamp (see PilotRunDir), which is lexically
+// sortable, so the newest run is the directory with the largest name.
+//
+// Unlike WritePilotRunsIndex (rewritten only at the END of a wake), the
+// per-run meta.json is written at the START of a wake with status="running"
+// and rewritten at the end — so reading it directly lets the pilot SSE stream
+// observe an in-progress wake in real time (issue #240).
+func LatestPilotRunMetaPath(project string) string {
+	root := filepath.Join(DataDir(), "pilot-runs", project)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return ""
+	}
+	var latest string
+	for _, e := range entries {
+		if e.IsDir() && e.Name() > latest {
+			latest = e.Name()
+		}
+	}
+	if latest == "" {
+		return ""
+	}
+	return filepath.Join(root, latest, "meta.json")
+}
+
 func collectPilotRunEntries(root string) []PilotRunIndexEntry {
 	out := []PilotRunIndexEntry{}
 	if _, err := os.Stat(root); os.IsNotExist(err) {

--- a/web/src/routes/_app.projects.$name.tsx
+++ b/web/src/routes/_app.projects.$name.tsx
@@ -76,6 +76,22 @@ function previewMD(md: string): string {
   return (lines[0] ?? '').slice(0, 80)
 }
 
+// fmtDur renders a second count as a compact human duration: "17s",
+// "3m 2s", "1h 4m". Used by the live Pilot badge for both the elapsed
+// "running" timer and the "next wake in …" idle countdown (issue #240).
+function fmtDur(totalSec: number): string {
+  const s = Math.max(0, Math.floor(totalSec))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) {
+    const rem = s % 60
+    return rem ? `${m}m ${rem}s` : `${m}m`
+  }
+  const h = Math.floor(m / 60)
+  const remM = m % 60
+  return remM ? `${h}h ${remM}m` : `${h}h`
+}
+
 export const Route = createFileRoute('/_app/projects/$name')({
   component: ProjectDetail,
 })
@@ -115,6 +131,18 @@ function ProjectDetail() {
   // the newest entry without bouncing to the history page.
   const [pilotRuns, setPilotRuns] = useState<PilotRun[]>([])
   const [pilotRunDetail, setPilotRunDetail] = useState<PilotRun | null>(null)
+
+  // Live Pilot wake state (issue #240). Fed by the /api/project/pilot/stream
+  // SSE endpoint, which pushes the latest wake's meta.json (status /
+  // started_at / ended_at / error) as it changes — letting the top badge show
+  // a live "running" spinner + elapsed timer without a full refresh. null =
+  // no wake observed yet; falls back to pilotRuns[0] when the stream is
+  // unavailable so a dropped connection never blanks the badge.
+  const [livePilot, setLivePilot] = useState<PilotRun | null>(null)
+
+  // Ticks every second so the running elapsed timer and the idle "next wake
+  // in …" countdown stay live without re-fetching.
+  const [nowMs, setNowMs] = useState(() => Date.now())
 
   // Automation popover
   const [automationPopoverOpen, setAutomationPopoverOpen] = useState(false)
@@ -310,6 +338,57 @@ function ProjectDetail() {
       .catch(() => { /* idle */ })
     return () => { stopPolling(); stopDeploymentPolling() }
   }, [name])
+
+  // Live Pilot status stream (issue #240). The server pushes the latest
+  // wake's meta.json over SSE whenever it changes — including the start of a
+  // wake (status="running") and its completion — so the top badge reflects
+  // the live state at ~1s latency. Mirrors the dashboard's run-stream pattern
+  // (_app.dashboard.tsx): EventSource auto-reconnects on drop, and the
+  // pilot-runs poll below is KEPT as a graceful fallback so a dropped or
+  // unavailable stream never freezes the badge.
+  useEffect(() => {
+    if (typeof EventSource === 'undefined') return
+    let es: EventSource | null = null
+    try {
+      es = new EventSource(`/api/project/pilot/stream?project=${encodeURIComponent(name)}`)
+      es.onmessage = e => {
+        try {
+          const parsed = JSON.parse(e.data)
+          if (parsed && typeof parsed === 'object') {
+            setLivePilot(parsed as PilotRun)
+            // When a wake just finished, refresh the history so the "Latest
+            // Pilot wake" summary card below the header catches up too.
+            if (parsed.status === 'success' || parsed.status === 'failed' || parsed.status === 'auth-error') {
+              fetchPilotRuns()
+            }
+          } else {
+            setLivePilot(null) // "null" frame = no wake has happened yet
+          }
+        } catch {
+          /* ignore a malformed frame; the next frame or the poll recovers */
+        }
+      }
+      es.onerror = () => {} // EventSource reconnects on its own; poll covers the gap
+    } catch {
+      /* SSE construction failed; the pilot-runs poll fallback covers updates */
+    }
+    return () => es?.close()
+  }, [name])
+
+  // Polling fallback for the live badge: re-fetch pilot-runs every 5s so the
+  // running/idle state surfaces even when SSE is unavailable. Cheap and
+  // unobtrusive; mirrors the dashboard's 5s refetch cadence.
+  useEffect(() => {
+    const id = setInterval(() => fetchPilotRuns(), 5000)
+    return () => clearInterval(id)
+  }, [name])
+
+  // 1s ticker driving the running elapsed timer + idle countdown.
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
   useConfigChanged(() => {
     fetchProject()
     fetchAvailableRepos()
@@ -604,6 +683,23 @@ function ProjectDetail() {
   // an amber banner so the user sees the obstacle without grepping logs.
   const pilotSkipReason = (project?.automation?.last_skip_reason ?? '').trim()
 
+  // Live badge derivation (issue #240). Prefer the SSE-fed livePilot; fall
+  // back to the newest polled wake so the badge still animates when SSE is
+  // down. A wake counts as "running" only while its meta.json says so.
+  const effectivePilot = livePilot ?? (pilotRuns.length > 0 ? pilotRuns[0] : null)
+  const pilotRunning = effectivePilot?.status === 'running'
+  const pilotElapsedSec = pilotRunning && effectivePilot?.started_at
+    ? (nowMs - new Date(effectivePilot.started_at).getTime()) / 1000
+    : 0
+  // next wake = last_woken_at + cooldown_minutes (already exposed by
+  // /api/project/get). Only meaningful when automation is on with a cooldown.
+  const cooldownMin = project?.automation?.cooldown_minutes ?? 0
+  const lastWokenAt = project?.automation?.last_woken_at
+  const nextWakeMs = lastWokenAt && cooldownMin > 0
+    ? new Date(lastWokenAt).getTime() + cooldownMin * 60_000
+    : 0
+  const nextWakeInSec = nextWakeMs ? (nextWakeMs - nowMs) / 1000 : 0
+
   return (
     <div className="max-w-5xl mx-auto px-4 py-6">
       <Link
@@ -655,29 +751,51 @@ function ProjectDetail() {
                     onClick={() => setAutomationPopoverOpen(o => !o)}
                     className={cn(
                       'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium transition-colors',
-                      // Amber state: automation is on but Schedule recorded
-                      // a skip last pass — clearest signal that the pill's
-                      // "on" claim is currently a lie. Take precedence over
-                      // the green "enabled" colouring.
-                      project.automation?.enabled && pilotSkipReason
-                        ? 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-950/60'
-                        : project.automation?.enabled
-                          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-950/60'
-                          : 'bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700/60',
-                    )}
-                    title={pilotSkipReason ? `Pilot enabled but last pass skipped: ${pilotSkipReason}` : 'Automation settings'}
-                  >
-                    <span
-                      className={cn(
-                        'inline-block w-1.5 h-1.5 rounded-full',
-                        project.automation?.enabled && pilotSkipReason
-                          ? 'bg-amber-500'
+                      // Running takes top precedence — a live wake is the most
+                      // informative state, so render it distinctly (indigo +
+                      // spinner) regardless of skip/enabled colouring.
+                      pilotRunning
+                        ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-300 hover:bg-indigo-200 dark:hover:bg-indigo-950/60'
+                        // Amber state: automation is on but Schedule recorded
+                        // a skip last pass — clearest signal that the pill's
+                        // "on" claim is currently a lie. Take precedence over
+                        // the green "enabled" colouring.
+                        : project.automation?.enabled && pilotSkipReason
+                          ? 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-950/60'
                           : project.automation?.enabled
-                            ? 'bg-emerald-500 animate-pulse'
-                            : 'bg-slate-400',
-                      )}
-                    />
-                    Pilot {project.automation?.enabled ? (pilotSkipReason ? 'skipped' : 'on') : 'off'}
+                            ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-950/60'
+                            : 'bg-slate-100 text-slate-600 dark:bg-slate-800/60 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700/60',
+                    )}
+                    title={
+                      pilotRunning
+                        ? `Pilot is running — ${fmtDur(pilotElapsedSec)} elapsed`
+                        : pilotSkipReason
+                          ? `Pilot enabled but last pass skipped: ${pilotSkipReason}`
+                          : 'Automation settings'
+                    }
+                  >
+                    {pilotRunning ? (
+                      <Loader2 className="w-2.5 h-2.5 animate-spin" />
+                    ) : (
+                      <span
+                        className={cn(
+                          'inline-block w-1.5 h-1.5 rounded-full',
+                          project.automation?.enabled && pilotSkipReason
+                            ? 'bg-amber-500'
+                            : project.automation?.enabled
+                              ? 'bg-emerald-500 animate-pulse'
+                              : 'bg-slate-400',
+                        )}
+                      />
+                    )}
+                    {pilotRunning
+                      ? <>Pilot running · <span className="tabular-nums">{fmtDur(pilotElapsedSec)}</span></>
+                      : <>Pilot {project.automation?.enabled ? (pilotSkipReason ? 'skipped' : 'on') : 'off'}</>}
+                    {/* Idle countdown: only when on, not skipped, and a next
+                        wake is actually scheduled in the future. */}
+                    {!pilotRunning && project.automation?.enabled && !pilotSkipReason && nextWakeInSec > 0 && (
+                      <span className="opacity-70 tabular-nums">· next in {fmtDur(nextWakeInSec)}</span>
+                    )}
                     <Settings2 className="w-2.5 h-2.5 ml-0.5 opacity-60" />
                   </button>
                   {automationPopoverOpen && (


### PR DESCRIPTION
Fixes #240

## 范围（阶段一 MVP）
按 issue 评论收窄后的范围实现：消除 Project 详情页 Pilot 运行时的「静止感」，提供 `running / idle` 二态 + 已运行时长的实时反馈。全部复用现有范式，**不改造 wake 流程、不新增 Stage 字段、不解析 stream-json**。

## 改动
- **后端 SSE 端点** `GET /api/project/pilot/stream?project=<name>`（`internal/api/pilot_stream.go`）：仿 `run_stream.go` 的「轮询文件字节变化 → SSE 推送」范式，server 端轮询该项目**最新一次 wake 的 meta.json** 并在变化时推送。复用 `streamPollInterval` / heartbeat。
  - 关键点：wake 在**开始时**就写 `meta.json`（`status:running`）、结束时重写终态，因此直接读最新 meta.json 可观测到进行中的 wake（而索引 `pilot-runs.json` 仅在 wake 结束时刷新）。
- **snapshot 辅助** `LatestPilotRunMetaPath(project)`：按时间戳目录名取最新 wake 的 meta.json 路径。
- **路由注册**：`cmd/clawflow/commands/web.go` 在 `/api/project/pilot/wake` 旁加一行。
- **前端徽标动态化**（`web/src/routes/_app.projects.$name.tsx`）：
  - 订阅新 SSE 端点（`EventSource`），运行中显示 spinner + 由 `started_at` 实时累加的已运行时长（indigo 徽标）；
  - 空闲（enabled 且未 skip）显示 `Pilot on · next in …`，倒计时用已暴露的 `Automation.last_woken_at + cooldown_minutes` 推算，无需后端改字段；
  - wake 结束（success/failed/auth-error）自动 `fetchPilotRuns()` 刷新「Latest Pilot wake」摘要卡片；
  - **降级**：保留每 5s 的 pilot-runs 轮询 + `livePilot ?? pilotRuns[0]` 兜底，SSE 断连/不可用时徽标仍不回到完全静止。

## 验收对照
- [x] 运行中徽标显示 spinner + 实时累加已运行时长
- [x] 空闲显示 `Pilot on` + next wake 倒计时
- [x] 运行结束折叠回 Latest Pilot wake 摘要卡片
- [x] SSE 端点工作，断连/无事件降级为轮询，页面不回到静止

## 明确不做（留给阶段二）
`scanning/thinking/acting` 细粒度状态机、逐条流式活动流、5 段进度条、`PilotRunMeta.Stage` / wake 打点 / stream-json 解析。

## 测试
- 新增 `internal/api/pilot_stream_test.go`（6 个用例：初始帧 / 变化推送 / 405 / 缺 project 参数 / 无 wake 返回 null / 取最新目录）。
- `go test ./...` 全绿；`pnpm build`（vite + tsc 类型检查）通过。
- 未做端到端实跑 `clawflow web`（需真实运行中的 wake 才能直观看到 spinner）；逻辑已由单测覆盖 SSE 推送链路。

🤖 Generated with [Claude Code](https://claude.com/claude-code)