### PR TITLE
fix(web): 统一 repo 路径为 /repos/{org}/{repo}，消除 %252F 双重编码

### DIFF
--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -587,8 +587,8 @@ function IssueRow({
         />
         {showRepo && (
           <Link
-            to="/repos/$repoName"
-            params={{ repoName: encodeURIComponent(group.repo) }}
+            to="/repos/$"
+            params={{ _splat: group.repo }}
             onClick={e => e.stopPropagation()}
             className="font-mono text-[11px] text-muted-foreground hover:text-foreground hover:underline shrink-0 max-w-[14rem] truncate"
             title={group.repo}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -19,7 +19,7 @@ import { Route as AppDashboardRouteImport } from './routes/_app.dashboard'
 import { Route as AppReposIndexRouteImport } from './routes/_app.repos.index'
 import { Route as AppProjectsIndexRouteImport } from './routes/_app.projects.index'
 import { Route as AppReposAddRouteImport } from './routes/_app.repos.add'
-import { Route as AppReposRepoNameRouteImport } from './routes/_app.repos.$repoName'
+import { Route as AppReposSplatRouteImport } from './routes/_app.repos.$'
 import { Route as AppProjectsNameRouteImport } from './routes/_app.projects.$name'
 import { Route as AppProjectsNamePilotRunsRouteImport } from './routes/_app.projects.$name_.pilot-runs'
 import { Route as AppRunsSlugIssueTsRouteImport } from './routes/_app.runs.$slug.$issue.$ts'
@@ -73,9 +73,9 @@ const AppReposAddRoute = AppReposAddRouteImport.update({
   path: '/repos/add',
   getParentRoute: () => AppRoute,
 } as any)
-const AppReposRepoNameRoute = AppReposRepoNameRouteImport.update({
-  id: '/repos/$repoName',
-  path: '/repos/$repoName',
+const AppReposSplatRoute = AppReposSplatRouteImport.update({
+  id: '/repos/$',
+  path: '/repos/$',
   getParentRoute: () => AppRoute,
 } as any)
 const AppProjectsNameRoute = AppProjectsNameRouteImport.update({
@@ -103,7 +103,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof AppSettingsRoute
   '/usage': typeof AppUsageRoute
   '/projects/$name': typeof AppProjectsNameRoute
-  '/repos/$repoName': typeof AppReposRepoNameRoute
+  '/repos/$': typeof AppReposSplatRoute
   '/repos/add': typeof AppReposAddRoute
   '/projects/': typeof AppProjectsIndexRoute
   '/repos/': typeof AppReposIndexRoute
@@ -117,7 +117,7 @@ export interface FileRoutesByTo {
   '/settings': typeof AppSettingsRoute
   '/usage': typeof AppUsageRoute
   '/projects/$name': typeof AppProjectsNameRoute
-  '/repos/$repoName': typeof AppReposRepoNameRoute
+  '/repos/$': typeof AppReposSplatRoute
   '/repos/add': typeof AppReposAddRoute
   '/projects': typeof AppProjectsIndexRoute
   '/repos': typeof AppReposIndexRoute
@@ -134,7 +134,7 @@ export interface FileRoutesById {
   '/_app/settings': typeof AppSettingsRoute
   '/_app/usage': typeof AppUsageRoute
   '/_app/projects/$name': typeof AppProjectsNameRoute
-  '/_app/repos/$repoName': typeof AppReposRepoNameRoute
+  '/_app/repos/$': typeof AppReposSplatRoute
   '/_app/repos/add': typeof AppReposAddRoute
   '/_app/projects/': typeof AppProjectsIndexRoute
   '/_app/repos/': typeof AppReposIndexRoute
@@ -151,7 +151,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/usage'
     | '/projects/$name'
-    | '/repos/$repoName'
+    | '/repos/$'
     | '/repos/add'
     | '/projects/'
     | '/repos/'
@@ -165,7 +165,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/usage'
     | '/projects/$name'
-    | '/repos/$repoName'
+    | '/repos/$'
     | '/repos/add'
     | '/projects'
     | '/repos'
@@ -181,7 +181,7 @@ export interface FileRouteTypes {
     | '/_app/settings'
     | '/_app/usage'
     | '/_app/projects/$name'
-    | '/_app/repos/$repoName'
+    | '/_app/repos/$'
     | '/_app/repos/add'
     | '/_app/projects/'
     | '/_app/repos/'
@@ -266,11 +266,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppReposAddRouteImport
       parentRoute: typeof AppRoute
     }
-    '/_app/repos/$repoName': {
-      id: '/_app/repos/$repoName'
-      path: '/repos/$repoName'
-      fullPath: '/repos/$repoName'
-      preLoaderRoute: typeof AppReposRepoNameRouteImport
+    '/_app/repos/$': {
+      id: '/_app/repos/$'
+      path: '/repos/$'
+      fullPath: '/repos/$'
+      preLoaderRoute: typeof AppReposSplatRouteImport
       parentRoute: typeof AppRoute
     }
     '/_app/projects/$name': {
@@ -319,7 +319,7 @@ interface AppRouteChildren {
   AppProjectsRoute: typeof AppProjectsRouteWithChildren
   AppSettingsRoute: typeof AppSettingsRoute
   AppUsageRoute: typeof AppUsageRoute
-  AppReposRepoNameRoute: typeof AppReposRepoNameRoute
+  AppReposSplatRoute: typeof AppReposSplatRoute
   AppReposAddRoute: typeof AppReposAddRoute
   AppReposIndexRoute: typeof AppReposIndexRoute
   AppRunsSlugIssueTsRoute: typeof AppRunsSlugIssueTsRoute
@@ -331,7 +331,7 @@ const AppRouteChildren: AppRouteChildren = {
   AppProjectsRoute: AppProjectsRouteWithChildren,
   AppSettingsRoute: AppSettingsRoute,
   AppUsageRoute: AppUsageRoute,
-  AppReposRepoNameRoute: AppReposRepoNameRoute,
+  AppReposSplatRoute: AppReposSplatRoute,
   AppReposAddRoute: AppReposAddRoute,
   AppReposIndexRoute: AppReposIndexRoute,
   AppRunsSlugIssueTsRoute: AppRunsSlugIssueTsRoute,

--- a/web/src/routes/_app.dashboard.tsx
+++ b/web/src/routes/_app.dashboard.tsx
@@ -973,8 +973,8 @@ function PendingRow({ p, repoMap }: { p: Pending; repoMap: RepoInfoMap }) {
         {p.issue_title || '(no title)'}
       </span>
       <Link
-        to="/repos/$repoName"
-        params={{ repoName: encodeURIComponent(p.repo) }}
+        to="/repos/$"
+        params={{ _splat: p.repo }}
         onClick={e => e.stopPropagation()}
         className="text-xs text-muted-foreground hover:text-foreground hover:underline shrink-0 hidden sm:inline"
       >
@@ -1135,8 +1135,8 @@ function IssueGroupRow({
           {timeAgo(group.lastActivity)}
         </span>
         <Link
-          to="/repos/$repoName"
-          params={{ repoName: encodeURIComponent(group.repo) }}
+          to="/repos/$"
+          params={{ _splat: group.repo }}
           className="text-xs text-muted-foreground hover:text-foreground hover:underline shrink-0 hidden lg:inline"
           onClick={e => e.stopPropagation()}
         >
@@ -1259,8 +1259,8 @@ function Row({
         #{r.issue_number}
       </a>
       <Link
-        to="/repos/$repoName"
-        params={{ repoName: encodeURIComponent(r.repo) }}
+        to="/repos/$"
+        params={{ _splat: r.repo }}
         className="text-xs text-muted-foreground hover:text-foreground hover:underline shrink-0 hidden sm:inline"
       >
         {r.repo}

--- a/web/src/routes/_app.projects.$name.tsx
+++ b/web/src/routes/_app.projects.$name.tsx
@@ -1290,8 +1290,8 @@ function ProjectDetail() {
                         className="flex items-center justify-between px-4 py-2 hover:bg-secondary/20 group gap-3"
                       >
                         <Link
-                          to="/repos/$repoName"
-                          params={{ repoName: encodeURIComponent(repo) }}
+                          to="/repos/$"
+                          params={{ _splat: repo }}
                           className="font-mono text-sm text-foreground hover:underline truncate"
                           title={repo}
                         >

--- a/web/src/routes/_app.repos.$.tsx
+++ b/web/src/routes/_app.repos.$.tsx
@@ -26,13 +26,15 @@ interface Repo {
   auto_merge: boolean
   bound_machine?: string
 }
-export const Route = createFileRoute('/_app/repos/$repoName')({
+export const Route = createFileRoute('/_app/repos/$')({
   component: RepoDetail,
 })
 
 function RepoDetail() {
-  const { repoName } = Route.useParams()
-  const fullName = decodeURIComponent(repoName)
+  const { _splat } = Route.useParams()
+  // Splat segment preserves `/` literally — `org/repo` arrives intact with
+  // no encoding, so no decodeURIComponent dance and no `%2F`/`%252F`.
+  const fullName = _splat ?? ''
   const chatDrawer = useChatDrawer()
 
   const [repo, setRepo] = useState<Repo | null>(null)

--- a/web/src/routes/_app.repos.index.tsx
+++ b/web/src/routes/_app.repos.index.tsx
@@ -422,8 +422,8 @@ function RepoList() {
                   <td className="px-4 py-2">
                     <div className="flex items-center gap-2">
                       <Link
-                        to="/repos/$repoName"
-                        params={{ repoName: encodeURIComponent(r.full_name) }}
+                        to="/repos/$"
+                        params={{ _splat: r.full_name }}
                         className="font-mono text-foreground hover:underline"
                       >
                         {r.full_name}

--- a/web/src/routes/_app.runs.$slug.$issue.$ts.tsx
+++ b/web/src/routes/_app.runs.$slug.$issue.$ts.tsx
@@ -153,8 +153,8 @@ function RunDetail() {
   return (
     <div className="max-w-4xl mx-auto px-4 py-6">
       <Link
-        to="/repos/$repoName"
-        params={{ repoName: encodeURIComponent(repo) }}
+        to="/repos/$"
+        params={{ _splat: repo }}
         className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mb-4"
       >
         <ChevronLeft className="w-3.5 h-3.5" /> <span className="font-mono">{repo}</span>


### PR DESCRIPTION
Fixes #252

## 问题
带组织前缀的仓库详情页 URL 形如 `/repos/patsnap%252Fopenai-plugins`：`/` 被 `encodeURIComponent` 编成 `%2F`，又被二次编码成 `%252F`，又长又难读。

## 改动
改用 TanStack Router 的 **splat 路由**承载 `org/repo`，splat 段天然保留 `/`，不再对 `/` 做任何编码：

- `_app.repos.\$repoName.tsx` → `_app.repos.\$.tsx`：路由改为 `/_app/repos/\$`，用 `params._splat` 接收整段 `org/repo`，去掉 `decodeURIComponent`。
- 统一 6 处 Link 调用点（`_app.repos.index.tsx`、`IssueList.tsx`、`_app.projects.\$name.tsx`、`_app.runs.\$slug.\$issue.\$ts.tsx`、`_app.dashboard.tsx` ×3）由 `to="/repos/\$repoName" params={{ repoName: encodeURIComponent(x) }}` 改为 `to="/repos/\$" params={{ _splat: x }}`。
- 用 TanStack Router 插件重新生成 `routeTree.gen.ts`（未手改）。
- 最终 URL：`/repos/patsnap/openai-plugins`，可读、可分享、可调试。

## 后端
无需改动：`web.go` 的 `/` SPA fallback 已对任意非资源多段路径回退 `index.html`，各 API 用 `?repo=fullName` 查询参数而非路径参数，不受影响。

## 测试
- `npm run build`（vite build + tsc --noEmit）通过，类型检查覆盖了所有 `_splat` Link 调用点。
- 已确认 `routeTree.gen.ts` 正确生成 splat 路由（`/repos/\$`），静态子路由 `/repos/add` 优先级不被 splat 吞掉。
- 未做浏览器端硬刷新冒烟（无前端 e2e 测试框架）；逻辑上 `/repos/org/repo` 命中 SPA fallback。

## 备注
已分享的旧 `%252F` 链接在新路由下会失效（404→fallback 但 `_splat` 含编码字符比对不上 config）。issue 约定直接弃用旧格式，未加兼容重定向。