### PR TITLE
feat: 支持在 repo 列表中点击分支图标切换 base 分支

### DIFF
--- a/cmd/clawflow/commands/web.go
+++ b/cmd/clawflow/commands/web.go
@@ -286,6 +286,8 @@ here — run 'clawflow run' first if you want fresh data.`,
 			mux.HandleFunc("/api/repo/git-status/refresh", api.HandleGitStatusRefresh)
 			mux.HandleFunc("/api/repo/git-pull", api.HandleGitPull)
 			mux.HandleFunc("/api/repo/git-push", api.HandleGitPush)
+			mux.HandleFunc("/api/repo/branches", api.HandleRepoBranches)
+			mux.HandleFunc("/api/repo/set-base-branch", api.HandleRepoSetBaseBranch)
 			mux.HandleFunc("/api/repos/list-remote", api.HandleListRemoteRepos)
 			mux.HandleFunc("/api/repos/add-remote", api.HandleAddRemoteRepo)
 			mux.HandleFunc("/api/settings", api.HandleGetSettings)

--- a/internal/api/repo_branches.go
+++ b/internal/api/repo_branches.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"net/http"
+	"os/exec"
+	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/branch"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/gitsync"
+)
+
+type branchesResponse struct {
+	Branches   []branchEntry `json:"branches"`
+	Base       string        `json:"base"`
+	Current    string        `json:"current"`
+	FetchError string        `json:"fetch_error,omitempty"`
+}
+
+type branchEntry struct {
+	Name    string `json:"name"`
+	Remote  bool   `json:"remote"`
+	IsBase  bool   `json:"is_base"`
+	Current bool   `json:"is_current"`
+}
+
+// HandleRepoBranches handles GET /api/repo/branches?repo=...
+// Returns the local and remote-tracking branches for a repo,
+// annotated with which one is the configured base and which is HEAD.
+func HandleRepoBranches(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	repo := r.URL.Query().Get("repo")
+	if repo == "" {
+		writeJSON(w, 400, map[string]string{"error": "repo is required"})
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if _, ok := cfg.Repos[repo]; !ok {
+		writeJSON(w, 404, map[string]string{"error": "repo not found in config"})
+		return
+	}
+
+	local := gitsync.LocalPath(cfg, repo)
+	if local == "" {
+		writeJSON(w, 404, map[string]string{"error": "repo not cloned locally"})
+		return
+	}
+
+	base := baseBranchFromCfg(cfg, repo)
+
+	// Fetch remote refs; tolerate failure and return stale cached refs.
+	var fetchErr string
+	if err := branch.Fetch(local); err != nil {
+		fetchErr = err.Error()
+	}
+
+	current := headBranch(local)
+
+	localOut, _ := gitForEachRef(local, "refs/heads/")
+	localNames := parseTabRefLines(localOut, false)
+
+	remoteOut, _ := gitForEachRef(local, "refs/remotes/origin/")
+	remoteNames := parseTabRefLines(remoteOut, true)
+
+	// Deduplicate: skip remote branches that already exist locally.
+	localSet := map[string]bool{}
+	for _, n := range localNames {
+		localSet[n] = true
+	}
+
+	var entries []branchEntry
+	for _, name := range localNames {
+		if name == "HEAD" {
+			continue
+		}
+		entries = append(entries, branchEntry{
+			Name:    name,
+			Remote:  false,
+			IsBase:  name == base,
+			Current: name == current,
+		})
+	}
+	for _, name := range remoteNames {
+		if name == "HEAD" || localSet[name] {
+			continue
+		}
+		entries = append(entries, branchEntry{
+			Name:    name,
+			Remote:  true,
+			IsBase:  name == base,
+			Current: name == current,
+		})
+	}
+
+	writeJSON(w, 200, branchesResponse{
+		Branches:   entries,
+		Base:       base,
+		Current:    current,
+		FetchError: fetchErr,
+	})
+}
+
+// parseTabRefLines parses TAB-delimited "name\tdate" output from gitForEachRef.
+func parseTabRefLines(out string, remote bool) []string {
+	var names []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name := strings.SplitN(line, "\t", 2)[0]
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if remote {
+			name = strings.TrimPrefix(name, "origin/")
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+// gitForEachRef lists refs under pattern using TAB as field separator.
+// TAB avoids the NUL-in-args exec rejection on macOS.
+func gitForEachRef(dir, pattern string) (string, error) {
+	c := exec.Command("git", "for-each-ref", "--format=%(refname:short)\t%(committerdate:unix)", pattern)
+	c.Dir = dir
+	out, err := c.Output()
+	return string(out), err
+}
+
+// headBranch returns the currently checked-out branch name (short form).
+func headBranch(local string) string {
+	c := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	c.Dir = local
+	out, err := c.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// baseBranchFromCfg returns the configured base branch for a repo, defaulting to "main".
+func baseBranchFromCfg(cfg *config.Config, repo string) string {
+	if cfg != nil {
+		if r, ok := cfg.Repos[repo]; ok && r.BaseBranch != "" {
+			return r.BaseBranch
+		}
+	}
+	return "main"
+}

--- a/internal/api/repo_branches_test.go
+++ b/internal/api/repo_branches_test.go
@@ -1,0 +1,74 @@
+package api
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// initTestRepo creates a minimal git repo with one commit so for-each-ref works.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmds := [][]string{
+		{"git", "init", "-b", "main"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		c := exec.Command(args[0], args[1:]...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", args, out)
+		}
+	}
+	return dir
+}
+
+func TestHeadBranch(t *testing.T) {
+	dir := initTestRepo(t)
+	got := headBranch(dir)
+	if got != "main" {
+		t.Errorf("headBranch = %q, want %q", got, "main")
+	}
+}
+
+func TestGitForEachRef_LocalBranches(t *testing.T) {
+	dir := initTestRepo(t)
+	out, err := gitForEachRef(dir, "refs/heads/")
+	if err != nil {
+		t.Fatalf("gitForEachRef: %v", err)
+	}
+	if out == "" {
+		t.Fatal("expected non-empty output for local refs")
+	}
+}
+
+func TestGitForEachRef_RemoteBranches_Empty(t *testing.T) {
+	dir := initTestRepo(t)
+	// No remotes configured — should return empty output without error.
+	_, err := gitForEachRef(dir, "refs/remotes/origin/")
+	if err != nil {
+		t.Fatalf("gitForEachRef remote: %v", err)
+	}
+}
+
+func TestHeadBranch_AfterCheckout(t *testing.T) {
+	dir := initTestRepo(t)
+	c := exec.Command("git", "checkout", "-b", "feature/test")
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("checkout: %s", out)
+	}
+	got := headBranch(dir)
+	if got != "feature/test" {
+		t.Errorf("headBranch = %q, want %q", got, "feature/test")
+	}
+}
+
+func TestBaseBranchFromCfg_NilConfig(t *testing.T) {
+	got := baseBranchFromCfg(nil, "any/repo")
+	if got != "main" {
+		t.Errorf("baseBranchFromCfg(nil) = %q, want \"main\"", got)
+	}
+}

--- a/internal/api/repo_set_base_branch.go
+++ b/internal/api/repo_set_base_branch.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/gitsync"
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+)
+
+type setBaseBranchRequest struct {
+	Repo      string `json:"repo"`
+	NewBranch string `json:"branch"`
+}
+
+type setBaseBranchResponse struct {
+	Status     string         `json:"status"`
+	HeadAction string         `json:"head_action"` // "switched" | "kept"
+	GitStatus  gitsync.Status `json:"git_status"`
+}
+
+// HandleRepoSetBaseBranch handles POST /api/repo/set-base-branch.
+// Updates config.Repo.BaseBranch, saves config, refreshes snapshot,
+// pushes to Gist, and re-computes gitsync status. If HEAD == old base
+// and worktree is clean, also checks out the new branch.
+func HandleRepoSetBaseBranch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req setBaseBranchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, 400, map[string]string{"error": "invalid JSON"})
+		return
+	}
+	if req.Repo == "" || req.NewBranch == "" {
+		writeJSON(w, 400, map[string]string{"error": "repo and branch are required"})
+		return
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	if _, ok := cfg.Repos[req.Repo]; !ok {
+		writeJSON(w, 404, map[string]string{"error": "repo not found in config"})
+		return
+	}
+
+	local := gitsync.LocalPath(cfg, req.Repo)
+	if local == "" {
+		writeJSON(w, 404, map[string]string{"error": "repo not cloned locally"})
+		return
+	}
+
+	// Capture current state before mutation.
+	oldBase := baseBranchFromCfg(cfg, req.Repo)
+	oldStatus := gitsync.Refresh(cfg, req.Repo)
+
+	// Update BaseBranch in config.
+	config.TouchRepo(cfg, req.Repo, func(r config.Repo) config.Repo {
+		r.BaseBranch = req.NewBranch
+		return r
+	})
+
+	if err := cfg.Save(); err != nil {
+		writeErr(w, err)
+		return
+	}
+	if err := snapshot.WriteRepos(cfg); err != nil {
+		// Non-fatal: config already saved.
+		fmt.Fprintf(os.Stderr, "⚠ set-base-branch: refresh repos.json: %v\n", err)
+	}
+	AutoPush()
+
+	// Optionally checkout the new branch when HEAD == old base and clean.
+	headAction := "kept"
+	if oldStatus.Current == oldBase && !oldStatus.Dirty {
+		if checkoutErr := gitCheckout(local, req.NewBranch); checkoutErr == nil {
+			headAction = "switched"
+		} else {
+			fmt.Fprintf(os.Stderr, "⚠ set-base-branch: checkout %s: %v\n", req.NewBranch, checkoutErr)
+		}
+	}
+
+	// Recompute sync status with new base.
+	newStatus := gitsync.Refresh(cfg, req.Repo)
+
+	writeJSON(w, 200, setBaseBranchResponse{
+		Status:     "ok",
+		HeadAction: headAction,
+		GitStatus:  newStatus,
+	})
+}
+
+func gitCheckout(dir, branch string) error {
+	c := exec.Command("git", "checkout", branch)
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		return fmt.Errorf("git checkout %s: %w\n%s", branch, err, string(out))
+	}
+	return nil
+}

--- a/internal/branch/branch.go
+++ b/internal/branch/branch.go
@@ -269,6 +269,13 @@ func ListMerged(localPath, base string, includeRemote bool) ([]Branch, error) {
 	return result, nil
 }
 
+// ParseRefLinesExported is the exported wrapper for parseRefLines, allowing
+// other packages (e.g. internal/api) to reuse the git for-each-ref parsing
+// logic without duplicating it.
+func ParseRefLinesExported(out string, remote bool) []Branch {
+	return parseRefLines(out, remote)
+}
+
 // DeleteLocal removes a local branch. When force is false it uses `git branch
 // -d` (refuses unmerged branches); force switches to `-D`. Deleting the
 // currently checked-out branch or one held by a worktree fails with git's own

