### PR TITLE
fix(config): honor gitlab_hosts scheme/port when parsing SSH repo input

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -958,6 +958,47 @@ func ReadGitRemoteURL(dir string) (string, error) {
 	return "", fmt.Errorf("no remote origin found in %s/.git/config", dir)
 }
 
+// normalizeGitLabHost converts a configured gitlab_hosts entry into a full URL,
+// preserving an explicit scheme and port. A bare hostname defaults to https.
+//
+//	"gitlab.company.com"           → "https://gitlab.company.com"
+//	"http://git.internal.com:8080" → "http://git.internal.com:8080"
+//	"https://gitlab.com/"          → "https://gitlab.com"
+//
+// It mirrors internal/api.normalizeGitLabURL; the logic is duplicated here
+// because the api package imports config and cannot be imported back.
+func normalizeGitLabHost(host string) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "http://") || strings.HasPrefix(host, "https://") {
+		return strings.TrimSuffix(host, "/")
+	}
+	return "https://" + host
+}
+
+// gitlabHostName extracts the bare, lowercased hostname (no scheme or port)
+// from a configured gitlab_hosts entry, for comparison against an SSH/URL host.
+func gitlabHostName(entry string) string {
+	u, err := url.Parse(normalizeGitLabHost(entry))
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(entry))
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+// resolveGitLabBaseURL returns the API base URL for an SSH/URL host. When the
+// host matches a configured gitlab_hosts entry, the entry's normalized full URL
+// is used so its scheme and port are honored (e.g. an http-only self-hosted
+// instance). Otherwise it falls back to "https://" + host.
+func resolveGitLabBaseURL(host string, gitlabHosts []string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	for _, h := range gitlabHosts {
+		if gitlabHostName(h) == host {
+			return normalizeGitLabHost(h)
+		}
+	}
+	return "https://" + host
+}
+
 // ParseRepoInput parses a repo argument which may be:
 //   - "owner/repo"                          → github (default)
 //   - "https://github.com/owner/repo"       → github
@@ -1004,13 +1045,9 @@ func ParseRepoInput(input string, gitlabHosts []string) (RepoInfo, error) {
 			parts := strings.SplitN(fullPath, "/", 3)
 			return RepoInfo{OwnerRepo: parts[0] + "/" + parts[1], Platform: "github"}, nil
 		}
-		// GitLab: keep full path
-		baseURL := "https://" + host
-		for _, h := range gitlabHosts {
-			if strings.ToLower(strings.TrimSpace(h)) == host {
-				return RepoInfo{OwnerRepo: fullPath, Platform: "gitlab", BaseURL: baseURL}, nil
-			}
-		}
+		// GitLab: keep full path. Honor the configured gitlab_hosts entry's
+		// scheme/port (e.g. http-only self-hosted) instead of assuming https.
+		baseURL := resolveGitLabBaseURL(host, gitlabHosts)
 		return RepoInfo{OwnerRepo: fullPath, Platform: "gitlab", BaseURL: baseURL}, nil
 	}
 
