### PR TITLE
fix(web): balance multi-repo issue list with per-repo quota

### DIFF
--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -91,6 +91,13 @@ export interface SectionConfig {
   tone: 'blue' | 'amber' | 'muted' | 'gray' | 'red'
   filter: (g: IssueGroup) => boolean
   limit?: number
+  // perRepoLimit caps how many rows EACH repo may show in this section, used
+  // by cross-repo (project-level) lists so one active repo can't flood the
+  // whole section. When set and the section spans 2+ repos, rows are taken
+  // round-robin across repos (≤ perRepoLimit each) instead of global top-N;
+  // with a single repo it falls back to `limit` so per-repo views are
+  // unaffected. See limitSectionGroups.
+  perRepoLimit?: number
   emptyHidden?: boolean
 }
 
@@ -273,9 +280,53 @@ export const PROJECT_SECTIONS: SectionConfig[] = [
       return hasTrigger && !hasAgentLabel
     },
   },
-  { title: 'Done', tone: 'muted', filter: g => g.state === 'open', limit: 10 },
-  { title: 'Closed', tone: 'gray', filter: g => g.state === 'closed', limit: 10 },
+  // limit (10) is the single-repo fallback; perRepoLimit (3) kicks in once a
+  // project aggregates 2+ repos so each repo stays visible instead of the
+  // most active one flooding the whole bucket (issue #258).
+  { title: 'Done', tone: 'muted', filter: g => g.state === 'open', limit: 10, perRepoLimit: 3 },
+  { title: 'Closed', tone: 'gray', filter: g => g.state === 'closed', limit: 10, perRepoLimit: 3 },
 ]
+
+// limitSectionGroups decides which rows of a section are visible.
+//
+// Default behaviour is the historical global top-N (`groups.slice(0, limit)`).
+// When `perRepoLimit` is set AND the section spans 2+ repos, it switches to a
+// per-repo quota: groups are bucketed by repo (input is already issue-number
+// descending, so each bucket stays newest-first) and emitted round-robin so
+// every repo shows up to `perRepoLimit` rows and no single active repo floods
+// the section (issue #258). Repos are ordered by their newest issue number so
+// the most recently active repo leads each round. With a single repo it falls
+// back to `limit`, leaving per-repo views unchanged.
+export function limitSectionGroups(
+  groups: IssueGroup[],
+  config: Pick<SectionConfig, 'limit' | 'perRepoLimit'>,
+): { visible: IssueGroup[]; perRepoActive: boolean } {
+  const { limit, perRepoLimit } = config
+  if (!limit && !perRepoLimit) return { visible: groups, perRepoActive: false }
+
+  const repoCount = new Set(groups.map(g => g.repo)).size
+  if (perRepoLimit && repoCount > 1) {
+    const byRepo = new Map<string, IssueGroup[]>()
+    for (const g of groups) {
+      const arr = byRepo.get(g.repo) ?? []
+      arr.push(g)
+      byRepo.set(g.repo, arr)
+    }
+    const repos = Array.from(byRepo.keys()).sort(
+      (a, b) => (byRepo.get(b)![0]?.issue_number ?? 0) - (byRepo.get(a)![0]?.issue_number ?? 0),
+    )
+    const visible: IssueGroup[] = []
+    for (let round = 0; round < perRepoLimit; round++) {
+      for (const repo of repos) {
+        const g = byRepo.get(repo)![round]
+        if (g) visible.push(g)
+      }
+    }
+    return { visible, perRepoActive: true }
+  }
+
+  return { visible: limit ? groups.slice(0, limit) : groups, perRepoActive: false }
+}
 
 // IssueList is the visual root. Caller passes pre-computed groups and
 // the section configuration; the component handles bucketing, headers,
@@ -430,7 +481,7 @@ function IssueSection({
     gray: 'bg-gray-400',
     red: 'bg-red-400',
   }[config.tone]
-  const visible = config.limit ? groups.slice(0, config.limit) : groups
+  const { visible, perRepoActive } = limitSectionGroups(groups, config)
   const hidden = groups.length - visible.length
   // Closed gets the "view more on GitHub" footer link to a single repo.
   // Cross-repo lists (project page) skip this — there's no single repo
@@ -447,7 +498,9 @@ function IssueSection({
         </h3>
         {hidden > 0 && (
           <span className="text-[11px] text-muted-foreground">
-            · showing {visible.length} most recent
+            {perRepoActive
+              ? `· showing ${visible.length} (≤${config.perRepoLimit} per repo)`
+              : `· showing ${visible.length} most recent`}
           </span>
         )}
       </div>


### PR DESCRIPTION
Fixes #258

## 问题
项目级 Backlog / issue 列表的 `Done` / `Closed` 分段对所有仓库的 issue 取**全局 top-N**（按 issue 编号降序），导致活跃且编号高的单个仓库（如 devops/pop #33~#24）占满整个 10 条配额，其他仓库完全不可见。

## 改动
仅改 `web/src/components/IssueList.tsx`（57 增 / 4 删）：

- `SectionConfig` 新增可选字段 `perRepoLimit`。
- 新增纯函数 `limitSectionGroups(groups, config)`：
  - 当 `perRepoLimit` 已设置且分段跨 **2+ 仓库**时，按 repo 分桶（输入已是 issue 编号降序，每桶保持最新在前），再**跨仓库 round-robin** 取数，每个仓库最多 `perRepoLimit` 条，仓库顺序按各自最新 issue 编号排序（最近活跃的仓库领先）。
  - 单仓库时回退到原 `limit` 行为，**repo 页面 / 单仓库项目零回归**。
- 分段头部文案在配额模式下显示 `· showing N (≤K per repo)`，否则维持 `· showing N most recent`。
- `PROJECT_SECTIONS` 的 `Done` / `Closed` 设为 `limit: 10` + `perRepoLimit: 3`；`REPO_SECTIONS` 不变。

## 测试
- `cd web && npm install && npx tsc --noEmit` 通过，无类型错误。
- `npm run build`（vite build + tsc）成功。
- web/ 当前无单测框架（无 vitest/jest），`limitSectionGroups` 已抽为导出纯函数，便于后续接入测试框架后补测。
- 运行时未在浏览器手动验证多仓库聚合页面渲染（需真实多仓库快照数据），逻辑改动集中在客户端纯函数，建议合并前在含 2+ 仓库的项目页观察 `Done`/`Closed` 分段是否均衡露出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)