### PR TITLE
feat(issue): add `clawflow issue view <id>` subcommand

### DIFF
--- a/cmd/clawflow/commands/issue.go
+++ b/cmd/clawflow/commands/issue.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -23,6 +24,7 @@ func NewIssueCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newIssueCreateCmd())
 	cmd.AddCommand(newIssueEditCmd())
+	cmd.AddCommand(newIssueViewCmd())
 	cmd.AddCommand(newIssueListCmd())
 	cmd.AddCommand(newIssueSearchCmd())
 	cmd.AddCommand(newIssueCommentCmd())
@@ -275,6 +277,59 @@ func newIssueEditCmd() *cobra.Command {
 		setTitle = cmd.Flags().Changed("title")
 		setBody = cmd.Flags().Changed("body")
 	}
+	return cmd
+}
+
+func newIssueViewCmd() *cobra.Command {
+	var repo string
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "view <id>",
+		Short: "View a single issue's details by number",
+		Long: `Show the core fields of a single issue: title, number, state (open/closed),
+labels, body, and web URL. <id> is the issue's display number (#number), not
+the platform-internal ID.`,
+		Example: "  clawflow issue view 7 --repo owner/repo\n  clawflow issue view 7 --repo owner/repo --json",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			number, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid issue id %q: must be a number", args[0])
+			}
+			client, _, err := newVCSClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			issue, err := client.GetIssue(repo, number)
+			if err != nil {
+				return err
+			}
+			if issue == nil {
+				return fmt.Errorf("issue #%d not found in %s", number, repo)
+			}
+			if jsonOutput {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(issue)
+			}
+			fmt.Printf("#%d  %s\n", issue.Number, issue.Title)
+			fmt.Printf("State:  %s\n", issue.State)
+			if len(issue.Labels) > 0 {
+				fmt.Printf("Labels: %s\n", strings.Join(issue.Labels, ", "))
+			} else {
+				fmt.Printf("Labels: (none)\n")
+			}
+			if issue.URL != "" {
+				fmt.Printf("URL:    %s\n", issue.URL)
+			}
+			fmt.Printf("\n%s\n", issue.Body)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "output the full issue as JSON")
+	_ = cmd.MarkFlagRequired("repo")
 	return cmd
 }
 

--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -964,15 +964,36 @@ func (c *Client) GetIssue(repo string, number int) (*vcs.Issue, error) {
 		return nil, fmt.Errorf("github get issue: HTTP %d: %s", status, data)
 	}
 	var raw struct {
-		ID     int64  `json:"id"`
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		State  string `json:"state"`
+		ID        int64  `json:"id"`
+		Number    int    `json:"number"`
+		Title     string `json:"title"`
+		Body      string `json:"body"`
+		State     string `json:"state"`
+		HTMLURL   string `json:"html_url"`
+		CreatedAt string `json:"created_at"`
+		UpdatedAt string `json:"updated_at"`
+		Labels    []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, err
 	}
-	return &vcs.Issue{ID: raw.ID, Number: raw.Number, Title: raw.Title, State: raw.State}, nil
+	labels := make([]string, len(raw.Labels))
+	for i, l := range raw.Labels {
+		labels[i] = l.Name
+	}
+	return &vcs.Issue{
+		ID:        raw.ID,
+		Number:    raw.Number,
+		Title:     raw.Title,
+		Body:      raw.Body,
+		State:     raw.State,
+		Labels:    labels,
+		URL:       raw.HTMLURL,
+		CreatedAt: raw.CreatedAt,
+		UpdatedAt: raw.UpdatedAt,
+	}, nil
 }
 
 // UploadAttachment is not supported on GitHub: the REST API v3 has no public

--- a/internal/vcs/github/client_test.go
+++ b/internal/vcs/github/client_test.go
@@ -181,6 +181,57 @@ func TestUpdateIssue(t *testing.T) {
 	}
 }
 
