### PR TITLE
feat(project): 支持同一 repo 被多个 project 添加为成员

### DIFF
--- a/cmd/clawflow/commands/repo.go
+++ b/cmd/clawflow/commands/repo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/project"
 	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 )
@@ -17,6 +18,7 @@ func NewRepoCmd() *cobra.Command {
 		Short: "Manage monitored repositories",
 	}
 	cmd.AddCommand(newRepoListCmd())
+	cmd.AddCommand(newRepoShowCmd())
 	cmd.AddCommand(newRepoAddCmd())
 	cmd.AddCommand(newRepoRemoveCmd())
 	cmd.AddCommand(newRepoEnableCmd())
@@ -58,6 +60,63 @@ func newRepoListCmd() *cobra.Command {
 				}
 				fmt.Printf("%-40s %-10s %-12s %-10s %-10s %s\n", name, status, r.BaseBranch, autoApprove, autoMerge, r.Description)
 			}
+			return nil
+		},
+	}
+}
+
+func newRepoShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <owner/repo>",
+		Short: "Show details for a repository, including the projects it belongs to",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ownerRepo := args[0]
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			r, exists := cfg.Repos[ownerRepo]
+			if !exists {
+				return fmt.Errorf("repo %q not found", ownerRepo)
+			}
+			status := "disabled"
+			if r.Enabled {
+				status = "enabled"
+			}
+			fmt.Printf("repo:         %s\n", ownerRepo)
+			fmt.Printf("status:       %s\n", status)
+			fmt.Printf("base_branch:  %s\n", r.BaseBranch)
+			fmt.Printf("local_path:   %s\n", r.LocalPath)
+			if r.Description != "" {
+				fmt.Printf("description:  %s\n", r.Description)
+			}
+
+			// Multi-membership view (issue #267): list every project that
+			// claims this repo, and mark which one is authoritative for the
+			// project-context header injected into operators/chat.
+			projects, err := project.FindProjectsByRepo(ownerRepo)
+			if err != nil {
+				return err
+			}
+			if len(projects) == 0 {
+				fmt.Println("projects:     (none)")
+				return nil
+			}
+			primary, _ := project.FindProjectByRepo(ownerRepo)
+			primaryName := ""
+			if primary != nil {
+				primaryName = primary.Name
+			}
+			names := make([]string, 0, len(projects))
+			for _, p := range projects {
+				if p.Name == primaryName {
+					names = append(names, p.Name+" (primary)")
+				} else {
+					names = append(names, p.Name)
+				}
+			}
+			fmt.Printf("projects:     %s\n", strings.Join(names, ", "))
 			return nil
 		},
 	}