--- a/web/src/components/GitSyncCell.tsx
+++ b/web/src/components/GitSyncCell.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   ArrowUp,
   ArrowDown,
@@ -11,8 +11,10 @@ import {
   Unlink,
   CloudOff,
   X,
+  Star,
 } from 'lucide-react'
 import { cn } from '../lib/utils'
+import { emitConfigChanged } from '../lib/configEvents'
 
 // GitStatus mirrors gitsync.Status from the backend (data/git-status.json and
 // the /api/repo/git-status* endpoints).
@@ -34,6 +36,20 @@ interface GitActionResponse {
   output: string
   error?: string
   git_status: GitStatus
+}
+
+interface BranchEntry {
+  name: string
+  remote: boolean
+  is_base: boolean
+  is_current: boolean
+}
+
+interface BranchesResponse {
+  branches: BranchEntry[]
+  base: string
+  current: string
+  fetch_error?: string
 }
 
 /**
@@ -58,12 +74,81 @@ export function GitSyncCell({
   onUpdate?: (s: GitStatus) => void
 }) {
   const [busy, setBusy] = useState<'pull' | 'push' | 'refresh' | null>(null)
-  // Live error from the last pull/push/refresh, plus which op produced it,
-  // so the modal can title itself. Falls back to status.error (cached fetch
-  // failure from the background hook) when there is no live error.
   const [error, setError] = useState<string>('')
   const [errorKind, setErrorKind] = useState<'pull' | 'push' | 'fetch' | ''>('')
   const [modalOpen, setModalOpen] = useState(false)
+
+  // Branch switcher popover state
+  const [branchOpen, setBranchOpen] = useState(false)
+  const [branches, setBranches] = useState<BranchEntry[]>([])
+  const [branchLoading, setBranchLoading] = useState(false)
+  const [branchSwitching, setBranchSwitching] = useState(false)
+  const [switchToast, setSwitchToast] = useState<string>('')
+  const branchRef = useRef<HTMLDivElement>(null)
+
+  const fetchBranches = useCallback(async () => {
+    setBranchLoading(true)
+    try {
+      const r = await fetch(`/api/repo/branches?repo=${encodeURIComponent(repo)}`)
+      if (r.ok) {
+        const d: BranchesResponse = await r.json()
+        setBranches(d.branches || [])
+      }
+    } catch {
+      // silently degrade
+    } finally {
+      setBranchLoading(false)
+    }
+  }, [repo])
+
+  useEffect(() => {
+    if (branchOpen) void fetchBranches()
+  }, [branchOpen, fetchBranches])
+
+  // Close branch popover on outside click / Escape
+  useEffect(() => {
+    if (!branchOpen) return
+    function handleClick(e: MouseEvent) {
+      if (branchRef.current && !branchRef.current.contains(e.target as Node)) {
+        setBranchOpen(false)
+      }
+    }
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setBranchOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleEsc)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleEsc)
+    }
+  }, [branchOpen])
+
+  async function switchBranch(newBranch: string) {
+    if (branchSwitching) return
+    setBranchSwitching(true)
+    try {
+      const r = await fetch('/api/repo/set-base-branch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repo, branch: newBranch }),
+      })
+      const d = await r.json()
+      if (d.git_status) onUpdate?.(d.git_status)
+      const toast = d.head_action === 'switched'
+        ? `已切换 base 并 checkout 到 ${newBranch}`
+        : `已更新 base 为 ${newBranch}，HEAD 保持不变。已开 PR 不会自动 retarget`
+      setSwitchToast(toast)
+      setTimeout(() => setSwitchToast(''), 4000)
+      emitConfigChanged()
+      setBranchOpen(false)
+    } catch {
+      setSwitchToast('切换失败，请重试')
+      setTimeout(() => setSwitchToast(''), 3000)
+    } finally {
+      setBranchSwitching(false)
+    }
+  }
 
   async function action(kind: 'pull' | 'push') {
     if (busy) return
@@ -124,21 +209,78 @@ export function GitSyncCell({
   const { ahead, behind, dirty, has_upstream } = status
   const synced = has_upstream && ahead === 0 && behind === 0
   const refreshSpin = busy === 'refresh'
-  // The error icon surfaces either a live action error or a cached fetch error.
   const activeError = error || status.error || ''
   const activeErrorKind = error ? errorKind : status.error ? 'fetch' : ''
+  // HEAD is off-base: pull/push would fail, so disable them proactively.
+  const headOffBase = !!(status.current && status.current !== status.branch)
+  const headOffBaseTitle = headOffBase
+    ? `HEAD 当前在 ${status.current}，请先切回 base 再同步`
+    : undefined
+
+  // Separate local vs remote branches for the popover
+  const localBranches = branches.filter(b => !b.remote)
+  const remoteBranches = branches.filter(b => b.remote)
 
   return (
     <>
       <div className="flex items-center gap-1.5">
-        {/* branch chip */}
-        <span
-          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono text-muted-foreground bg-muted border border-border"
-          title={`base branch: ${status.branch}${status.current && status.current !== status.branch ? ` (checked out: ${status.current})` : ''}`}
-        >
-          <GitBranch className="w-3 h-3" />
-          {status.branch}
-        </span>
+        {/* branch chip — clickable button that opens popover */}
+        <div ref={branchRef} className="relative">
+          <button
+            type="button"
+            onClick={() => setBranchOpen(v => !v)}
+            aria-expanded={branchOpen}
+            aria-haspopup="listbox"
+            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono text-muted-foreground bg-muted border border-border hover:bg-accent hover:text-foreground transition-colors"
+            title={`base: ${status.branch}${headOffBase ? ` (HEAD: ${status.current})` : ''} — 点击切换 base 分支`}
+          >
+            <GitBranch className="w-3 h-3" />
+            base: {status.branch}
+          </button>
+
+          {/* branch switcher popover */}
+          {branchOpen && (
+            <div
+              className="absolute left-0 top-full mt-1 w-56 rounded-lg border shadow-lg z-50 p-2 flex flex-col gap-1"
+              style={{ background: 'hsl(var(--bg-panel))', borderColor: 'hsl(var(--border))' }}
+              role="listbox"
+              aria-label="切换 base 分支"
+            >
+              {branchLoading ? (
+                <span className="text-xs text-muted-foreground flex items-center gap-1 px-2 py-1">
+                  <Loader2 className="w-3 h-3 animate-spin" /> 加载分支…
+                </span>
+              ) : branches.length === 0 ? (
+                <span className="text-xs text-muted-foreground px-2 py-1">暂无分支</span>
+              ) : (
+                <>
+                  {localBranches.length > 0 && (
+                    <p className="text-[10px] uppercase tracking-wide text-muted-foreground/60 px-1 pt-0.5">本地</p>
+                  )}
+                  {localBranches.map(b => (
+                    <BranchItem key={b.name} b={b} onSelect={switchBranch} switching={branchSwitching} />
+                  ))}
+                  {remoteBranches.length > 0 && (
+                    <p className="text-[10px] uppercase tracking-wide text-muted-foreground/60 px-1 pt-1">远端</p>
+                  )}
+                  {remoteBranches.map(b => (
+                    <BranchItem key={'r/' + b.name} b={b} onSelect={switchBranch} switching={branchSwitching} />
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* HEAD label when HEAD != base */}
+        {headOffBase && (
+          <span
+            className="inline-flex items-center gap-0.5 px-1 py-0.5 rounded text-[10px] font-mono text-muted-foreground/70 bg-muted/50 border border-border/50"
+            title={`当前 checkout 分支：${status.current}`}
+          >
+            HEAD: {status.current}
+          </span>
+        )}
 
         {!has_upstream ? (
           <span className="inline-flex items-center text-muted-foreground/70" title="origin 上没有对应分支 (no upstream)">
@@ -154,12 +296,12 @@ export function GitSyncCell({
               <button
                 type="button"
                 onClick={() => action('pull')}
-                disabled={!!busy || dirty}
-                title={dirty ? '工作区有未提交改动，请先提交或暂存后再 pull' : `落后远端 ${behind} 个提交，点击 git pull`}
+                disabled={!!busy || dirty || headOffBase}
+                title={headOffBase ? headOffBaseTitle : dirty ? '工作区有未提交改动，请先提交或暂存后再 pull' : `落后远端 ${behind} 个提交，点击 git pull`}
                 className={cn(
                   'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[11px] font-semibold border transition-colors',
                   'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100',
-                  (!!busy || dirty) && 'opacity-50 cursor-not-allowed',
+                  (!!busy || dirty || headOffBase) && 'opacity-50 cursor-not-allowed',
                 )}
               >
                 {busy === 'pull' ? <Loader2 className="w-3 h-3 animate-spin" /> : <ArrowDown className="w-3 h-3" />}
@@ -170,12 +312,12 @@ export function GitSyncCell({
               <button
                 type="button"
                 onClick={() => action('push')}
-                disabled={!!busy}
-                title={`领先远端 ${ahead} 个提交，点击 git push`}
+                disabled={!!busy || headOffBase}
+                title={headOffBase ? headOffBaseTitle : `领先远端 ${ahead} 个提交，点击 git push`}
                 className={cn(
                   'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[11px] font-semibold border transition-colors',
                   'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100',
-                  !!busy && 'opacity-50 cursor-not-allowed',
+                  (!!busy || headOffBase) && 'opacity-50 cursor-not-allowed',
                 )}
               >
                 {busy === 'push' ? <Loader2 className="w-3 h-3 animate-spin" /> : <ArrowUp className="w-3 h-3" />}
@@ -249,6 +391,53 @@ export function GitSyncCell({
           </div>
         </div>
       )}
+
+      {/* switch toast */}
+      {switchToast && (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 px-3 py-2 rounded-lg shadow-lg text-xs bg-foreground text-background max-w-sm text-center">
+          {switchToast}
+        </div>
+      )}
     </>
+  )
+}
+
+// BranchItem renders one row inside the branch switcher popover.
+function BranchItem({
+  b,
+  onSelect,
+  switching,
+}: {
+  b: BranchEntry
+  onSelect: (name: string) => void
+  switching: boolean
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={b.is_base}
+      disabled={switching || b.is_base}
+      onClick={() => onSelect(b.name)}
+      className={cn(
+        'flex items-center gap-1.5 w-full text-left px-2 py-1 rounded text-xs font-mono transition-colors',
+        b.is_base
+          ? 'bg-accent/50 text-foreground cursor-default'
+          : 'hover:bg-accent text-muted-foreground hover:text-foreground',
+        switching && 'opacity-50 cursor-wait',
+      )}
+      title={b.is_base ? '当前 base 分支' : `切换 base 到 ${b.name}`}
+    >
+      {b.is_base
+        ? <Star className="w-3 h-3 shrink-0 text-amber-500" />
+        : b.is_current
+          ? <Check className="w-3 h-3 shrink-0 text-green-500" />
+          : <span className="w-3 h-3 shrink-0" />
+      }
+      <span className="truncate">{b.name}</span>
+      {b.remote && (
+        <span className="ml-auto text-[9px] text-muted-foreground/60 shrink-0">remote</span>
+      )}
+    </button>
   )
 }


### PR DESCRIPTION
Fixes #260

## 改动说明

### 前端 — `web/src/components/GitSyncCell.tsx`
- branch chip 从只读 `<span>` 改为可点击按钮，文案改为 `base: <name>`
- 点击弹出 popover：列出本地与远端分支，`★` 标记当前 base，`✓` 标记当前 HEAD
- 选中其他分支后调用 `POST /api/repo/set-base-branch`，等待响应后通过 `onUpdate` 刷新状态，并显示 toast 提示（含已开