### PR TITLE
feat(web): main-branch git sync status with one-click pull/push

### DIFF
--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -22,6 +22,7 @@ import (
 	rootmod "github.com/zhoushoujianwork/clawflow"
 	"github.com/zhoushoujianwork/clawflow/internal/api"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/gitsync"
 	clog "github.com/zhoushoujianwork/clawflow/internal/log"
 	ptyserver "github.com/zhoushoujianwork/clawflow/internal/pty"
 	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
@@ -207,6 +208,33 @@ here — run 'clawflow run' first if you want fresh data.`,
 				}
 			}()
 
+			// Background git-status sync: low-frequency `git fetch` +
+			// ahead/behind recompute for every repo, cached to
+			// data/git-status.json. This is the "定时兜底" backstop for the
+			// Hook — the dashboard reads the cache instantly on render and
+			// only triggers an on-demand refresh when the user is looking.
+			// Kept deliberately infrequent (every 5 min) so we never hammer
+			// remotes; an initial run primes the cache shortly after start.
+			go func() {
+				prime := time.NewTimer(10 * time.Second)
+				defer prime.Stop()
+				<-prime.C
+				if cfg, err := config.Load(); err == nil {
+					gitsync.RefreshAll(cfg)
+				}
+				tick := time.NewTicker(5 * time.Minute)
+				defer tick.Stop()
+				for range tick.C {
+					cfg, err := config.Load()
+					if err != nil {
+						lg.Warn("web/gitstatus_tick", "err", err.Error())
+						continue
+					}
+					n := len(gitsync.RefreshAll(cfg))
+					lg.Info("web/gitstatus_tick", "repos", n)
+				}
+			}()
+
 			// Periodic auto-runner: when settings.run_interval_minutes > 0,
 			// fire `clawflow run` on a recurring tick. The ticker shares
 			// the runActive mutex with the manual Run button (via
@@ -254,6 +282,10 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/repo/remove", api.HandleRepoRemove)
 			mux.HandleFunc("/api/repo/clone", api.HandleClone)
 			mux.HandleFunc("/api/repo/refresh-issues", api.HandleRepoRefreshIssues)
+			mux.HandleFunc("/api/repo/git-status", api.HandleGitStatus)
+			mux.HandleFunc("/api/repo/git-status/refresh", api.HandleGitStatusRefresh)
+			mux.HandleFunc("/api/repo/git-pull", api.HandleGitPull)
+			mux.HandleFunc("/api/repo/git-push", api.HandleGitPush)
 			mux.HandleFunc("/api/repos/list-remote", api.HandleListRemoteRepos)
 			mux.HandleFunc("/api/repos/add-remote", api.HandleAddRemoteRepo)
 			mux.HandleFunc("/api/settings", api.HandleGetSettings)

--- a/internal/api/git_status.go
+++ b/internal/api/git_status.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/gitsync"
+)
+
+// HandleGitStatus handles GET /api/repo/git-status — returns the cached git
+// sync status for every configured repo (read-only, instant). The dashboard
+// reads this on render for an immediate view, then triggers an async refresh.
+func HandleGitStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	writeJSON(w, 200, gitsync.ReadCache())
+}
+
+type gitRepoRequest struct {
+	Repo string `json:"repo"`
+}
+
+// HandleGitStatusRefresh handles POST /api/repo/git-status/refresh — runs a
+// `git fetch` and recomputes the sync status. With a "repo" field it refreshes
+// just that repo (the per-row Hook); without one it refreshes all repos (the
+// background backstop, also callable from the UI). Returns the updated
+// entries.
+func HandleGitStatusRefresh(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req gitRepoRequest
+	// Body is optional; an empty/absent body means "refresh all".
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if req.Repo != "" {
+		if _, ok := cfg.Repos[req.Repo]; !ok {
+			writeJSON(w, 404, map[string]string{"error": "repo not found in config"})
+			return
+		}
+		st := gitsync.Refresh(cfg, req.Repo)
+		writeJSON(w, 200, []gitsync.Status{st})
+		return
+	}
+	writeJSON(w, 200, gitsync.RefreshAll(cfg))
+}
+
+type gitActionResponse struct {
+	Status string         `json:"status"` // "ok" | "error"
+	Output string         `json:"output"` // git's combined stdout/stderr
+	Error  string         `json:"error,omitempty"`
+	Git    gitsync.Status `json:"git_status"`
+}
+
+// HandleGitPull handles POST /api/repo/git-pull — fast-forwards the base
+// branch from origin for one repo and returns the refreshed status. Git
+// failures (non-ff, dirty tree, auth) are returned as a 200 with status:error
+// and the git output so the dashboard can surface the message inline for the
+// user to resolve locally.
+func HandleGitPull(w http.ResponseWriter, r *http.Request) {
+	gitAction(w, r, gitsync.Pull)
+}
+
+// HandleGitPush handles POST /api/repo/git-push — pushes the base branch to
+// origin for one repo and returns the refreshed status. Same error contract as
+// HandleGitPull.
+func HandleGitPush(w http.ResponseWriter, r *http.Request) {
+	gitAction(w, r, gitsync.Push)
+}
+
+func gitAction(w http.ResponseWriter, r *http.Request, action func(*config.Config, string) (string, gitsync.Status, error)) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req gitRepoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if req.Repo == "" {
+		writeJSON(w, 400, map[string]string{"error": "repo is required"})
+		return
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if _, ok := cfg.Repos[req.Repo]; !ok {
+		writeJSON(w, 404, map[string]string{"error": "repo not found in config"})
+		return
+	}
+
+	out, st, actionErr := action(cfg, req.Repo)
+	resp := gitActionResponse{Status: "ok", Output: out, Git: st}
+	if actionErr != nil {
+		resp.Status = "error"
+		resp.Error = actionErr.Error()
+	}
+	// 200 even on git failure: the operation completed cleanly at the HTTP
+	// layer and the failure is a domain result the UI renders inline, not a
+	// server error.
+	writeJSON(w, 200, resp)
+}

--- a/internal/branch/branch.go
+++ b/internal/branch/branch.go
@@ -14,6 +14,7 @@ package branch
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
 	"strconv"
@@ -96,16 +97,133 @@ func gitOut(dir string, args ...string) (string, error) {
 	return string(out), nil
 }
 
+// headlessEnv returns the process environment plus the guards that keep git
+// from blocking on interactive prompts when invoked without a TTY (background
+// fetch, dashboard-triggered pull/push). GIT_TERMINAL_PROMPT=0 blocks HTTP
+// credential prompts; the SSH BatchMode/ConnectTimeout options block key
+// passphrase prompts and bound the TCP connect for git-over-SSH. Without these
+// a background fetch can hang indefinitely on a credential prompt — the same
+// class of failure as issue #216. (clone.cloneRepo already sets these; the
+// background sync path must match.)
+func headlessEnv() []string {
+	return append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=10",
+	)
+}
+
 // Fetch updates remote-tracking refs and prunes deleted ones so the
 // remote-tracking view is accurate before analysis. Failure is returned to the
 // caller, which may choose to proceed with cached refs.
 func Fetch(localPath string) error {
 	c := exec.Command("git", "fetch", "--prune", "origin")
 	c.Dir = localPath
+	c.Env = headlessEnv()
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("git fetch --prune origin: %w\n%s", err, out)
 	}
 	return nil
+}
+
+// SyncStatus describes the configured base branch's position relative to its
+// remote-tracking counterpart (origin/<base>). Computed against the local
+// clone; callers should run Fetch first so origin/<base> reflects the remote
+// tip. All counts are zero and HasUpstream is false when origin/<base> is
+// missing (e.g. a brand-new branch never pushed).
+type SyncStatus struct {
+	Branch      string `json:"branch"`       // the base branch name compared
+	Ahead       int    `json:"ahead"`        // local commits not on origin → push needed
+	Behind      int    `json:"behind"`       // origin commits not local → pull needed
+	Dirty       bool   `json:"dirty"`        // worktree has uncommitted changes
+	HasUpstream bool   `json:"has_upstream"` // origin/<base> ref exists
+	Current     string `json:"current"`      // currently checked-out branch (may differ from base)
+}
+
+// GetSyncStatus computes the ahead/behind/dirty state of base relative to
+// origin/<base> for the clone at localPath. It does NOT fetch — run Fetch
+// first for an up-to-date comparison. base defaults to "main" when empty.
+func GetSyncStatus(localPath, base string) (SyncStatus, error) {
+	if base == "" {
+		base = "main"
+	}
+	st := SyncStatus{Branch: base}
+
+	// Currently checked-out branch (best-effort; detached HEAD yields "HEAD").
+	if cur, err := gitOut(localPath, "rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		st.Current = strings.TrimSpace(cur)
+	}
+
+	// Dirty = any staged/unstaged/untracked change.
+	if out, err := gitOut(localPath, "status", "--porcelain"); err == nil {
+		st.Dirty = strings.TrimSpace(out) != ""
+	}
+
+	// Without origin/<base> there is nothing to compare against.
+	if _, err := gitOut(localPath, "rev-parse", "--verify", "--quiet", "refs/remotes/origin/"+base); err != nil {
+		st.HasUpstream = false
+		return st, nil
+	}
+	st.HasUpstream = true
+
+	// `--left-right --count A...B` prints "<left>\t<right>": commits reachable
+	// from A but not B, then from B but not A. With A=origin/base, B=base:
+	// left = behind (remote ahead of us), right = ahead (we are ahead).
+	out, err := gitOut(localPath, "rev-list", "--left-right", "--count", "origin/"+base+"..."+base)
+	if err != nil {
+		return st, err
+	}
+	fields := strings.Fields(out)
+	if len(fields) == 2 {
+		st.Behind, _ = strconv.Atoi(fields[0])
+		st.Ahead, _ = strconv.Atoi(fields[1])
+	}
+	return st, nil
+}
+
+// runGitCombined runs a git command capturing combined stdout+stderr with the
+// headless env, returning the trimmed output and any error. The output is
+// surfaced to the user verbatim on failure so they can resolve it locally.
+func runGitCombined(localPath string, args ...string) (string, error) {
+	c := exec.Command("git", args...)
+	c.Dir = localPath
+	c.Env = headlessEnv()
+	out, err := c.CombinedOutput()
+	text := strings.TrimSpace(string(out))
+	if err != nil {
+		if text != "" {
+			return text, fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, text)
+		}
+		return text, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return text, nil
+}
+
+// Pull fast-forwards the base branch from origin. It refuses to run unless the
+// clone is currently on base (a non-ff or wrong-branch pull could move an
+// unrelated feature branch) and uses --ff-only so it never creates a merge
+// commit or attempts conflict resolution — matching the issue's "show the
+// error, let the user handle it locally" contract. Returns git's combined
+// output for display.
+func Pull(localPath, base string) (string, error) {
+	if base == "" {
+		base = "main"
+	}
+	cur, err := gitOut(localPath, "rev-parse", "--abbrev-ref", "HEAD")
+	if err == nil && strings.TrimSpace(cur) != base {
+		return "", fmt.Errorf("本地仓库当前在分支 %q，pull 仅在 %q 分支上执行；请先切换分支或在本地手动处理", strings.TrimSpace(cur), base)
+	}
+	return runGitCombined(localPath, "pull", "--ff-only", "origin", base)
+}
+
+// Push pushes the local base branch to origin/<base>. Pushing the ref
+// explicitly (origin <base>) works regardless of the currently checked-out
+// branch. A rejected push (e.g. local is behind) surfaces as an error with
+// git's message for the user to resolve.
+func Push(localPath, base string) (string, error) {
+	if base == "" {
+		base = "main"
+	}
+	return runGitCombined(localPath, "push", "origin", base)
 }
 
 // ListMerged returns local (and, when includeRemote is set, remote-tracking)

--- a/internal/branch/sync_test.go
+++ b/internal/branch/sync_test.go
@@ -1,0 +1,198 @@
+package branch
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// gitEnv returns a deterministic git identity so commits succeed in CI.
+func gitEnv() []string {
+	return append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	c.Env = gitEnv()
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// makeRemoteAndClone builds a bare "origin" remote seeded with one commit on
+// `main`, plus a working clone of it. Returns (clonePath, remotePath).
+func makeRemoteAndClone(t *testing.T) (string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	base := t.TempDir()
+	remote := filepath.Join(base, "remote.git")
+	seed := filepath.Join(base, "seed")
+	clonePath := filepath.Join(base, "clone")
+
+	mustGit(t, base, "init", "--bare", "-b", "main", remote)
+
+	// Seed the remote with an initial commit via a throwaway clone.
+	mustGit(t, base, "clone", remote, seed)
+	writeFile(t, seed, "a.txt", "1\n")
+	mustGit(t, seed, "add", ".")
+	mustGit(t, seed, "commit", "-m", "init")
+	mustGit(t, seed, "push", "origin", "main")
+
+	// The clone under test.
+	mustGit(t, base, "clone", remote, clonePath)
+	return clonePath, remote
+}
+
+func TestGetSyncStatus_Clean(t *testing.T) {
+	clonePath, _ := makeRemoteAndClone(t)
+	st, err := GetSyncStatus(clonePath, "main")
+	if err != nil {
+		t.Fatalf("GetSyncStatus: %v", err)
+	}
+	if !st.HasUpstream {
+		t.Errorf("HasUpstream = false, want true")
+	}
+	if st.Ahead != 0 || st.Behind != 0 {
+		t.Errorf("ahead=%d behind=%d, want 0/0", st.Ahead, st.Behind)
+	}
+	if st.Dirty {
+		t.Errorf("Dirty = true, want false")
+	}
+	if st.Branch != "main" || st.Current != "main" {
+		t.Errorf("branch=%q current=%q, want main/main", st.Branch, st.Current)
+	}
+}
+
+func TestGetSyncStatus_AheadAndDirty(t *testing.T) {
+	clonePath, _ := makeRemoteAndClone(t)
+	// Local commit not pushed → ahead 1.
+	writeFile(t, clonePath, "b.txt", "2\n")
+	mustGit(t, clonePath, "add", ".")
+	mustGit(t, clonePath, "commit", "-m", "local work")
+	// Uncommitted change → dirty.
+	writeFile(t, clonePath, "a.txt", "changed\n")
+
+	st, err := GetSyncStatus(clonePath, "main")
+	if err != nil {
+		t.Fatalf("GetSyncStatus: %v", err)
+	}
+	if st.Ahead != 1 {
+		t.Errorf("ahead = %d, want 1", st.Ahead)
+	}
+	if st.Behind != 0 {
+		t.Errorf("behind = %d, want 0", st.Behind)
+	}
+	if !st.Dirty {
+		t.Errorf("Dirty = false, want true")
+	}
+}
+
+func TestGetSyncStatus_Behind(t *testing.T) {
+	clonePath, remote := makeRemoteAndClone(t)
+	// Push a new commit to the remote via an independent clone so our clone
+	// under test falls behind by one.
+	other := filepath.Join(t.TempDir(), "other")
+	mustGit(t, filepath.Dir(other), "clone", remote, other)
+	writeFile(t, other, "c.txt", "3\n")
+	mustGit(t, other, "add", ".")
+	mustGit(t, other, "commit", "-m", "remote work")
+	mustGit(t, other, "push", "origin", "main")
+
+	if err := Fetch(clonePath); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	st, err := GetSyncStatus(clonePath, "main")
+	if err != nil {
+		t.Fatalf("GetSyncStatus: %v", err)
+	}
+	if st.Behind != 1 {
+		t.Errorf("behind = %d, want 1", st.Behind)
+	}
+	if st.Ahead != 0 {
+		t.Errorf("ahead = %d, want 0", st.Ahead)
+	}
+}
+
+func TestGetSyncStatus_NoUpstream(t *testing.T) {
+	clonePath, _ := makeRemoteAndClone(t)
+	st, err := GetSyncStatus(clonePath, "nonexistent-branch")
+	if err != nil {
+		t.Fatalf("GetSyncStatus: %v", err)
+	}
+	if st.HasUpstream {
+		t.Errorf("HasUpstream = true, want false for missing origin branch")
+	}
+	if st.Ahead != 0 || st.Behind != 0 {
+		t.Errorf("ahead=%d behind=%d, want 0/0 when no upstream", st.Ahead, st.Behind)
+	}
+}
+
+func TestPull_FastForward(t *testing.T) {
+	clonePath, remote := makeRemoteAndClone(t)
+	other := filepath.Join(t.TempDir(), "other")
+	mustGit(t, filepath.Dir(other), "clone", remote, other)
+	writeFile(t, other, "c.txt", "3\n")
+	mustGit(t, other, "add", ".")
+	mustGit(t, other, "commit", "-m", "remote work")
+	mustGit(t, other, "push", "origin", "main")
+
+	if _, err := Pull(clonePath, "main"); err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+	st, err := GetSyncStatus(clonePath, "main")
+	if err != nil {
+		t.Fatalf("GetSyncStatus: %v", err)
+	}
+	if st.Behind != 0 {
+		t.Errorf("after pull behind = %d, want 0", st.Behind)
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, "c.txt")); err != nil {
+		t.Errorf("pulled file c.txt missing: %v", err)
+	}
+}
+
+func TestPull_WrongBranchRefused(t *testing.T) {
+	clonePath, _ := makeRemoteAndClone(t)
+	mustGit(t, clonePath, "checkout", "-b", "feature")
+	if _, err := Pull(clonePath, "main"); err == nil {
+		t.Errorf("Pull on non-base branch should be refused, got nil error")
+	}
+}
+
+func TestPush_AheadSucceeds(t *testing.T) {
+	clonePath, remote := makeRemoteAndClone(t)
+	writeFile(t, clonePath, "b.txt", "2\n")
+	mustGit(t, clonePath, "add", ".")
+	mustGit(t, clonePath, "commit", "-m", "local work")
+
+	if _, err := Push(clonePath, "main"); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	// Verify the remote advanced by checking ahead is back to 0 after fetch.
+	if err := Fetch(clonePath); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	st, err := GetSyncStatus(clonePath, "main")
+	if err != nil {
+		t.Fatalf("GetSyncStatus: %v", err)
+	}
+	if st.Ahead != 0 {
+		t.Errorf("after push ahead = %d, want 0", st.Ahead)
+	}
+	_ = remote
+}

--- a/internal/gitsync/gitsync.go
+++ b/internal/gitsync/gitsync.go
@@ -1,0 +1,211 @@
+// Package gitsync computes and caches the git sync status (ahead/behind/dirty)
+// of each configured repo's base branch relative to its remote, and drives the
+// one-button pull/push actions exposed by the dashboard.
+//
+// The cache lives at ~/.clawflow/data/git-status.json (next to the other
+// dashboard snapshots) and is indexed by repo full name. The dashboard reads
+// the cache for instant render (Hook), a background tick in `clawflow web`
+// refreshes it at low frequency (fetch + recompute), and explicit refresh /
+// pull / push requests update the relevant entry in place.
+package gitsync
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/branch"
+	"github.com/zhoushoujianwork/clawflow/internal/clone"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+)
+
+// Status is the cached sync state for one repo's base branch. It is the shape
+// the dashboard consumes from /data/git-status.json and the git-status API.
+type Status struct {
+	Repo        string    `json:"repo"`
+	Branch      string    `json:"branch"`
+	Ahead       int       `json:"ahead"`
+	Behind      int       `json:"behind"`
+	Dirty       bool      `json:"dirty"`
+	HasUpstream bool      `json:"has_upstream"`
+	HasClone    bool      `json:"has_clone"`
+	Current     string    `json:"current,omitempty"`
+	LastFetch   time.Time `json:"last_fetch"`
+	Error       string    `json:"error,omitempty"`
+}
+
+// cacheMu serializes read-modify-write of the on-disk cache so concurrent
+// refresh / pull / push handlers don't clobber each other's entries.
+var cacheMu sync.Mutex
+
+// CacheFile is the path to the on-disk status cache.
+func CacheFile() string {
+	return filepath.Join(snapshot.DataDir(), "git-status.json")
+}
+
+// ReadCache loads all cached entries. A missing or unreadable file yields an
+// empty slice (not an error) so first-run and corrupt-file cases render empty
+// rather than failing the dashboard.
+func ReadCache() []Status {
+	data, err := os.ReadFile(CacheFile())
+	if err != nil {
+		return nil
+	}
+	var entries []Status
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil
+	}
+	return entries
+}
+
+func writeCache(entries []Status) error {
+	path := CacheFile()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-gitstatus-")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// upsert merges one entry into the cache by repo full name, preserving the
+// entries of all other repos.
+func upsert(s Status) error {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	entries := ReadCache()
+	replaced := false
+	for i := range entries {
+		if entries[i].Repo == s.Repo {
+			entries[i] = s
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		entries = append(entries, s)
+	}
+	return writeCache(entries)
+}
+
+// LocalPath resolves the on-disk clone path for a repo without cloning. It
+// prefers the configured LocalPath (when it exists on disk) and otherwise
+// looks for an auto-clone at the conventional location. Returns "" when no
+// local clone is present.
+func LocalPath(cfg *config.Config, repo string) string {
+	repoCfg, ok := cfg.Repos[repo]
+	if !ok {
+		return ""
+	}
+	if repoCfg.LocalPath != "" {
+		expanded := clone.ExpandHome(repoCfg.LocalPath)
+		if _, err := os.Stat(expanded); err == nil {
+			return expanded
+		}
+	}
+	return clone.DetectLocalClone(cfg, repo, repoCfg)
+}
+
+func baseBranch(cfg *config.Config, repo string) string {
+	if r, ok := cfg.Repos[repo]; ok && r.BaseBranch != "" {
+		return r.BaseBranch
+	}
+	return "main"
+}
+
+// Refresh runs `git fetch` then recomputes the sync status for one repo and
+// writes it to the cache. When no local clone exists, it records a
+// HasClone=false entry (so the UI can show "not cloned") rather than erroring.
+// A fetch failure is non-fatal: the status is still computed against the
+// existing remote-tracking refs and the fetch error is attached for display.
+func Refresh(cfg *config.Config, repo string) Status {
+	now := time.Now().UTC()
+	base := baseBranch(cfg, repo)
+	local := LocalPath(cfg, repo)
+	if local == "" {
+		s := Status{Repo: repo, Branch: base, HasClone: false, LastFetch: now}
+		_ = upsert(s)
+		return s
+	}
+
+	s := Status{Repo: repo, Branch: base, HasClone: true, LastFetch: now}
+	if err := branch.Fetch(local); err != nil {
+		s.Error = err.Error()
+	}
+	if sync, err := branch.GetSyncStatus(local, base); err != nil {
+		if s.Error == "" {
+			s.Error = err.Error()
+		}
+	} else {
+		s.Ahead = sync.Ahead
+		s.Behind = sync.Behind
+		s.Dirty = sync.Dirty
+		s.HasUpstream = sync.HasUpstream
+		s.Current = sync.Current
+	}
+	_ = upsert(s)
+	return s
+}
+
+// RefreshAll recomputes the status for every configured repo and returns the
+// full set. Intended for the low-frequency background tick in `clawflow web`.
+func RefreshAll(cfg *config.Config) []Status {
+	out := make([]Status, 0, len(cfg.Repos))
+	for repo := range cfg.Repos {
+		out = append(out, Refresh(cfg, repo))
+	}
+	return out
+}
+
+// Pull fast-forwards the base branch from origin and refreshes the cached
+// status. Returns git's combined output, the refreshed status, and any error.
+func Pull(cfg *config.Config, repo string) (string, Status, error) {
+	base := baseBranch(cfg, repo)
+	local := LocalPath(cfg, repo)
+	if local == "" {
+		return "", Status{Repo: repo, Branch: base, HasClone: false}, errNoClone
+	}
+	out, err := branch.Pull(local, base)
+	st := Refresh(cfg, repo)
+	return out, st, err
+}
+
+// Push pushes the base branch to origin and refreshes the cached status.
+// Returns git's combined output, the refreshed status, and any error.
+func Push(cfg *config.Config, repo string) (string, Status, error) {
+	base := baseBranch(cfg, repo)
+	local := LocalPath(cfg, repo)
+	if local == "" {
+		return "", Status{Repo: repo, Branch: base, HasClone: false}, errNoClone
+	}
+	out, err := branch.Push(local, base)
+	st := Refresh(cfg, repo)
+	return out, st, err
+}
+
+// errNoClone is returned by Pull/Push when the repo has no local clone.
+var errNoClone = &noCloneError{}
+
+type noCloneError struct{}
+
+func (*noCloneError) Error() string {
+	return "该仓库尚未克隆到本地，无法执行 git 操作"
+}

--- a/internal/gitsync/gitsync_test.go
+++ b/internal/gitsync/gitsync_test.go
@@ -1,0 +1,49 @@
+package gitsync
+
+import (
+	"testing"
+)
+
+// TestCacheRoundTripAndUpsert verifies the on-disk cache write/read cycle and
+// that upsert replaces an existing repo's entry in place while preserving the
+// others. HOME is redirected to a temp dir so DataDir() resolves under it.
+func TestCacheRoundTripAndUpsert(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if got := ReadCache(); len(got) != 0 {
+		t.Fatalf("fresh cache should be empty, got %d", len(got))
+	}
+
+	if err := upsert(Status{Repo: "a/one", Branch: "main", Ahead: 2}); err != nil {
+		t.Fatalf("upsert a/one: %v", err)
+	}
+	if err := upsert(Status{Repo: "b/two", Branch: "main", Behind: 3}); err != nil {
+		t.Fatalf("upsert b/two: %v", err)
+	}
+
+	got := ReadCache()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+
+	// Update an existing entry — should replace, not append.
+	if err := upsert(Status{Repo: "a/one", Branch: "main", Ahead: 5, Dirty: true}); err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+	got = ReadCache()
+	if len(got) != 2 {
+		t.Fatalf("expected still 2 entries after update, got %d", len(got))
+	}
+	var found *Status
+	for i := range got {
+		if got[i].Repo == "a/one" {
+			found = &got[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("a/one missing after update")
+	}
+	if found.Ahead != 5 || !found.Dirty {
+		t.Errorf("a/one not updated: ahead=%d dirty=%v, want 5/true", found.Ahead, found.Dirty)
+	}
+}

--- a/web/src/components/GitSyncCell.tsx
+++ b/web/src/components/GitSyncCell.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+import { ArrowUp, ArrowDown, RefreshCw, AlertCircle, Check, Loader2, GitBranch } from 'lucide-react'
+import { cn } from '../lib/utils'
+
+// GitStatus mirrors gitsync.Status from the backend (data/git-status.json and
+// the /api/repo/git-status* endpoints).
+export interface GitStatus {
+  repo: string
+  branch: string
+  ahead: number
+  behind: number
+  dirty: boolean
+  has_upstream: boolean
+  has_clone: boolean
+  current?: string
+  last_fetch?: string
+  error?: string
+}
+
+interface GitActionResponse {
+  status: string
+  output: string
+  error?: string
+  git_status: GitStatus
+}
+
+/**
+ * GitSyncCell renders one repo's main-branch sync state plus one-click
+ * pull/push. It is surface-agnostic (repos table, repo detail, dashboard,
+ * project page) — drop it anywhere a repo row is shown and feed it the cached
+ * status. On pull/push it calls the backend, then reports the refreshed status
+ * back up via onUpdate so the parent's map stays in sync. Git failures are
+ * shown inline; the user resolves them locally (no auto-retry/conflict-fix).
+ */
+export function GitSyncCell({
+  repo,
+  status,
+  onUpdate,
+}: {
+  repo: string
+  status?: GitStatus
+  onUpdate?: (s: GitStatus) => void
+}) {
+  const [busy, setBusy] = useState<'pull' | 'push' | 'refresh' | null>(null)
+  const [error, setError] = useState<string>('')
+
+  async function action(kind: 'pull' | 'push') {
+    if (busy) return
+    setBusy(kind)
+    setError('')
+    try {
+      const resp = await fetch(`/api/repo/git-${kind}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repo }),
+      })
+      const data: GitActionResponse = await resp.json()
+      if (data.git_status) onUpdate?.(data.git_status)
+      if (data.status === 'error') {
+        setError(data.error || data.output || `git ${kind} failed`)
+      }
+    } catch {
+      setError('网络错误，请重试')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function refresh() {
+    if (busy) return
+    setBusy('refresh')
+    setError('')
+    try {
+      const resp = await fetch('/api/repo/git-status/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repo }),
+      })
+      const data: GitStatus[] = await resp.json()
+      if (Array.isArray(data) && data[0]) onUpdate?.(data[0])
+    } catch {
+      setError('网络错误，请重试')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  if (!status || !status.has_clone) {
+    return <span className="text-xs text-muted-foreground/60">not cloned</span>
+  }
+
+  const { ahead, behind, dirty, has_upstream } = status
+  const synced = has_upstream && ahead === 0 && behind === 0
+  const refreshSpin = busy === 'refresh'
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1.5">
+        {/* branch chip */}
+        <span
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono text-muted-foreground bg-muted border border-border"
+          title={`base branch: ${status.branch}${status.current && status.current !== status.branch ? ` (checked out: ${status.current})` : ''}`}
+        >
+          <GitBranch className="w-3 h-3" />
+          {status.branch}
+        </span>
+
+        {!has_upstream ? (
+          <span className="text-[10px] text-muted-foreground" title="origin 上没有对应分支">no upstream</span>
+        ) : synced ? (
+          <span className="inline-flex items-center gap-0.5 text-[11px] text-green-600" title="已与远端同步">
+            <Check className="w-3 h-3" /> up to date
+          </span>
+        ) : (
+          <>
+            {behind > 0 && (
+              <button
+                type="button"
+                onClick={() => action('pull')}
+                disabled={!!busy || dirty}
+                title={dirty ? '工作区有未提交改动，请先提交或暂存后再 pull' : `落后远端 ${behind} 个提交，点击 git pull`}
+                className={cn(
+                  'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[11px] font-semibold border transition-colors',
+                  'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100',
+                  (!!busy || dirty) && 'opacity-50 cursor-not-allowed',
+                )}
+              >
+                {busy === 'pull' ? <Loader2 className="w-3 h-3 animate-spin" /> : <ArrowDown className="w-3 h-3" />}
+                {behind}
+              </button>
+            )}
+            {ahead > 0 && (
+              <button
+                type="button"
+                onClick={() => action('push')}
+                disabled={!!busy}
+                title={`领先远端 ${ahead} 个提交，点击 git push`}
+                className={cn(
+                  'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[11px] font-semibold border transition-colors',
+                  'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100',
+                  !!busy && 'opacity-50 cursor-not-allowed',
+                )}
+              >
+                {busy === 'push' ? <Loader2 className="w-3 h-3 animate-spin" /> : <ArrowUp className="w-3 h-3" />}
+                {ahead}
+              </button>
+            )}
+          </>
+        )}
+
+        {dirty && (
+          <span className="text-[10px] text-amber-600" title="工作区有未提交改动">dirty</span>
+        )}
+
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={!!busy}
+          title="重新检测同步状态（git fetch）"
+          className="inline-flex items-center text-muted-foreground/60 hover:text-foreground disabled:opacity-50"
+        >
+          <RefreshCw className={cn('w-3 h-3', refreshSpin && 'animate-spin')} />
+        </button>
+      </div>
+
+      {(error || status.error) && (
+        <div
+          className="flex items-start gap-1 text-[10px] text-destructive max-w-[280px]"
+          title={error || status.error}
+        >
+          <AlertCircle className="w-3 h-3 shrink-0 mt-0.5" />
+          <span className="break-words line-clamp-3">{error || status.error}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/routes/_app.repos.index.tsx
+++ b/web/src/routes/_app.repos.index.tsx
@@ -5,6 +5,7 @@ import { FolderOpen, Plus, Trash2, Link2, Link2Off, Search, X, Check, Loader2 } 
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
+import { GitSyncCell, type GitStatus } from '../components/GitSyncCell'
 import { useConfigChanged } from '../lib/configEvents'
 
 interface Repo {
@@ -53,6 +54,11 @@ function RepoList() {
 
   const [repos, setRepos] = useState<Repo[]>([])
   const [runs, setRuns] = useState<RunEntry[]>([])
+  // Git sync status keyed by repo full_name. Seeded from the cached
+  // /api/repo/git-status (instant) then refreshed in the background (the
+  // Hook: git fetch + recompute) so the user sees ahead/behind without
+  // waiting on a live fetch per render.
+  const [gitStatus, setGitStatus] = useState<Record<string, GitStatus>>({})
   const [ideScheme, setIdeScheme] = useState('vscode://file/')
   const [hostname, setHostname] = useState<string>('')
   const [loading, setLoading] = useState(true)
@@ -74,9 +80,17 @@ function RepoList() {
       fetch('/api/settings', { cache: 'no-store' })
         .then(r => (r.ok ? r.json() : null))
         .catch(() => null),
-    ]).then(([rp, rn, settings]) => {
+      fetch('/api/repo/git-status', { cache: 'no-store' })
+        .then(r => (r.ok ? r.json() : []))
+        .catch(() => []),
+    ]).then(([rp, rn, settings, gs]) => {
       setRepos(Array.isArray(rp) ? rp : [])
       setRuns(Array.isArray(rn) ? rn : [])
+      if (Array.isArray(gs)) {
+        const m: Record<string, GitStatus> = {}
+        for (const s of gs as GitStatus[]) if (s?.repo) m[s.repo] = s
+        setGitStatus(m)
+      }
       if (settings?.global?.default_ide) {
         const ide = settings.global.default_ide as string
         const schemeMap: Record<string, string> = {
@@ -94,6 +108,31 @@ function RepoList() {
 
   useEffect(() => { loadAll() }, [loadAll])
   useConfigChanged(loadAll)
+
+  // Apply a single repo's refreshed git status into the map.
+  const updateGitStatus = useCallback((s: GitStatus) => {
+    if (!s?.repo) return
+    setGitStatus(prev => ({ ...prev, [s.repo]: s }))
+  }, [])
+
+  // Hook: once repos are loaded, kick off a background fetch+recompute for
+  // all of them so ahead/behind reflects the latest remote without blocking
+  // first paint. Runs once per mount; the cache covers subsequent renders and
+  // the 5-min web backstop keeps it warm.
+  const didRefreshGit = useRef(false)
+  useEffect(() => {
+    if (loading || didRefreshGit.current) return
+    didRefreshGit.current = true
+    fetch('/api/repo/git-status/refresh', { method: 'POST' })
+      .then(r => (r.ok ? r.json() : []))
+      .then((arr: GitStatus[]) => {
+        if (!Array.isArray(arr)) return
+        const m: Record<string, GitStatus> = {}
+        for (const s of arr) if (s?.repo) m[s.repo] = s
+        setGitStatus(m)
+      })
+      .catch(() => { /* background best-effort */ })
+  }, [loading])
 
   const counts = useMemo(() => {
     const c = new Map<string, number>()
@@ -369,6 +408,7 @@ function RepoList() {
                 <th className="text-left px-4 py-2 font-semibold">Repo</th>
                 <th className="text-left px-4 py-2 font-semibold">Last activity</th>
                 <th className="text-left px-4 py-2 font-semibold">Base</th>
+                <th className="text-left px-4 py-2 font-semibold">Sync</th>
                 <th className="text-left px-4 py-2 font-semibold">Enabled</th>
                 <th className="text-left px-4 py-2 font-semibold">Auto-approve</th>
                 <th className="text-left px-4 py-2 font-semibold">Auto-merge</th>
@@ -412,6 +452,13 @@ function RepoList() {
                     {lastActivityMap[r.full_name] ? timeAgo(lastActivityMap[r.full_name]) : '—'}
                   </td>
                   <td className="px-4 py-2 text-muted-foreground font-mono text-xs">{r.base_branch}</td>
+                  <td className="px-4 py-2">
+                    <GitSyncCell
+                      repo={r.full_name}
+                      status={gitStatus[r.full_name]}
+                      onUpdate={updateGitStatus}
+                    />
+                  </td>
                   <td className="px-4 py-2">
                     <TogglePill
                       on={r.enabled}


### PR DESCRIPTION
Fixes #243

## 做了什么

在 Repo 维度感知本地主分支相对远端的同步状态，并在 repos 列表上提供一键 pull/push。失败时把 git 错误就地展示，由用户回本地自行处理（不做自动重试/解冲突）。

### 后端

- **`internal/branch`**
  - `GetSyncStatus(localPath, base)`：用 `git rev-list --left-right --count origin/<base>...<base>` 算 ahead/behind，附带 `dirty`(`git status --porcelain`)、`has_upstream`(origin/<base> 是否存在)、当前 checkout 分支。
  - `Pull`：`git pull --ff-only origin <base>`，并加了「仅在 base 分支上才允许 pull」的护栏（避免把 feature 分支误推进）。
  - `Push`：`git push origin <base>`（显式推 ref，不依赖当前 checkout）。
  - **加固 `Fetch`**：补上 `GIT_TERMINAL_PROMPT=0` 和 SSH `BatchMode`，与 `clone.cloneRepo` 一致，避免后台无人值守 fetch 在凭证/passphrase 提示上挂死（同 issue #216 类）。
- **`internal/gitsync`**（新包）：fetch + 重算的编排，以及原子写入的缓存 `~/.clawflow/data/git-status.json`（按 repo 索引）。无本地 clone 时记 `has_clone=false`，不报错。
- **`internal/api/git_status.go`**：
  - `GET /api/repo/git-status` —— 读缓存（即时）
  - `POST /api/repo/git-status/refresh` —— 带 `repo` 刷新单个（Hook），不带则刷新全部
  - `POST /api/repo/git-pull` / `POST /api/repo/git-push` —— 执行并回传 git 输出；git 失败返回 200 + `status:error`，让前端就地展示
- **`web.go`**：注册路由 + 低频后台 tick（启动 10s 后预热，之后每 5 分钟 `git fetch` 刷缓存）作为 Hook 的兜底。

### 前端

- **`GitSyncCell`**（可复用组件）：branch 徽标 + ahead/behind 箭头按钮 + dirty 标识 + 重新检测；dirty 时禁用 pull 并提示；错误就地展示。
- repos 列表新增 **Sync** 列：先读缓存即时渲染，挂载后后台触发一次 refresh。

## 测试

- `go test ./...` 全绿。新增 `internal/branch/sync_test.go`（用 bare remote + clone 覆盖 clean/ahead/behind/dirty/no-upstream/pull-ff/wrong-branch-refused/push）与 `internal/gitsync/gitsync_test.go`（缓存读写 + upsert）。
- `pnpm build`（含 `tsc --noEmit`）通过。
- 运行时冒烟：`clawflow web` 起服务，确认 `GET /api/repo/git-status` 返回缓存（后台 tick 已用真实仓库填充，含 branch/ahead/behind/has_clone）、方法守卫 405、未知 repo 404。

## 范围说明 / 后续

本 PR 落地了评估里点名的**主战场 repos 列表**（`_app.repos.index.tsx`）。`GitSyncCell` 设计为 surface-agnostic，可直接复用到 repo 详情 / dashboard / projects 详情页——这几处接入留作后续小改动，不在本 PR 范围内（评估也把「所有展示面清单」列为待确认项）。

pull/push 鉴权复用 origin remote 已配置的凭证（HTTPS token 或 SSH key）；如 origin 无可用凭证会失败并把 git 报错回显，符合「展示错误、用户自处理」的约定。