### PR TITLE
feat: add project jump icon to repo list and detail views

### DIFF
--- a/web/src/lib/projectMembership.ts
+++ b/web/src/lib/projectMembership.ts
@@ -1,0 +1,17 @@
+/**
+ * Reverse-index utility: given a repo full_name and the project list,
+ * return the names of all projects that contain it.
+ */
+export interface ProjectEntry {
+  name: string
+  repos: string[]
+}
+
+export function findProjectsForRepo(
+  repoFullName: string,
+  projects: ProjectEntry[],
+): string[] {
+  return projects
+    .filter(p => Array.isArray(p.repos) && p.repos.includes(repoFullName))
+    .map(p => p.name)
+}

--- a/web/src/routes/_app.repos.$.tsx
+++ b/web/src/routes/_app.repos.$.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
-import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off, FolderOpen } from 'lucide-react'
+import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off, FolderOpen, FolderKanban } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
 import { useChatDrawer } from '../lib/chatContext'
 import { useConfigChanged } from '../lib/configEvents'
+import { findProjectsForRepo, type ProjectEntry } from '../lib/projectMembership'
 import {
   IssueList,
   REPO_SECTIONS,
@@ -55,6 +56,7 @@ function RepoDetail() {
   const [allIssues, setAllIssues] = useState<IssueEntry[]>([])
   const [hostname, setHostname] = useState<string>('')
   const [ideScheme, setIdeScheme] = useState('vscode://file/')
+  const [owningProjects, setOwningProjects] = useState<string[]>([])
 
   const cloneNow = useCallback(() => {
     if (!repo || cloning) return
@@ -88,7 +90,8 @@ function RepoDetail() {
       fetch('/data/pending.json', { cache: 'no-store' }).then(r => (r.ok ? r.json() : [])).catch(() => []),
       fetch('/data/issues.json', { cache: 'no-store' }).then(r => (r.ok ? r.json() : [])).catch(() => []),
       fetch('/api/settings', { cache: 'no-store' }).then(r => (r.ok ? r.json() : null)).catch(() => null),
-    ]).then(([repos, allRuns, allPending, allIssuesData, settings]) => {
+      fetch('/data/projects.json', { cache: 'no-store' }).then(r => (r.ok ? r.json() : [])).catch(() => []),
+    ]).then(([repos, allRuns, allPending, allIssuesData, settings, projects]) => {
       const match = (Array.isArray(repos) ? repos : []).find((x: Repo) => x.full_name === fullName) || null
       setRepo(match)
       setRuns((Array.isArray(allRuns) ? allRuns : []).filter((r: Run) => r.repo === fullName))
@@ -105,6 +108,7 @@ function RepoDetail() {
         }
         setIdeScheme(schemeMap[ide] ?? 'vscode://file/')
       }
+      setOwningProjects(findProjectsForRepo(fullName, Array.isArray(projects) ? projects as ProjectEntry[] : []))
     })
   }, [fullName])
 
