### PR TITLE
fix: 为各路由页面动态设置浏览器标签页标题

### DIFF
--- a/web/src/lib/useDocumentTitle.ts
+++ b/web/src/lib/useDocumentTitle.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+
+const DEFAULT_TITLE = 'ClawFlow — Automated Issue to PR'
+
+/**
+ * Dynamically sets document.title to `${prefix} · ClawFlow` when a prefix
+ * is provided, or restores the default title when the component unmounts.
+ */
+export function useDocumentTitle(prefix?: string) {
+  useEffect(() => {
+    document.title = prefix ? `${prefix} · ClawFlow` : DEFAULT_TITLE
+    return () => {
+      document.title = DEFAULT_TITLE
+    }
+  }, [prefix])
+}

--- a/web/src/routes/_app.dashboard.tsx
+++ b/web/src/routes/_app.dashboard.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import {
   Search,
   ExternalLink,
@@ -243,6 +244,7 @@ export const Route = createFileRoute('/_app/dashboard')({
 })
 
 function Dashboard() {
+  useDocumentTitle('Dashboard')
   const [runs, setRuns] = useState<Run[]>([])
   const [meta, setMeta] = useState<Meta | null>(null)
   const [repos, setRepos] = useState<Repo[]>([])

--- a/web/src/routes/_app.operators.tsx
+++ b/web/src/routes/_app.operators.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { cn } from '../lib/utils'
 
 interface Operator {
@@ -54,6 +55,7 @@ export const Route = createFileRoute('/_app/operators')({
 })
 
 function OperatorsList() {
+  useDocumentTitle('Operators')
   const [ops, setOps] = useState<Operator[]>([])
   const [loading, setLoading] = useState(true)
 

--- a/web/src/routes/_app.projects.$name.tsx
+++ b/web/src/routes/_app.projects.$name.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { ChevronLeft, ChevronDown, ChevronRight, FolderKanban, FolderOpen, ListTodo, MessageSquare, Sparkles, X, Trash2, Plus, Loader2, Activity, RotateCw, Settings2, Zap } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useChatDrawer } from '../lib/chatContext'
@@ -103,6 +104,7 @@ export const Route = createFileRoute('/_app/projects/$name')({
 
 function ProjectDetail() {
   const { name } = Route.useParams()
+  useDocumentTitle(name)
   const navigate = useNavigate()
   const chatDrawer = useChatDrawer()
 

--- a/web/src/routes/_app.projects.$name_.pilot-runs.tsx
+++ b/web/src/routes/_app.projects.$name_.pilot-runs.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { ChevronLeft, Activity, Copy, Check } from 'lucide-react'
 import { cn } from '../lib/utils'
 import {
@@ -19,6 +20,7 @@ export const Route = createFileRoute('/_app/projects/$name_/pilot-runs')({
 
 function PilotRunsPage() {
   const { name } = Route.useParams()
+  useDocumentTitle(`${name} · Pilot`)
   const [runs, setRuns] = useState<PilotRun[]>([])
   const [loading, setLoading] = useState(true)
   const [visible, setVisible] = useState(20)

--- a/web/src/routes/_app.repos.$.tsx
+++ b/web/src/routes/_app.repos.$.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off, FolderOpen } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
@@ -35,6 +36,7 @@ function RepoDetail() {
   // Splat segment preserves `/` literally — `org/repo` arrives intact with
   // no encoding, so no decodeURIComponent dance and no `%2F`/`%252F`.
   const fullName = _splat ?? ''
+  useDocumentTitle(fullName || undefined)
   const chatDrawer = useChatDrawer()
 
   const [repo, setRepo] = useState<Repo | null>(null)

--- a/web/src/routes/_app.repos.index.tsx
+++ b/web/src/routes/_app.repos.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { FolderOpen, Plus, Trash2, Link2, Link2Off, Search, X, Check, Loader2 } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
@@ -49,6 +50,7 @@ export const Route = createFileRoute('/_app/repos/')({
 })
 
 function RepoList() {
+  useDocumentTitle('Repos')
   const { provider } = Route.useSearch()
   const navigate = Route.useNavigate()
 

--- a/web/src/routes/_app.runs.$slug.$issue.$ts.tsx
+++ b/web/src/routes/_app.runs.$slug.$issue.$ts.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useEffect, useRef, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { ChevronLeft, ChevronRight, CheckCircle2, XCircle, SkipForward, Loader2, ExternalLink, ChevronsUp, ChevronsDown, Square } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, issueUrl, useRepoInfoMap } from '../lib/vcsUrls'
@@ -85,6 +86,7 @@ export const Route = createFileRoute('/_app/runs/$slug/$issue/$ts')({
 
 function RunDetail() {
   const { slug, issue, ts } = Route.useParams()
+  useDocumentTitle(`${slug}#${issue}`)
   // Absolute path from the server root. `./data/...` would break here
   // because the current URL is /runs/slug/issue/ts and the dashboard
   // would try to fetch /runs/slug/issue/data/... instead of /data/...

--- a/web/src/routes/_app.settings.tsx
+++ b/web/src/routes/_app.settings.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useCallback, useEffect, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { Check, Loader2, AlertCircle, X, Eye, EyeOff, Folder, ChevronRight, Home, Copy, ExternalLink, RefreshCw, Upload, Download, LogOut } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { emitConfigChanged, useConfigChanged } from '../lib/configEvents'
@@ -49,6 +50,7 @@ async function revealSecret(which: 'claude_api_key' | 'gh_token' | 'gitlab_token
 }
 
 function SettingsPage() {
+  useDocumentTitle('Settings')
   const [data, setData] = useState<SettingsView | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/routes/_app.usage.tsx
+++ b/web/src/routes/_app.usage.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react'
+import { useDocumentTitle } from '../lib/useDocumentTitle'
 import { Receipt } from 'lucide-react'
 import { type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
@@ -102,6 +103,7 @@ function fmtPeriodLabel(start: string, end: string): string {
 }
 
 function UsagePage() {
+  useDocumentTitle('Usage')
   const [summary, setSummary] = useState<UsageSummary | null>(null)
   const [repos, setRepos] = useState<Repo[]>([])
   const [loading, setLoading] = useState(true)


### PR DESCRIPTION
Fixes #261

## 变更内容

新增 `web/src/lib/useDocumentTitle.ts` hook，在各路由组件挂载时动态更新 `document.title`，格式统一为 `{prefix} · ClawFlow`：

| 页面 | 标题前缀示例 |
|------|-------------|
| 项目详情 | `clawflow · ClawFlow` |
| Repo 详情 | `zhoushoujianwork/clawflow · ClawFlow` |
| 运行详情 | `my-repo#42 · ClawFlow` |
| Pilot 历史 | `clawflow · Pilot · ClawFlow` |
| Dashboard | `Dashboard · ClawFlow` |
| Repos 列表 | `Repos · ClawFlow` |
| Settings | `Settings · ClawFlow` |
| Usage | `Usage · ClawFlow` |
| Operators | `Operators · ClawFlow` |

组件卸载时自动还原默认标题 `ClawFlow — Automated Issue to PR`，避免跨页面导航时标题残留。

## 测试

- `npm run build` 通过，零 TypeScript 错误
- 无后端改动，无新依赖，不影响 `embed.FS` 打包