@@ -1043,12 +1080,15 @@ func ParseRepoInput(input string, gitlabHosts []string) (RepoInfo, error) {
 	if fullPath == "" || !strings.Contains(fullPath, "/") {
 		return RepoInfo{}, fmt.Errorf("URL %q does not contain a valid project path", input)
 	}
+	// Default to the scheme/host the user typed. If the host matches a
+	// configured gitlab_hosts entry, prefer that entry's scheme/port so an
+	// http-only self-hosted instance is honored even when an https URL is passed.
 	baseURL := u.Scheme + "://" + u.Host
 	for _, h := range gitlabHosts {
-		if strings.ToLower(strings.TrimSpace(h)) == host {
-			return RepoInfo{OwnerRepo: fullPath, Platform: "gitlab", BaseURL: baseURL}, nil
+		if gitlabHostName(h) == host {
+			baseURL = normalizeGitLabHost(h)
+			break
 		}
 	}
-	// unknown host — assume gitlab self-hosted
 	return RepoInfo{OwnerRepo: fullPath, Platform: "gitlab", BaseURL: baseURL}, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,37 +7,49 @@ import (
 )
 
 func TestParseRepoInput(t *testing.T) {
-	gitlabHosts := []string{"gitlab.company.com"}
-
 	cases := []struct {
-		input       string
-		wantOwner   string
+		input        string
+		gitlabHosts  []string
+		wantOwner    string
 		wantPlatform string
-		wantBaseURL string
-		wantErr     bool
+		wantBaseURL  string
+		wantErr      bool
 	}{
 		// plain owner/repo → github
-		{"owner/repo", "owner/repo", "github", "", false},
+		{"owner/repo", []string{"gitlab.company.com"}, "owner/repo", "github", "", false},
 		// github HTTPS URL
-		{"https://github.com/owner/repo", "owner/repo", "github", "", false},
-		{"https://github.com/owner/repo.git", "owner/repo", "github", "", false},
+		{"https://github.com/owner/repo", []string{"gitlab.company.com"}, "owner/repo", "github", "", false},
+		{"https://github.com/owner/repo.git", []string{"gitlab.company.com"}, "owner/repo", "github", "", false},
 		// github SSH
-		{"git@github.com:owner/repo.git", "owner/repo", "github", "", false},
+		{"git@github.com:owner/repo.git", []string{"gitlab.company.com"}, "owner/repo", "github", "", false},
 		// gitlab HTTPS — known host
-		{"https://gitlab.company.com/ns/repo", "ns/repo", "gitlab", "https://gitlab.company.com", false},
+		{"https://gitlab.company.com/ns/repo", []string{"gitlab.company.com"}, "ns/repo", "gitlab", "https://gitlab.company.com", false},
 		// gitlab HTTPS — nested namespace
-		{"https://gitlab.company.com/ns/group/repo", "ns/group/repo", "gitlab", "https://gitlab.company.com", false},
-		// gitlab HTTPS — unknown host (self-hosted)
-		{"http://git.patsnap.com/devops/platform/insightgo.git", "devops/platform/insightgo", "gitlab", "http://git.patsnap.com", false},
+		{"https://gitlab.company.com/ns/group/repo", []string{"gitlab.company.com"}, "ns/group/repo", "gitlab", "https://gitlab.company.com", false},
+		// gitlab HTTPS — unknown host (self-hosted), user-typed scheme preserved
+		{"http://git.patsnap.com/devops/platform/insightgo.git", []string{"gitlab.company.com"}, "devops/platform/insightgo", "gitlab", "http://git.patsnap.com", false},
 		// gitlab SSH
-		{"git@gitlab.company.com:ns/group/repo.git", "ns/group/repo", "gitlab", "https://gitlab.company.com", false},
+		{"git@gitlab.company.com:ns/group/repo.git", []string{"gitlab.company.com"}, "ns/group/repo", "gitlab", "https://gitlab.company.com", false},
+
+		// --- issue #248: SSH branch must honor configured scheme/port ---
+		// SSH host matches a configured http:// entry → base_url keeps http
+		{"git@git.patsnap.com:devops/pop-web.git", []string{"http://git.patsnap.com"}, "devops/pop-web", "gitlab", "http://git.patsnap.com", false},
+		// SSH host with bare-hostname entry → defaults to https
+		{"git@git.patsnap.com:devops/pop-web.git", []string{"git.patsnap.com"}, "devops/pop-web", "gitlab", "https://git.patsnap.com", false},
+		// SSH host with custom port entry → scheme and port preserved
+		{"git@git.internal.com:ns/repo.git", []string{"http://git.internal.com:8080"}, "ns/repo", "gitlab", "http://git.internal.com:8080", false},
+		// SSH host not in config → fallback https + host (backward compatible)
+		{"git@git.unknown.com:ns/repo.git", []string{"http://git.patsnap.com"}, "ns/repo", "gitlab", "https://git.unknown.com", false},
+		// HTTPS URL whose host matches an http:// config entry → config scheme wins
+		{"https://git.patsnap.com/devops/pop-web", []string{"http://git.patsnap.com"}, "devops/pop-web", "gitlab", "http://git.patsnap.com", false},
+
 		// invalid
-		{"notarepo", "", "", "", true},
+		{"notarepo", []string{"gitlab.company.com"}, "", "", "", true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {
-			info, err := config.ParseRepoInput(tc.input, gitlabHosts)
+			info, err := config.ParseRepoInput(tc.input, tc.gitlabHosts)
 			if tc.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")


### PR DESCRIPTION
Fixes #248

## 根因

`ParseRepoInput` 的 SSH 分支硬编码 `https://` 作为自建 GitLab 的 base_url，且用原始 `gitlab_hosts` 条目（可能带 scheme，如 `http://git.patsnap.com`）直接与裸 hostname 比较，导致带 scheme 的条目永远匹配不上——整个循环是死代码，无论匹配与否返回值相同。

对于只提供 http 服务的自建实例，repo add 落库的 base_url 始终是 https，于是 token 校验路径（走 `normalizeGitLabURL`，尊重 scheme）能过，但 label init 因 `dial tcp ...:443: connect: connection refused` 失败。

## 修改

- 新增 `normalizeGitLabHost` / `gitlabHostName` / `resolveGitLabBaseURL` 三个 helper（与 `internal/api.normalizeGitLabURL` 逻辑一致；因 api 依赖 config 不能反向 import，故在 config 包内复制）。
- SSH 分支：按规范化 hostname 匹配 `gitlab_hosts`，命中时保留该条目的 scheme 与 port，未命中回退 `https://` + host（向后兼容）。
- HTTPS URL 分支：清理同样的死循环；默认保留用户输入的 scheme，命中配置条目时以配置的 scheme/port 为准。

## 测试

`go test ./internal/config/...` 通过。新增用例覆盖：
- `http://git.patsnap.com` 条目 + SSH 输入 → base_url 为 `http://git.patsnap.com`
- 裸 hostname 条目 → 默认 https
- 带端口条目 `http://git.internal.com:8080` → scheme 与 port 均保留
- 未配置 host → 回退 https（向后兼容）
- HTTPS 输入命中 http 配置条目 → 以配置 scheme 为准

## 存量数据说明

本修复不会自动纠正已落库的错误 base_url。受影响用户需 `repo remove` 后用 `--base-url http://...` 重新 add，或手改 config.yaml。