@@ -251,6 +255,34 @@ function RepoDetail() {
               </span>
               <span>·</span>
               <span className="font-mono">base: {repo.base_branch}</span>
+              {owningProjects.length === 1 && (
+                <>
+                  <span>·</span>
+                  <Link
+                    to="/projects/$name"
+                    params={{ name: owningProjects[0] }}
+                    title={`Belongs to project: ${owningProjects[0]}`}
+                    aria-label={`Open owning project: ${owningProjects[0]}`}
+                    className="inline-flex items-center gap-0.5 hover:text-foreground hover:underline"
+                  >
+                    <FolderKanban className="w-3 h-3" /> {owningProjects[0]}
+                  </Link>
+                </>
+              )}
+              {owningProjects.length > 1 && owningProjects.map(pname => (
+                <span key={pname}>
+                  <span>·</span>
+                  <Link
+                    to="/projects/$name"
+                    params={{ name: pname }}
+                    title={`Belongs to project: ${pname}`}
+                    aria-label={`Open owning project: ${pname}`}
+                    className="inline-flex items-center gap-0.5 hover:text-foreground hover:underline ml-1"
+                  >
+                    <FolderKanban className="w-3 h-3" /> {pname}
+                  </Link>
+                </span>
+              ))}
               {repoVcsUrl && (
                 <>
                   <span>·</span>

--- a/web/src/routes/_app.repos.index.tsx
+++ b/web/src/routes/_app.repos.index.tsx
@@ -2,12 +2,13 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
-import { FolderOpen, Plus, Trash2, Link2, Link2Off, Search, X, Check, Loader2 } from 'lucide-react'
+import { FolderOpen, FolderKanban, Plus, Trash2, Link2, Link2Off, Search, X, Check, Loader2 } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
 import { GitSyncCell, type GitStatus } from '../components/GitSyncCell'
 import { useConfigChanged } from '../lib/configEvents'
+import { findProjectsForRepo, type ProjectEntry } from '../lib/projectMembership'
 
 interface Repo {
   full_name: string
@@ -70,6 +71,7 @@ function RepoList() {
   // Kept as a Set so toggling one repo doesn't block the rest.
   const [busy, setBusy] = useState<Set<string>>(new Set())
   const [bindMenuFor, setBindMenuFor] = useState<string | null>(null)
+  const [projects, setProjects] = useState<ProjectEntry[]>([])
 
   const loadAll = useCallback(() => {
     return Promise.all([
@@ -85,7 +87,10 @@ function RepoList() {
       fetch('/api/repo/git-status', { cache: 'no-store' })
         .then(r => (r.ok ? r.json() : []))
         .catch(() => []),
-    ]).then(([rp, rn, settings, gs]) => {
+      fetch('/data/projects.json', { cache: 'no-store' })
+        .then(r => (r.ok ? r.json() : []))
+        .catch(() => []),
+    ]).then(([rp, rn, settings, gs, proj]) => {
       setRepos(Array.isArray(rp) ? rp : [])
       setRuns(Array.isArray(rn) ? rn : [])
       if (Array.isArray(gs)) {
@@ -104,6 +109,7 @@ function RepoList() {
         setIdeScheme(schemeMap[ide] ?? 'vscode://file/')
       }
       if (settings?.global?.hostname) setHostname(settings.global.hostname as string)
+      setProjects(Array.isArray(proj) ? proj as ProjectEntry[] : [])
       setLoading(false)
     })
   }, [])
@@ -448,6 +454,18 @@ function RepoList() {
                           <FolderOpen className="w-3.5 h-3.5" />
                         </a>
                       )}
+                      {findProjectsForRepo(r.full_name, projects).map(pname => (
+                        <Link
+                          key={pname}
+                          to="/projects/$name"
+                          params={{ name: pname }}
+                          title={`Belongs to project: ${pname}`}
+                          aria-label={`Open owning project: ${pname}`}
+                          className="inline-flex items-center text-muted-foreground hover:text-foreground shrink-0"
+                        >
+                          <FolderKanban className="w-3.5 h-3.5" />
+                        </Link>
+                      ))}
                     </div>
                   </td>
                   <td className="px-4 py-2 text-muted-foreground text-xs tabular-nums">


### PR DESCRIPTION
Fixes #266

## 变更内容

新增 ：导出  反向索引工具函数，从已有的  数据中查找 repo 归属的 project 列表。

**Repo 详情页**（）：
- 在 meta 信息行加入  图标 + project 名称链接，点击直接跳转到 
- 鼠标悬浮显示 tooltip "Belongs to project: <name>"
- 多归属时逐一渲染多个图标链接
- 无归属时不渲染（空状态无副作用）
- 使用 TanStack Router  保证 SPA 内跳转

**Repo 列表页**（）：
- 在每行 repo 名旁加  图标，仅显示图标（不占列宽），hover 可见 tooltip
- 与现有 VcsIcon / FolderOpen 图标对齐（尺寸 w-3.5 h-3.5，同色调 muted-foreground）

**隐藏逻辑**：无需检测路由上下文——从 repo 详情页跳转到 project 后，用户已经离开了 repo 视图，图标自然不显示。

## 测试

- （vite build + tsc --noEmit）通过，零类型错误