+func TestGetIssue(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/issues/7": func(w http.ResponseWriter, r *http.Request) {
+			jsonResp(w, 200, map[string]any{
+				"id":         12345,
+				"number":     7,
+				"title":      "a bug",
+				"body":       "something broke",
+				"state":      "open",
+				"html_url":   "https://github.com/owner/repo/issues/7",
+				"created_at": "2026-01-01T00:00:00Z",
+				"updated_at": "2026-01-02T00:00:00Z",
+				"labels":     []map[string]string{{"name": "bug"}, {"name": "feat"}},
+			})
+		},
+	})
+
+	issue, err := client.GetIssue("owner/repo", 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issue == nil {
+		t.Fatal("expected issue, got nil")
+	}
+	if issue.Number != 7 || issue.Title != "a bug" || issue.Body != "something broke" {
+		t.Errorf("unexpected issue: %#v", issue)
+	}
+	if issue.State != "open" || issue.URL != "https://github.com/owner/repo/issues/7" {
+		t.Errorf("unexpected state/url: %#v", issue)
+	}
+	if !issue.HasLabel("bug") || !issue.HasLabel("feat") {
+		t.Errorf("expected labels bug+feat, got %v", issue.Labels)
+	}
+}
+
+func TestGetIssueNotFound(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/issues/999": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "not found", 404)
+		},
+	})
+
+	issue, err := client.GetIssue("owner/repo", 999)
+	if err != nil {
+		t.Fatalf("expected nil error on 404, got %v", err)
+	}
+	if issue != nil {
+		t.Fatalf("expected nil issue on 404, got %#v", issue)
+	}
+}
+
 func TestInitLabels_SkipsExisting(t *testing.T) {
 	created := []string{}
 	client := newTestClient(t, map[string]http.HandlerFunc{

--- a/internal/vcs/gitlab/client.go
+++ b/internal/vcs/gitlab/client.go
@@ -769,6 +769,50 @@ func (c *Client) GetParentIssue(repo string, issueNumber int) (*vcs.Issue, error
 	return nil, vcs.ErrNotSupported
 }
 
+// GetIssue fetches a single issue by its IID (display number).
+func (c *Client) GetIssue(repo string, number int) (*vcs.Issue, error) {
+	path := fmt.Sprintf("/projects/%s/issues/%d", projectID(repo), number)
+	data, status, err := c.doJSON("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status == 404 {
+		return nil, nil
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("gitlab get issue: HTTP %d: %s", status, data)
+	}
+	var raw struct {
+		ID        int64    `json:"id"`
+		IID       int      `json:"iid"`
+		Title     string   `json:"title"`
+		Body      string   `json:"description"`
+		State     string   `json:"state"`
+		Labels    []string `json:"labels"`
+		WebURL    string   `json:"web_url"`
+		CreatedAt string   `json:"created_at"`
+		UpdatedAt string   `json:"updated_at"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	state := raw.State
+	if state == "opened" {
+		state = "open"
+	}
+	return &vcs.Issue{
+		ID:        raw.ID,
+		Number:    raw.IID,
+		Title:     raw.Title,
+		Body:      raw.Body,
+		State:     state,
+		Labels:    raw.Labels,
+		URL:       raw.WebURL,
+		CreatedAt: raw.CreatedAt,
+		UpdatedAt: raw.UpdatedAt,
+	}, nil
+}
+
 // UploadAttachment uploads a local file to the project's attachment storage via
 // POST /projects/:id/uploads and returns the ready-to-embed markdown GitLab
 // generates (e.g. "![file](/uploads/<hash>/file.png)"). The returned path is

--- a/internal/vcs/gitlab/client_test.go
+++ b/internal/vcs/gitlab/client_test.go
@@ -209,6 +209,60 @@ func TestUpdateIssue(t *testing.T) {
 	}
 }
 
+func TestGetIssue(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/issues/7": func(w http.ResponseWriter, r *http.Request) {
+			jsonResp(w, 200, map[string]any{
+				"id":          98765,
+				"iid":         7,
+				"title":       "a bug",
+				"description": "something broke",
+				"state":       "opened",
+				"labels":      []string{"bug", "feat"},
+				"web_url":     "https://gitlab.com/ns/group/repo/-/issues/7",
+				"created_at":  "2026-01-01T00:00:00Z",
+				"updated_at":  "2026-01-02T00:00:00Z",
+			})
+		},
+	})
+
+	issue, err := client.GetIssue("ns/group/repo", 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issue == nil {
+		t.Fatal("expected issue, got nil")
+	}
+	if issue.Number != 7 || issue.Title != "a bug" || issue.Body != "something broke" {
+		t.Errorf("unexpected issue: %#v", issue)
+	}
+	if issue.State != "open" {
+		t.Errorf("expected normalized state 'open', got %q", issue.State)
+	}
+	if issue.URL != "https://gitlab.com/ns/group/repo/-/issues/7" {
+		t.Errorf("unexpected url: %q", issue.URL)
+	}
+	if !issue.HasLabel("bug") || !issue.HasLabel("feat") {
+		t.Errorf("expected labels bug+feat, got %v", issue.Labels)
+	}
+}
+
+func TestGetIssueNotFound(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/issues/999": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "not found", 404)
+		},
+	})
+
+	issue, err := client.GetIssue("ns/group/repo", 999)
+	if err != nil {
+		t.Fatalf("expected nil error on 404, got %v", err)
+	}
+	if issue != nil {
+		t.Fatalf("expected nil issue on 404, got %#v", issue)
+	}
+}
+
 func TestInitLabels_SkipsExisting(t *testing.T) {
 	created := []string{}
 	client := newTestClient(t, map[string]http.HandlerFunc{

--- a/internal/vcs/interface.go
+++ b/internal/vcs/interface.go
@@ -23,8 +23,12 @@ type Issue struct {
 	Body      string   `json:"body"`
 	Labels    []string `json:"labels"`
 	State     string   `json:"state"`
-	CreatedAt string   `json:"created_at,omitempty"`
-	UpdatedAt string   `json:"updated_at,omitempty"`
+	// URL is the web (HTML) URL of the issue. Populated by GetIssue
+	// (GitHub html_url / GitLab web_url); other list calls may leave it
+	// empty.
+	URL       string `json:"url,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
 	// ClosedAt is populated only when State == "closed". GitHub /
 	// GitLab both return null when open; clients normalize to "" here.
 	// Used by Pilot's issue_digest to count "closed in last 24h"
@@ -106,6 +110,10 @@ type Client interface {
 	// Issues
 	ListOpenIssues(repo string) ([]Issue, error)
 	ListIssues(repo string, state string, labels []string) ([]Issue, error)
+	// GetIssue fetches a single issue by its display number. Returns
+	// (nil, nil) when the issue does not exist (404), so callers can
+	// distinguish "not found" from a transport error.
+	GetIssue(repo string, number int) (*Issue, error)
 	ListIssueComments(repo string, issueNumber int) ([]string, error)
 	ListIssueCommentsDetail(repo string, issueNumber int) ([]IssueComment, error)
 	CloseIssue(repo string, issueNumber int) error


### PR DESCRIPTION
Fixes #253

## What changed

新增 `clawflow issue view <id>` 子命令，直接查看单个 issue 的核心字段，免去用 `issue search` / `issue list` 间接定位。

- **`internal/vcs/interface.go`**：`vcs.Issue` 新增 `URL` 字段；`Client` 接口提升 `GetIssue(repo, number)`（404 → `nil, nil`）。
- **`internal/vcs/github/client.go`**：扩展已有 `GetIssue`，解析 `body` / `labels` / `html_url` / 时间戳。
- **`internal/vcs/gitlab/client.go`**：新增 `GetIssue`，复用 `GET /projects/:id/issues/:iid`，`web_url` → `URL`、`opened` 归一化为 `open`。
- **`cmd/clawflow/commands/issue.go`**：新增 `newIssueViewCmd`，`view <id> --repo <owner/name> [--json]`，`<id>` 为展示编号（#number）。

## Output

人读输出逐字段打印（编号+标题、State、Labels、URL、正文）；`--json` 走 `json.NewEncoder`。

## Testing

- `go test ./internal/vcs/...`：GitHub/GitLab 各补 `GetIssue`（200 全字段 + 404 → nil）用例，全绿。
- `go test ./cmd/clawflow/commands/`：通过。
- `go build ./...` / `go vet`：通过（构建时临时生成 `web/dist` 占位以满足 `//go:embed`，验证后已清理，未提交）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)