### PR TITLE
fix(run): defer leaf operators on issues that became parents (#270)

### DIFF
--- a/cmd/clawflow/commands/issue270_test.go
+++ b/cmd/clawflow/commands/issue270_test.go
@@ -1,0 +1,112 @@
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/operator"
+	"github.com/zhoushoujianwork/clawflow/internal/vcs"
+)
+
+// fakeSubLister is a minimal subIssueLister for exercising isStaleLeafJob
+// without standing up a full vcs.Client.
+type fakeSubLister struct {
+	subs []vcs.Issue
+	err  error
+}
+
+func (f fakeSubLister) ListSubIssues(repo string, issueNumber int) ([]vcs.Issue, error) {
+	return f.subs, f.err
+}
+
+func leafOp() *operator.Operator {
+	return &operator.Operator{
+		Name:    "evaluate-bug",
+		Trigger: operator.Trigger{AppliesTo: operator.AppliesLeaf},
+	}
+}
+
+// TestIsStaleLeafJob covers the issue #270 freshness recheck: a leaf-gated
+// operator whose subject grew sub-issues between scan and execution must be
+// reported stale (and thus skipped) so the parent defers to track-progress.
+func TestIsStaleLeafJob(t *testing.T) {
+	cases := []struct {
+		name      string
+		op        *operator.Operator
+		client    fakeSubLister
+		wantStale bool
+		wantCount int
+	}{
+		{
+			name:      "leaf op, sub-issues attached since poll -> stale",
+			op:        leafOp(),
+			client:    fakeSubLister{subs: []vcs.Issue{{Number: 140}, {Number: 141}}},
+			wantStale: true,
+			wantCount: 2,
+		},
+		{
+			name:      "leaf op, still a leaf -> not stale",
+			op:        leafOp(),
+			client:    fakeSubLister{subs: nil},
+			wantStale: false,
+			wantCount: 0,
+		},
+		{
+			name:      "non-leaf op (applies_to empty) is never rechecked",
+			op:        &operator.Operator{Name: "track-progress", Trigger: operator.Trigger{AppliesTo: operator.AppliesParent}},
+			client:    fakeSubLister{subs: []vcs.Issue{{Number: 140}}},
+			wantStale: false,
+			wantCount: 0,
+		},
+		{
+			name:      "ListSubIssues error (e.g. GitLab ErrNotSupported) -> not stale",
+			op:        leafOp(),
+			client:    fakeSubLister{err: errors.New("not supported")},
+			wantStale: false,
+			wantCount: 0,
+		},
+		{
+			name:      "nil op is safely not stale (defensive)",
+			op:        nil,
+			client:    fakeSubLister{subs: []vcs.Issue{{Number: 140}}},
+			wantStale: false,
+			wantCount: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stale, n := isStaleLeafJob(tc.client, tc.op, "owner/repo", 139)
+			if stale != tc.wantStale || n != tc.wantCount {
+				t.Errorf("isStaleLeafJob = (%v, %d), want (%v, %d)", stale, n, tc.wantStale, tc.wantCount)
+			}
+		})
+	}
+}
+
+// TestOperatorPriority pins the explicit dispatch order (issue #270):
+// decompose must outrank every evaluator, which in turn outrank implement,
+// so a tracking issue is split before it is evaluated regardless of how the
+// operators happen to sort alphabetically.
+func TestOperatorPriority(t *testing.T) {
+	if operatorPriority("decompose") >= operatorPriority("evaluate-bug") {
+		t.Error("decompose must run before evaluate-bug")
+	}
+	if operatorPriority("decompose") >= operatorPriority("evaluate-feat") {
+		t.Error("decompose must run before evaluate-feat")
+	}
+	if operatorPriority("evaluate-bug") >= operatorPriority("implement") {
+		t.Error("evaluators must run before implement")
+	}
+	// A leaf issue matching both decompose and evaluate-bug must pick
+	// decompose, mirroring the firstMatch selection in scanRepoOnce.
+	ops := []string{"evaluate-bug", "decompose"}
+	best := ops[0]
+	for _, name := range ops[1:] {
+		if operatorPriority(name) < operatorPriority(best) {
+			best = name
+		}
+	}
+	if best != "decompose" {
+		t.Errorf("firstMatch among %v = %q, want decompose", ops, best)
+	}
+}

