### PR TITLE
fix(operator): track-progress 需 PR 已 merge 才算子任务完成

### DIFF
--- a/skills/track-progress/SKILL.md
+++ b/skills/track-progress/SKILL.md
@@ -42,14 +42,31 @@ If the command returns an error or empty list, fall back to parsing the checklis
 clawflow issue list --repo {repo} --state all --json
 ```
 
+### Step 1b: Fetch all PRs (needed to verify merges)
+
+Run:
+```
+clawflow pr list --repo {repo} --state all --json
+```
+
+This returns every PR as a JSON array. Each entry has `number`, `title`, `head_branch`, `body`, `state`, and `merged_at`. You will use this in Step 2 to confirm whether an implemented sub-issue's PR has actually been **merged** (not just opened).
+
+A PR is **merged** when `state == "merged"` OR `merged_at` is a non-empty string. An open PR (`state == "open"`, empty `merged_at`) is NOT merged, even if the sub-issue carries `agent-implemented`.
+
 ### Step 2: Determine completion status for each sub-issue
 
-A sub-issue is **done** if:
-- `state` is `"closed"`, OR
-- `labels` contains `"agent-implemented"`, OR
-- `labels` contains `"agent-skipped"`
+The critical distinction: `agent-implemented` only means a PR was **opened**, not that it **landed**. A sub-issue's work is not done until its PR is merged (or it was explicitly skipped). Use these rules, in order:
 
-Otherwise it is **pending**.
+A sub-issue is **done** if:
+- `state` is `"closed"` (a merged PR with `Fixes #N` auto-closes the sub-issue), OR
+- `labels` contains `"agent-skipped"`, OR
+- `labels` contains `"agent-implemented"` **AND its PR is merged** — locate the PR from Step 1b by matching `head_branch == "fix/issue-{N}"` or a `Fixes #{N}` reference in the PR `body`, then confirm it is merged (`state == "merged"` or non-empty `merged_at`).
+
+A sub-issue is **pending** if:
+- It carries `"agent-implemented"` but its PR is still open, or no matching PR can be found (the change has not landed yet — re-check next run), OR
+- It has none of the above signals.
+
+When a sub-issue is pending only because its PR is open/unmerged, note that in the status table (e.g. `⏳ PR open, not merged`) so the reason is visible.
 
 ### Step 3: Build status report
 
@@ -58,8 +75,9 @@ Otherwise it is **pending**.
 
 | Sub-issue | Title | Status |
 |---|---|---|
-| #{n1} | {title} | ✅ Done |
-| #{n2} | {title} | ⏳ Pending |
+| #{n1} | {title} | ✅ Done (merged) |
+| #{n2} | {title} | ⏳ PR open, not merged |
+| #{n3} | {title} | ⏳ Pending |
 
 **{done}/{total} sub-issues complete.**
 ```
@@ -92,4 +110,6 @@ Otherwise it is **pending**.
 
 - Always re-fetch sub-issue state fresh via `list-sub` — do not rely on checklist checkboxes in the body (they may be stale).
 - If `list-sub` fails for a sub-issue, treat it as pending and note the error in the table.
+- `agent-implemented` ≠ done. It means a PR was opened, not merged. Never close a tracking issue while a sub-issue's PR is still open — re-check on the next run instead.
+- If `pr list` fails or returns no matching PR for an `agent-implemented` sub-issue, treat that sub-issue as pending (its change has not been confirmed to land).
 - The outcome marker MUST be the last non-empty line of stdout.


### PR DESCRIPTION
Fixes #246

## 问题
`track-progress` 算子的 Step 2「Determine completion status」把 `agent-implemented` 无条件计入 done。但 `agent-implemented` 的语义只是「PR 已开出」，并不代表「已 merge」。当 `auto_merge` 关闭（或合并撞上瞬时竞态失败，如 #224）时，子任务带着 `agent-implemented` 但 PR 仍 open，父 tracking issue 就会在改动未落地时被提前标 `agent-closed` 并关闭。这正是用户观察到的「2/3 进度却被关闭」——success 被当成了 done。

## 改动
仅改 `skills/track-progress/SKILL.md`（纯 prompt 局部改动）：

1. 新增 **Step 1b**：`clawflow pr list --repo {repo} --state all --json` 拉取全部 PR，定义「merged」信号为 `state == "merged"` 或非空 `merged_at`（对应 `PR.IsMerged()` 语义）。
2. 重写 **Step 2** done 判定，按顺序：
   - `state == "closed"`（合并带 `Fixes #N` 会自动关闭子 issue）→ done
   - `agent-skipped` → done
   - `agent-implemented` **且其 PR 已 merge**（按 `head_branch == fix/issue-{N}` 或 body 含 `Fixes #N` 定位 PR）→ done
   - `agent-implemented` 但 PR 仍 open / 无法定位 → **pending**（父 issue 保持 `agent-watching`，下轮再查）
3. 状态表新增 `⏳ PR open, not merged` 行；Constraints 明确「`agent-implemented` ≠ done」「pr list 失败或无匹配 PR 时按 pending 处理」。

## 测试
- `go test ./internal/operator/...` 通过。
- 改动为纯 markdown 算子文件，通过 `embed.FS` (`//go:embed all:skills`) 嵌入，无 Go 代码变更。
- 注：本 worktree 缺少前端构建产物 `web/dist`，根包全量 `go build` 因该 embed 模式无法在此快照完成（与本改动无关）；CI 会用完整产物构建。

修复合入后建议在 `daboluocc/bbclaw #89` 上移除 `agent-closed` 重新跑一轮验证。