@@ -245,12 +304,13 @@ func setRepoEnabled(ownerRepo string, enabled bool) error {
 func newRepoSetCmd() *cobra.Command {
 	var autoApprove string
 	var autoMerge string
+	var primaryProject string
 
 	cmd := &cobra.Command{
 		Use:     "set <owner/repo>",
 		Short:   "Set configuration flags for a repository",
 		Args:    cobra.ExactArgs(1),
-		Example: "  clawflow repo set owner/repo --auto-approve on\n  clawflow repo set owner/repo --auto-merge on",
+		Example: "  clawflow repo set owner/repo --auto-approve on\n  clawflow repo set owner/repo --auto-merge on\n  clawflow repo set owner/repo --primary-project myproj",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ownerRepo := args[0]
 			cfg, err := config.Load()
@@ -259,6 +319,28 @@ func newRepoSetCmd() *cobra.Command {
 			}
 			if _, exists := cfg.Repos[ownerRepo]; !exists {
 				return fmt.Errorf("repo %q not found", ownerRepo)
+			}
+			// --primary-project chooses the authoritative project whose
+			// context header is injected into operators/chat when the repo
+			// belongs to several projects (issue #267). Pass "" to clear it
+			// (falls back to the lexicographically first project). When set,
+			// the named project must already contain this repo.
+			primaryProjectSet := cmd.Flags().Changed("primary-project")
+			if primaryProjectSet && primaryProject != "" {
+				members, err := project.FindProjectsByRepo(ownerRepo)
+				if err != nil {
+					return err
+				}
+				ok := false
+				for _, p := range members {
+					if p.Name == primaryProject {
+						ok = true
+						break
+					}
+				}
+				if !ok {
+					return fmt.Errorf("project %q does not contain repo %q (add it first with: clawflow project add-repo %s %s)", primaryProject, ownerRepo, primaryProject, ownerRepo)
+				}
 			}
 			// Validate flags before mutating.
 			if autoApprove != "" {
@@ -292,6 +374,9 @@ func newRepoSetCmd() *cobra.Command {
 						r.AutoMerge = false
 					}
 				}
+				if primaryProjectSet {
+					r.PrimaryProject = primaryProject
+				}
 				return r
 			})
 			r := cfg.Repos[ownerRepo]
@@ -304,11 +389,19 @@ func newRepoSetCmd() *cobra.Command {
 			fmt.Printf("repo %q updated\n", ownerRepo)
 			fmt.Printf("  auto_approve: %v\n", r.AutoApprove)
 			fmt.Printf("  auto_merge:   %v\n", r.AutoMerge)
+			if primaryProjectSet {
+				if r.PrimaryProject == "" {
+					fmt.Printf("  primary_project: (cleared)\n")
+				} else {
+					fmt.Printf("  primary_project: %s\n", r.PrimaryProject)
+				}
+			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&autoApprove, "auto-approve", "", "enable/disable auto-approve: on or off")
 	cmd.Flags().StringVar(&autoMerge, "auto-merge", "", "enable/disable auto-merge: on or off")
+	cmd.Flags().StringVar(&primaryProject, "primary-project", "", "authoritative project for context injection when the repo belongs to multiple projects (empty clears it)")
 	return cmd
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,15 @@ type Repo struct {
 	// excluded from cloud sync (see syncableRepo in sync.go).
 	BoundMachine string `yaml:"bound_machine,omitempty"`
 
+	// PrimaryProject names the authoritative project for this repo when it
+	// belongs to more than one project (multi-membership, issue #267). The
+	// project header injected into operator/chat prompts (HeaderForRepo) is
+	// always taken from a single project to keep runtime context
+	// deterministic; PrimaryProject picks which one. When empty, the lookup
+	// falls back to the lexicographically first project that still contains
+	// the repo, so single-membership repos behave exactly as before.
+	PrimaryProject string `yaml:"primary_project,omitempty"`
+
 	// UpdatedAt is the RFC3339 UTC timestamp of the last write to this repo
 	// entry. Used by the LWW (Last-Write-Wins) merge strategy during Gist
 	// sync: the side with the newer timestamp wins the whole entry. A zero

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/zhoushoujianwork/clawflow/internal/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -208,8 +209,12 @@ func Delete(name string) error {
 	return os.RemoveAll(dir)
 }
 
-// AddRepo associates a repo with the project. Returns an error if the
-// repo is already a member of this project or belongs to another project.
+// AddRepo associates a repo with the project. Returns an error only if the
+// repo is already a member of this same project. A repo may belong to
+// multiple projects (multi-membership, issue #267) — shared component or
+// tooling repos legitimately serve several projects, so cross-project
+// membership is no longer rejected. Runtime context injection stays
+// single-authority via the repo's primary project (see FindProjectByRepo).
 func AddRepo(name, repo string) error {
 	p, err := Get(name)
 	if err != nil {
@@ -219,11 +224,6 @@ func AddRepo(name, repo string) error {
 		if r == repo {
 			return fmt.Errorf("repo %q is already in project %q", repo, name)
 		}
-	}
-	// Enforce one-project constraint: scan all projects.
-	existing, err := FindProjectByRepo(repo)
-	if err == nil && existing != nil {
-		return fmt.Errorf("repo %q already belongs to project %q", repo, existing.Name)
 	}
 	p.Repos = append(p.Repos, repo)
 	sort.Strings(p.Repos)
@@ -266,21 +266,67 @@ func RemoveRepo(name, repo string) error {
 	return nil
 }
 
-// FindProjectByRepo scans all projects and returns the one containing
-// the given repo. Returns (nil, nil) if no project claims the repo.
-func FindProjectByRepo(repo string) (*Project, error) {
+// FindProjectsByRepo returns every project that contains the given repo,
+// sorted by name (List already returns name-sorted projects). Returns an
+// empty slice (not nil error) when no project claims the repo. This is the
+// multi-membership query (issue #267): a shared repo may legitimately belong
+// to several projects.
+func FindProjectsByRepo(repo string) ([]*Project, error) {
 	projects, err := List()
 	if err != nil {
 		return nil, err
 	}
+	var matched []*Project
 	for _, p := range projects {
 		for _, r := range p.Repos {
 			if r == repo {
+				matched = append(matched, p)
+				break
+			}
+		}
+	}
+	return matched, nil
+}
+
+// FindProjectByRepo returns the single authoritative ("primary") project for
+// the given repo. Returns (nil, nil) if no project claims the repo.
+//
+// Selection rule (issue #267, owner decision (b) — single authority):
+//   - if the repo's config sets primary_project AND that project still
+//     contains the repo, return it;
+//   - otherwise fall back to the lexicographically first project that
+//     contains the repo (deterministic; List is name-sorted).
+//
+// The fallback guarantees that a single-membership repo behaves exactly as
+// before, and that a stale/dangling primary_project (project deleted or repo
+// removed from it) degrades gracefully instead of injecting the wrong header.
+func FindProjectByRepo(repo string) (*Project, error) {
+	matched, err := FindProjectsByRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	if len(matched) == 0 {
+		return nil, nil
+	}
+	if primary := primaryProjectName(repo); primary != "" {
+		for _, p := range matched {
+			if p.Name == primary {
 				return p, nil
 			}
 		}
 	}
-	return nil, nil
+	return matched[0], nil
+}
+
+// primaryProjectName reads the repo's configured primary_project from
+// config.yaml. Returns "" when config is absent or the field is unset — both
+// are non-fatal and trigger the lexicographic fallback in FindProjectByRepo.
+func primaryProjectName(repo string) string {
+	cfg, err := config.Load()
+	if err != nil || cfg == nil {
+		return ""
+	}
+	return cfg.Repos[repo].PrimaryProject
 }
 
 // ReadContext reads the project's context.md. Returns "" if the file

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
 )
 
 func TestCreateAndGet(t *testing.T) {
@@ -82,16 +84,118 @@ func TestAddRemoveRepo(t *testing.T) {
 	}
 }
 
-func TestOneProjectConstraint(t *testing.T) {
+func TestMultiProjectMembership(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 
 	Create("alpha")
 	Create("beta")
+	if err := AddRepo("alpha", "owner/shared"); err != nil {
+		t.Fatalf("AddRepo alpha: %v", err)
+	}
+	// A repo may now belong to multiple projects (issue #267).
+	if err := AddRepo("beta", "owner/shared"); err != nil {
+		t.Fatalf("AddRepo beta should succeed for a shared repo: %v", err)
+	}
+
+	// Both projects list the repo.
+	a, _ := Get("alpha")
+	b, _ := Get("beta")
+	if len(a.Repos) != 1 || len(b.Repos) != 1 {
+		t.Fatalf("both projects should contain the repo: alpha=%v beta=%v", a.Repos, b.Repos)
+	}
+
+	// Re-adding to the same project still fails.
+	if err := AddRepo("alpha", "owner/shared"); err == nil {
+		t.Fatal("duplicate add to the same project should fail")
+	}
+}
+
+func TestFindProjectsByRepo(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("zebra")
+	Create("alpha")
+	AddRepo("zebra", "owner/shared")
 	AddRepo("alpha", "owner/shared")
 
-	if err := AddRepo("beta", "owner/shared"); err == nil {
-		t.Fatal("should reject repo already in another project")
+	got, err := FindProjectsByRepo("owner/shared")
+	if err != nil {
+		t.Fatalf("FindProjectsByRepo: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 projects, got %d", len(got))
+	}
+	// Sorted by name.
+	if got[0].Name != "alpha" || got[1].Name != "zebra" {
+		t.Fatalf("expected name-sorted [alpha zebra], got [%s %s]", got[0].Name, got[1].Name)
+	}
+
+	// Unknown repo returns empty, not error.
+	none, err := FindProjectsByRepo("owner/unknown")
+	if err != nil {
+		t.Fatalf("FindProjectsByRepo unknown: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected no projects for unknown repo, got %d", len(none))
+	}
+}
+
+func TestFindProjectByRepoPrimaryFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("zebra")
+	Create("alpha")
+	AddRepo("zebra", "owner/shared")
+	AddRepo("alpha", "owner/shared")
+
+	// No primary_project configured → deterministic lexicographic-first.
+	p, err := FindProjectByRepo("owner/shared")
+	if err != nil {
+		t.Fatalf("FindProjectByRepo: %v", err)
+	}
+	if p == nil || p.Name != "alpha" {
+		t.Fatalf("expected fallback to lexicographic-first 'alpha', got %v", p)
+	}
+}
+
+func TestFindProjectByRepoPrimaryConfigured(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	Create("zebra")
+	Create("alpha")
+	AddRepo("zebra", "owner/shared")
+	AddRepo("alpha", "owner/shared")
+
+	// Configure primary_project = zebra (not the lexicographic-first).
+	cfg := &config.Config{Repos: map[string]config.Repo{
+		"owner/shared": {PrimaryProject: "zebra"},
+	}}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("config Save: %v", err)
+	}
+
+	p, err := FindProjectByRepo("owner/shared")
+	if err != nil {
+		t.Fatalf("FindProjectByRepo: %v", err)
+	}
+	if p == nil || p.Name != "zebra" {
+		t.Fatalf("expected configured primary 'zebra', got %v", p)
+	}
+
+	// Stale primary (repo no longer in that project) → graceful fallback.
+	if err := RemoveRepo("zebra", "owner/shared"); err != nil {
+		t.Fatalf("RemoveRepo: %v", err)
+	}
+	p, err = FindProjectByRepo("owner/shared")
+	if err != nil {
+		t.Fatalf("FindProjectByRepo after stale: %v", err)
+	}
+	if p == nil || p.Name != "alpha" {
+		t.Fatalf("expected fallback to 'alpha' after stale primary, got %v", p)
 	}
 }
 

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -205,6 +205,13 @@ type RepoView struct {
 	// unbound. Exposed to the dashboard so the bind/unbind button can show
 	// the current binding state without a separate API call.
 	BoundMachine string `json:"bound_machine,omitempty"`
+	// Projects lists every project this repo belongs to, name-sorted
+	// (multi-membership, issue #267). PrimaryProject names the authoritative
+	// one whose context header is injected into operators/chat. Both are
+	// exposed so the repo detail card can render "belongs to projects: ..."
+	// and flag the primary without a separate API call.
+	Projects       []string `json:"projects,omitempty"`
+	PrimaryProject string   `json:"primary_project,omitempty"`
 }
 
 // OperatorView is the dashboard-facing view of one loaded operator.
@@ -615,16 +622,29 @@ func addUsage(agg *UsageAggregate, u *Usage) {
 func WriteRepos(cfg *config.Config) error {
 	views := make([]RepoView, 0, len(cfg.Repos))
 	for name, r := range cfg.Repos {
+		var projectNames []string
+		var primaryName string
+		if members, err := project.FindProjectsByRepo(name); err == nil && len(members) > 0 {
+			projectNames = make([]string, 0, len(members))
+			for _, p := range members {
+				projectNames = append(projectNames, p.Name)
+			}
+			if primary, _ := project.FindProjectByRepo(name); primary != nil {
+				primaryName = primary.Name
+			}
+		}
 		views = append(views, RepoView{
-			FullName:     name,
-			Platform:     r.Platform,
-			BaseURL:      r.BaseURL,
-			BaseBranch:   r.BaseBranch,
-			LocalPath:    r.LocalPath,
-			Enabled:      r.Enabled,
-			AutoApprove:  r.AutoApprove,
-			AutoMerge:    r.AutoMerge,
-			BoundMachine: r.BoundMachine,
+			FullName:       name,
+			Platform:       r.Platform,
+			BaseURL:        r.BaseURL,
+			BaseBranch:     r.BaseBranch,
+			LocalPath:      r.LocalPath,
+			Enabled:        r.Enabled,
+			AutoApprove:    r.AutoApprove,
+			AutoMerge:      r.AutoMerge,
+			BoundMachine:   r.BoundMachine,
+			Projects:       projectNames,
+			PrimaryProject: primaryName,
 		})
 	}
 	return writeJSON(filepath.Join(DataDir(), "repos.json"), views)

--- a/web/src/routes/_app.repos.$.tsx
+++ b/web/src/routes/_app.repos.$.tsx
@@ -27,6 +27,7 @@ interface Repo {
   auto_approve: boolean
   auto_merge: boolean
   bound_machine?: string
+  primary_project?: string
 }
 export const Route = createFileRoute('/_app/repos/$')({
   component: RepoDetail,
@@ -269,20 +270,30 @@ function RepoDetail() {
                   </Link>
                 </>
               )}
-              {owningProjects.length > 1 && owningProjects.map(pname => (
-                <span key={pname}>
-                  <span>·</span>
-                  <Link
-                    to="/projects/$name"
-                    params={{ name: pname }}
-                    title={`Belongs to project: ${pname}`}
-                    aria-label={`Open owning project: ${pname}`}
-                    className="inline-flex items-center gap-0.5 hover:text-foreground hover:underline ml-1"
-                  >
-                    <FolderKanban className="w-3 h-3" /> {pname}
-                  </Link>
-                </span>
-              ))}
+              {owningProjects.length > 1 && (() => {
+                // Mirror the backend rule (FindProjectByRepo): the primary
+                // project is the configured one, else the lexicographically
+                // first owning project.
+                const fallbackPrimary = [...owningProjects].sort()[0]
+                const primaryName = repo.primary_project || fallbackPrimary
+                return owningProjects.map(pname => {
+                  const isPrimary = pname === primaryName
+                  return (
+                  <span key={pname}>
+                    <span>·</span>
+                    <Link
+                      to="/projects/$name"
+                      params={{ name: pname }}
+                      title={isPrimary ? `Primary project (context source): ${pname}` : `Belongs to project: ${pname}`}
+                      aria-label={`Open owning project: ${pname}`}
+                      className="inline-flex items-center gap-0.5 hover:text-foreground hover:underline ml-1"
+                    >
+                      <FolderKanban className="w-3 h-3" /> {pname}{isPrimary ? ' ★' : ''}
+                    </Link>
+                  </span>
+                  )
+                })
+              })()}
               {repoVcsUrl && (
                 <>
                   <span>·</span>


### PR DESCRIPTION
Fixes #267

## 背景
一个 repo（公共组件库、共享工具仓库）可能同时服务多个 project。此前 `AddRepo` 强制单一归属，无法表达多对多。

## 方案（按 owner 在评论中敲定的方案 (b) — 主 project 单一权威）
多对多只服务**成员关系与展示发现**；运行时上下文注入保持**单一权威**，不做多份 context/testing/deployment 拼接，避免提示词膨胀与指令冲突。

## 变更
- `internal/project/project.go`
  - `AddRepo`：移除跨 project 唯一性约束（同 project 内重复仍报错）
  - 新增 `FindProjectsByRepo(repo) ([]*Project, error)`（按 project 名字典序）
  - `FindProjectByRepo` 改为返回**主 project**：优先 repo 配置的 `primary_project`，未设置则字典序第一；主 project 失效（被删/repo 已移出）时自动降级到字典序第一
- `internal/config/config.go`：`Repo` 新增 `primary_project` 字段
- `cmd/clawflow/commands/repo.go`
  - `repo set --primary-project <project>`：设置/清空主 project（校验该 project 确实包含此 repo）
  - 新增 `repo show <owner/repo>`：展示 repo 详情 + 全部归属 project（标注 primary）
- `internal/snapshot/snapshot.go`：`repos.json` 暴露 `projects` / `primary_project`
- `web/src/routes/_app.repos.$.tsx`：repo 详情头部已显示全部归属 project（前端早有 `findProjectsForRepo`），本次额外用 ★ 标注主 project

## 向后兼容
yaml 结构未变，无需迁移。单归属 repo 的 `HeaderForRepo`/`FindProjectByRepo` 行为与现状完全一致。

## 验收对照
- repo 可被 ≥2 个 project add-repo 成功，双方 `project show` 均列出 ✅
- `repo show` / web 详情能看到全部归属 project ✅
- operator header 来自主 project，未设 `primary_project` 时为字典序第一（确定性）✅
- 单归属 repo 现有行为不变（既有 `HeaderForRepo` 测试通过）✅

## 测试
- `go test ./...` 全绿；新增 `FindProjectsByRepo` / 主 project 选择 / 字典序 fallback / 悬空 primary 降级 / 多归属成功 的单测
- `web` 前端 `tsc --noEmit` + `npm run build` 通过
- 未做端到端真实仓库验证（无测试 GitHub 仓库环境），但改动逻辑为本地 config/project 模型，单测已覆盖核心路径