--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -490,6 +490,54 @@ func deterministicSkipReason(op *operator.Operator, repoCfg config.Repo) string 
 	return ""
 }
 
+// operatorPriority ranks operators that match the same issue in one scan so
+// firstMatch fires the right one (issue #270). Lower value = runs first.
+// This makes the decompose-before-evaluate ordering EXPLICIT instead of
+// relying on Registry.All()'s alphabetical sort (which only happened to put
+// "decompose" before "evaluate-bug"): a tracking issue must be decomposed —
+// flipping it to a parent — before any leaf evaluator gets a turn, otherwise
+// the evaluator races the split. Unlisted operators land in a middle default
+// tier and keep their relative alphabetical order via the stable comparison.
+func operatorPriority(name string) int {
+	switch {
+	case name == "decompose":
+		return 0 // structural: split before anything evaluates the issue
+	case strings.HasPrefix(name, "evaluate-"):
+		return 10 // assessment
+	case name == "implement":
+		return 20 // execution: runs after the issue is assessed
+	default:
+		return 15
+	}
+}
+
+// subIssueLister is the narrow slice of vcs.Client that isStaleLeafJob needs.
+// Declaring it locally keeps the freshness recheck unit-testable with a tiny
+// fake instead of a full vcs.Client implementation.
+type subIssueLister interface {
+	ListSubIssues(repo string, issueNumber int) ([]vcs.Issue, error)
+}
+
+// isStaleLeafJob reports whether a leaf-gated operator job has gone stale
+// because sub-issues were attached to its subject between scan and execution
+// (issue #270). scanRepoOnce snapshots SubTotal at poll time, but a leaf
+// operator can run for minutes (the issue's #139 evaluate-bug took 7m19s);
+// if sub-issues land in that window the issue is now a parent and should
+// defer to its coordinator (track-progress) rather than run a leaf
+// evaluate/implement. Only operators declaring applies_to: leaf are checked.
+// GitHub-only: GitLab's ListSubIssues returns ErrNotSupported, treated here
+// as "not stale" so the recheck naturally short-circuits.
+func isStaleLeafJob(client subIssueLister, op *operator.Operator, repo string, issueNumber int) (stale bool, subCount int) {
+	if op == nil || op.Trigger.AppliesTo != operator.AppliesLeaf {
+		return false, 0
+	}
+	subs, err := client.ListSubIssues(repo, issueNumber)
+	if err != nil {
+		return false, 0
+	}
+	return len(subs) > 0, len(subs)
+}
+
 // scanRepoOnce lists every open issue in the repo and returns the full
 // set of (issue × matching-operator) pending entries plus the runJobs
 // that the executor should fire (at most one per issue, the first
@@ -608,7 +656,14 @@ func scanRepoOnce(ctx context.Context, reg *operator.Registry, fullName string, 
 				Labels:      append([]string(nil), sub.Labels...),
 				CapturedAt:  capturedAt,
 			})
-			if firstMatch == nil {
+			// Pick the highest-priority matching operator to actually fire
+			// (issue #270). Explicit priority replaces the implicit reliance
+			// on Registry.All()'s alphabetical order: when both decompose and
+			// a leaf evaluator match the same issue, decompose MUST run first
+			// so the issue is split (and flips to non-leaf) before any
+			// evaluator races it. Equal-priority ties keep the stable
+			// alphabetical order from reg.All().
+			if firstMatch == nil || operatorPriority(op.Name) < operatorPriority(firstMatch.Name) {
 				firstMatch = op
 			}
 		}
@@ -826,6 +881,23 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 			fmt.Printf("%s → skip (labels changed since poll: %s)\n", prefix, reason)
 			return false, false
 		}
+	}
+
+	// Sub-issue freshness recheck (issue #270). The scan captured SubTotal
+	// at poll time, but a leaf operator can sit queued — and then run — for
+	// minutes. If sub-issues were attached to this issue in that window it
+	// is now a parent and must defer to its coordinator (track-progress),
+	// not run a leaf evaluate/implement. Re-fetch the live sub-issue count
+	// and, if it became a parent, skip and mark agent-skipped so the leaf
+	// gate keeps it out of the queue on later passes. GitHub-only — GitLab
+	// short-circuits inside isStaleLeafJob.
+	if stale, n := isStaleLeafJob(j.client, j.op, j.repo, j.sub.Number); stale {
+		fmt.Printf("%s → skip (became parent since poll: %d sub-issue(s))\n", prefix, n)
+		if err := j.client.AddLabel(j.repo, j.sub.Number, "agent-skipped"); err != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ add agent-skipped label: %v\n", prefix, err)
+		}
+		runLog.Info("run/skip_became_parent", "repo", j.repo, "issue", j.sub.Number, "op", j.op.Name, "subs", n)
+		return false, false
 	}
 
 	// Persist per-run events.jsonl + meta.json under the dashboard

