### PR TITLE
feat(operator): 算子触发引入父/叶子结构感知 (方案 A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ description: "一句话说明算子做什么、何时会被触发"
 operator:
   trigger:
     target: "issue"                                           # "issue" | "pr"
+    applies_to: "leaf"                                        # "any"(默认) | "parent" | "leaf" —— 按子 issue 结构过滤
     labels_required: ["bug"]                                  # 必须全部存在(AND)
     labels_excluded: ["agent-evaluated", "agent-skipped", "agent-running"]  # 任一存在即跳过(OR NOT)
   lock_label: "agent-running"                                 # 执行前加、完成/失败后删,并发锁
@@ -179,6 +180,7 @@ operator:
 | `name` | 唯一标识,必须与目录名一致 |
 | `description` | 人读说明,也用于 `clawflow operators list` |
 | `operator.trigger.target` | 扫哪类对象。`issue` 或 `pr` |
+| `operator.trigger.applies_to` | 可选。按子 issue 结构硬约束触发:`parent`=必须有子 issue(协调类算子,如 track-progress);`leaf`=必须无子 issue(干活类算子,如 evaluate-*/decompose/implement);`any` 或空=不约束(向后兼容)。GitLab 无原生 sub-issue,所有 issue 恒为 leaf |
 | `operator.trigger.labels_required` | 必须**全部**存在才触发(AND) |
 | `operator.trigger.labels_excluded` | 有任意一个就跳过(OR NOT) |
 | `operator.lock_label` | 并发锁,执行前加、完成后删 |

--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -531,12 +531,13 @@ func scanRepoOnce(ctx context.Context, reg *operator.Registry, fullName string, 
 	capturedAt := time.Now().UTC()
 	for _, iss := range issues {
 		sub := &operator.Subject{
-			Number: iss.Number,
-			Title:  iss.Title,
-			Body:   iss.Body,
-			Labels: iss.Labels,
-			State:  iss.State,
-			IsPR:   false,
+			Number:   iss.Number,
+			Title:    iss.Title,
+			Body:     iss.Body,
+			Labels:   iss.Labels,
+			State:    iss.State,
+			IsPR:     false,
+			SubTotal: iss.SubIssuesTotal,
 		}
 		debugf("[%s] #%d labels=%v title=%q", fullName, sub.Number, sub.Labels, sub.Title)
 		// Snapshot every operator that would match this issue's CURRENT

--- a/internal/operator/matcher.go
+++ b/internal/operator/matcher.go
@@ -17,6 +17,10 @@ type Subject struct {
 	IsPR       bool
 	HeadBranch string // PR only
 	URL        string // HTML URL, if the VCS exposes one
+	// SubTotal is the number of native sub-issues linked to this subject
+	// (GitHub sub_issues_summary.total). 0 = leaf (or a platform without
+	// native sub-issues, e.g. GitLab). Drives the AppliesTo structural gate.
+	SubTotal int
 }
 
 // HasLabel reports whether the subject carries the given label.
@@ -67,6 +71,17 @@ func MatchesWithReason(sub *Subject, op *Operator) (bool, string) {
 	for _, ex := range op.Trigger.LabelsExcluded {
 		if _, ok := labelSet[ex]; ok {
 			return false, fmt.Sprintf("excluded label %q present", ex)
+		}
+	}
+	// Structure-aware gate. "" and "any" impose no constraint (back-compat).
+	switch op.Trigger.AppliesTo {
+	case AppliesParent:
+		if sub.SubTotal <= 0 {
+			return false, "applies_to=parent but subject has no sub-issues (leaf)"
+		}
+	case AppliesLeaf:
+		if sub.SubTotal > 0 {
+			return false, fmt.Sprintf("applies_to=leaf but subject has %d sub-issue(s) (parent)", sub.SubTotal)
 		}
 	}
 	return true, "match"

--- a/internal/operator/matcher_test.go
+++ b/internal/operator/matcher_test.go
@@ -99,13 +99,13 @@ func TestMatches_LabelsRequiredAny(t *testing.T) {
 		labels []string
 		want   bool
 	}{
-		"feat present":           {[]string{"feat"}, true},
-		"feature present":        {[]string{"feature"}, true},
-		"both present":           {[]string{"feat", "feature"}, true},
-		"neither present":        {[]string{"bug"}, false},
-		"empty":                  {[]string{}, false},
-		"feat plus extras":       {[]string{"feat", "urgent"}, true},
-		"feature plus extras":    {[]string{"feature", "urgent"}, true},
+		"feat present":        {[]string{"feat"}, true},
+		"feature present":     {[]string{"feature"}, true},
+		"both present":        {[]string{"feat", "feature"}, true},
+		"neither present":     {[]string{"bug"}, false},
+		"empty":               {[]string{}, false},
+		"feat plus extras":    {[]string{"feat", "urgent"}, true},
+		"feature plus extras": {[]string{"feature", "urgent"}, true},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -134,6 +134,52 @@ func TestMatches_LabelsRequiredAndRequiredAnyCombined(t *testing.T) {
 	// AND satisfied but OR missing
 	if Matches(&Subject{Labels: []string{"urgent", "bug"}}, op) {
 		t.Error("urgent + bug without feat/feature should not match")
+	}
+}
+
+func TestMatches_AppliesTo(t *testing.T) {
+	cases := map[string]struct {
+		appliesTo string
+		subTotal  int
+		want      bool
+	}{
+		"parent matches issue with sub-issues":  {AppliesParent, 3, true},
+		"parent rejects leaf issue":             {AppliesParent, 0, false},
+		"leaf matches issue without sub-issues": {AppliesLeaf, 0, true},
+		"leaf rejects parent issue":             {AppliesLeaf, 2, false},
+		"any matches parent":                    {AppliesAny, 5, true},
+		"any matches leaf":                      {AppliesAny, 0, true},
+		"empty (back-compat) matches parent":    {"", 5, true},
+		"empty (back-compat) matches leaf":      {"", 0, true},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			op := &Operator{Trigger: Trigger{Target: "issue", AppliesTo: c.appliesTo}}
+			s := &Subject{SubTotal: c.subTotal}
+			if got := Matches(s, op); got != c.want {
+				t.Errorf("applies_to=%q subTotal=%d: got %v want %v", c.appliesTo, c.subTotal, got, c.want)
+			}
+		})
+	}
+}
+
+// Structural gate composes with label rules: required labels still apply, and
+// a structural miss is reported even when labels match.
+func TestMatches_AppliesToWithLabels(t *testing.T) {
+	op := &Operator{Trigger: Trigger{
+		Target:         "issue",
+		LabelsRequired: []string{"progress-check"},
+		AppliesTo:      AppliesParent,
+	}}
+	// Labels match but subject is a leaf → reject on structure.
+	if ok, reason := MatchesWithReason(&Subject{Labels: []string{"progress-check"}, SubTotal: 0}, op); ok {
+		t.Error("leaf should be rejected by applies_to=parent even with matching labels")
+	} else if reason == "" {
+		t.Error("expected a non-empty structural reason")
+	}
+	// Labels match and subject is a parent → match.
+	if !Matches(&Subject{Labels: []string{"progress-check"}, SubTotal: 2}, op) {
+		t.Error("parent with matching labels should match")
 	}
 }
 

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -22,7 +22,7 @@ type Operator struct {
 	// Cross-process locking is handled by local lockfiles in ~/.clawflow/locks/;
 	// the field is kept for back-compat with SKILL.md files that still declare
 	// `lock_label:`. New operators can safely omit it.
-	LockLabel   string
+	LockLabel string
 	// Outcomes is the allow-list of labels the operator may declare via the
 	// `<!-- clawflow:outcome=<label> -->` marker in its stdout. The runner
 	// adds the outcome label after posting the comment. An empty list means
@@ -37,12 +37,31 @@ type Operator struct {
 	Source string
 }
 
+// AppliesTo enumerates the sub-issue structure a trigger requires. It is a
+// deterministic, structure-aware gate layered on top of label matching:
+// "parent" fires only on issues that have sub-issues, "leaf" only on issues
+// that have none, and "any" (the default) ignores structure entirely.
+//
+// This lets coordinator operators (track-progress) run exclusively on tracking
+// parents while work operators (evaluate-*, decompose, implement) stay on
+// leaves — turning the previous prompt-level soft convention ("skip if I'm a
+// parent") into a hard matcher constraint.
+const (
+	AppliesAny    = "any"
+	AppliesParent = "parent"
+	AppliesLeaf   = "leaf"
+)
+
 // Trigger gates when an operator fires on a given issue/PR.
 type Trigger struct {
-	Target         string
+	Target            string
 	LabelsRequired    []string
 	LabelsRequiredAny []string // OR semantics: at least one must be present (empty = no constraint)
 	LabelsExcluded    []string
+	// AppliesTo is the sub-issue structure constraint: "" or "any" = no
+	// constraint (back-compat), "parent" = subject must have sub-issues,
+	// "leaf" = subject must have none. See the AppliesTo constants.
+	AppliesTo string
 }
 
 // frontmatter mirrors the YAML shape inside the SKILL.md.
@@ -55,6 +74,7 @@ type frontmatter struct {
 			LabelsRequired    []string `yaml:"labels_required"`
 			LabelsRequiredAny []string `yaml:"labels_required_any"`
 			LabelsExcluded    []string `yaml:"labels_excluded"`
+			AppliesTo         string   `yaml:"applies_to"`
 		} `yaml:"trigger"`
 		LockLabel string   `yaml:"lock_label"`
 		Outcomes  []string `yaml:"outcomes"`
@@ -88,6 +108,16 @@ func Parse(data []byte, source string) (*Operator, error) {
 	if tgt != "issue" && tgt != "pr" {
 		return nil, fmt.Errorf("%s: operator.trigger.target must be \"issue\" or \"pr\", got %q", source, tgt)
 	}
+	appliesTo := fm.Operator.Trigger.AppliesTo
+	switch appliesTo {
+	case "", AppliesAny, AppliesParent, AppliesLeaf:
+		// ok ("" normalized below to AppliesAny)
+	default:
+		return nil, fmt.Errorf("%s: operator.trigger.applies_to must be \"any\", \"parent\", or \"leaf\", got %q", source, appliesTo)
+	}
+	if appliesTo == "" {
+		appliesTo = AppliesAny
+	}
 	// lock_label was previously required as the issue-side concurrency
 	// gate; it is now ignored at runtime (see Operator.LockLabel doc).
 	// Tolerate both presence and absence so old and new SKILL.md files
@@ -101,6 +131,7 @@ func Parse(data []byte, source string) (*Operator, error) {
 			LabelsRequired:    fm.Operator.Trigger.LabelsRequired,
 			LabelsRequiredAny: fm.Operator.Trigger.LabelsRequiredAny,
 			LabelsExcluded:    fm.Operator.Trigger.LabelsExcluded,
+			AppliesTo:         appliesTo,
 		},
 		LockLabel: fm.Operator.LockLabel,
 		Outcomes:  fm.Operator.Outcomes,

--- a/internal/operator/operator_test.go
+++ b/internal/operator/operator_test.go
@@ -152,6 +152,55 @@ func TestParse_OutcomesOmitted_DefaultsToEmpty(t *testing.T) {
 	}
 }
 
+func TestParse_AppliesTo(t *testing.T) {
+	const skill = `---
+name: track-progress
+operator:
+  trigger:
+    target: issue
+    applies_to: parent
+    labels_required: [progress-check]
+---
+
+Body.`
+	op, err := Parse([]byte(skill), "track-progress/SKILL.md")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if op.Trigger.AppliesTo != AppliesParent {
+		t.Errorf("AppliesTo = %q, want %q", op.Trigger.AppliesTo, AppliesParent)
+	}
+}
+
+func TestParse_AppliesToDefaultsToAny(t *testing.T) {
+	op, err := Parse([]byte(validSkill), "test.md")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if op.Trigger.AppliesTo != AppliesAny {
+		t.Errorf("AppliesTo should default to %q when omitted; got %q", AppliesAny, op.Trigger.AppliesTo)
+	}
+}
+
+func TestParse_AppliesToInvalid(t *testing.T) {
+	const skill = `---
+name: foo
+operator:
+  trigger:
+    target: issue
+    applies_to: banana
+---
+
+Body.`
+	_, err := Parse([]byte(skill), "test")
+	if err == nil {
+		t.Fatal("expected error for invalid applies_to, got nil")
+	}
+	if !strings.Contains(err.Error(), "applies_to") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "applies_to")
+	}
+}
+
 func TestParse_PRTarget(t *testing.T) {
 	input := `---
 name: review-pr

--- a/skills/decompose/SKILL.md
+++ b/skills/decompose/SKILL.md
@@ -4,6 +4,7 @@ description: "Break a tracking issue into sub-issues via clawflow issue create +
 operator:
   trigger:
     target: "issue"
+    applies_to: "leaf"
     labels_required: ["ready-for-agent", "tracking"]
     labels_excluded: ["agent-decomposed", "agent-running", "agent-failed", "agent-skipped"]
   outcomes: ["agent-decomposed", "agent-skipped"]

--- a/skills/evaluate-bug/SKILL.md
+++ b/skills/evaluate-bug/SKILL.md
@@ -4,6 +4,7 @@ description: "Evaluate a bug-labeled issue for reproducibility, root cause, and 
 operator:
   trigger:
     target: "issue"
+    applies_to: "leaf"
     labels_required: ["bug"]
     labels_excluded: ["agent-evaluated", "agent-skipped", "agent-failed", "agent-running"]
   outcomes: ["agent-evaluated", "agent-skipped"]

--- a/skills/evaluate-feat/SKILL.md
+++ b/skills/evaluate-feat/SKILL.md
@@ -4,6 +4,7 @@ description: "Evaluate a feat-labeled issue for clarity, scope, and architectura
 operator:
   trigger:
     target: "issue"
+    applies_to: "leaf"
     labels_required: []
     labels_required_any: ["feat", "feature"]
     labels_excluded: ["agent-evaluated", "agent-skipped", "agent-failed", "agent-running"]

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -4,6 +4,7 @@ description: "Implement a code fix for a ready-for-agent issue: create a branch,
 operator:
   trigger:
     target: "issue"
+    applies_to: "leaf"
     labels_required: ["ready-for-agent"]
     labels_excluded: ["agent-implemented", "agent-skipped", "agent-failed", "agent-running", "tracking"]
   outcomes: ["agent-implemented", "agent-failed", "agent-skipped"]

--- a/skills/track-progress/SKILL.md
+++ b/skills/track-progress/SKILL.md
@@ -4,6 +4,7 @@ description: "Check whether all sub-issues of a tracking issue are complete via 
 operator:
   trigger:
     target: "issue"
+    applies_to: "parent"
     labels_required: ["progress-check"]
     labels_excluded: ["agent-closed", "agent-running", "agent-failed"]
   outcomes: ["agent-closed", "agent-watching"]


### PR DESCRIPTION
Part of #242

## 做了什么（方案 A — 后端结构硬约束）

给算子触发新增 `applies_to: parent | leaf | any` 字段，把「父 issue / 叶子 issue」做成 matcher 层的一等维度，从纯标签驱动升级为**结构感知的确定性硬约束**。

- **parent**：subject 必须有子 issue（`SubTotal > 0`）→ 协调类算子
- **leaf**：subject 必须无子 issue（`SubTotal == 0`）→ 干活类算子
- **any / 空**：不约束（向后兼容，与 `labels_required_any` 空值放行一致）

这解决了根因：已 decompose 的 tracking 父 issue 不再错误匹配干活类算子（evaluate / decompose / implement），父 issue 只跑协调算子（track-progress）。原本写在 `decompose/SKILL.md` 里的 LLM prompt 软约束，现在上移为 matcher 硬约束。

## 改动文件

- `internal/operator/operator.go`：`Trigger.AppliesTo` 字段 + frontmatter `applies_to` yaml tag + Parse 校验（非法值报错，空值归一为 `any`），接线方式与既有 `LabelsRequiredAny` 一一对应。
- `internal/operator/matcher.go`：`Subject.SubTotal` 字段 + `MatchesWithReason` 末尾的结构判定。判定放在 matcher 层，pending 快照（run.go:550）与执行前 re-match（run.go:777，`freshSub := *j.sub` 复制保留 SubTotal）自动一致，规避「pending 永挂」坑。
- `cmd/clawflow/commands/run.go`：Subject 构造处用 `iss.SubIssuesTotal` 填充 `SubTotal`（GitHub list API 已返回 `sub_issues_summary`）。
- 算子声明：`track-progress` → parent；`evaluate-feat` / `evaluate-bug` / `decompose` / `implement` → leaf。其余算子不声明 = any，零行为变化。
- `CLAUDE.md`：frontmatter schema 文档补充 `applies_to`。

## 测试

- `go test ./internal/operator/...`、`go test ./cmd/clawflow/...`、`go test ./...` 全绿。
- 新增 `TestMatches_AppliesTo`（表驱动，含 parent/leaf/any/空值回归）、`TestMatches_AppliesToWithLabels`（结构与标签组合）、`TestParse_AppliesTo` / `TestParse_AppliesToDefaultsToAny` / `TestParse_AppliesToInvalid`。
- `go build ./...` 通过（embed `web/dist` 在本地用临时桩验证，未提交）。

## 兼容性 / 备注

- **GitLab**：无原生 sub-issue，`SubIssuesTotal` 恒为 0，所有 issue 判为 leaf。这意味着 `track-progress`(parent only) 在 GitLab 上不触发——符合预期（GitLab 本就不走 decompose 链路）。
- **decompose 软约束保留**：`decompose/SKILL.md` 里「自己是子 issue 就跳过」语义是 *ParentNumber != nil*（有父），与 leaf（无子）正交——sub-issue 本身也是 leaf，故未删除该软约束，避免回归；父-only 的硬约束由 `applies_to: leaf` 覆盖。

## 未包含（方案 B，建议另起 follow-up）

issue 的方案 B（dashboard 把连续 `agent-watching` 巡检 run 折叠）**未在本 PR 实现**，原因：前端 `Run` 类型不含 outcome label 字段，无法区分「状态跃迁」与「空轮询」，需先在 `runs.json`/`RunMeta` 暴露 outcome 才能做。这与 evaluator「A/B 拆两个 ready-for-agent 分别派发」的建议一致。故本 PR 用 `Part of #242` 而非 `Fixes`，把 B 留给后续。