--- a/skills/track-progress/SKILL.md
+++ b/skills/track-progress/SKILL.md
@@ -84,13 +84,28 @@ When a sub-issue is pending only because its PR is open/unmerged, note that in t
 
 ### Step 4: Emit outcome
 
-**If ALL sub-issues are done:**
+**If ALL sub-issues are done:** emit the status table AND a one-time
+achievement summary, then close. The summary is the tracking issue's
+final wrap-up — it should let a reader understand what landed across all
+sub-issues without opening each one. For every sub-issue, write one line
+covering what it delivered and the PR/outcome that proves it (merged PR
+number, or `agent-skipped` if it was intentionally dropped). Pull the PR
+number and one-line description from the Step 1b PR list you already
+fetched; if a sub-issue was closed without a PR (e.g. duplicate, won't-do),
+say so briefly.
+
 ```
 ## 📊 Progress Check
 
 ...table...
 
 **{total}/{total} sub-issues complete. Closing tracking issue.**
+
+### ✅ Summary of what landed
+
+- #{n1} {title} — {what it delivered}, merged in #{pr1}
+- #{n2} {title} — {what it delivered}, merged in #{pr2}
+- #{n3} {title} — skipped (agent-skipped): {one-line reason}
 
 <!-- clawflow:outcome=agent-closed -->
 ```


### PR DESCRIPTION
Fixes #270

修复主 Issue 拆出子 Issue 后仍被当作 leaf 跑评估/实现算子的时序竞态。落地 Comment 4 定稿的「一个 PR、三个子任务」。

## 子任务 A — 执行前新鲜度二次校验（真正根因）
`run.go` 在 `scanRepoOnce` 一次性快照 `SubTotal`，但 leaf 算子可能排队/执行数分钟（截图中 #139 evaluate-bug 跑了 7m19s）。期间若子 Issue 被挂上，已入队的 job 不会复检。
- 在 `runOneOperator` 执行入口（lock 之后、紧接已有的 label 防竞态段）新增 `isStaleLeafJob`：对 `applies_to: leaf` 算子重新 `ListSubIssues`，若已变 parent 则跳过并打 `agent-skipped`，leaf 门控后续轮询自然不再入队。
- 仅 GitHub 生效：GitLab `ListSubIssues` 返回 ErrNotSupported，`isStaleLeafJob` 内部短路视为「未过期」。

## 子任务 B — 算子优先级显式化
`reg.All()` 按字母序返回，原先靠 `decompose < evaluate-bug` 字母序碰巧让拆解先跑。新增 `operatorPriority`（decompose=0 < evaluate-*=10 < implement=20），firstMatch 改为按优先级择优，消除「重命名即破」的隐式依赖。

## 子任务 C — 收尾评估扩展为成果汇总
`skills/track-progress/SKILL.md` 的 `agent-closed` 分支：关闭父 Issue 前输出一段跨子 Issue 的成果汇总（每个子任务做了什么 + 对应 merged PR / agent-skipped 原因），不新建算子。

## 不在范围内（已落地，未改动）
父 Issue 跳过执行类算子、decompose 自动挂 progress-check、持续轮询、完成后自动关闭。

## 测试
- 新增 `cmd/clawflow/commands/issue270_test.go`：覆盖 `isStaleLeafJob`（leaf 变 parent / 仍为 leaf / 非 leaf 算子 / ListSubIssues 报错即 GitLab 路径 / nil 防御）与 `operatorPriority`（decompose < evaluate < implement，且同时命中时恒选 decompose）。
- `go test ./cmd/clawflow/commands/... ./internal/operator/...` 全绿；`go vet` 与 `go build` 通过。
- 残留窗口说明：二次校验把竞态窗口从「整轮扫描时长」收敛到「复检到 job 真正执行的毫秒级」，并发下仍有极小残留窗口，属收敛而非根除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)