### PR TITLE
fix(snapshot): 同名重建仓库后历史执行记录被污染

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -577,6 +577,22 @@ func scanRepoOnce(ctx context.Context, reg *operator.Registry, fullName string, 
 		return nil, nil, fmt.Errorf("list open issues: %w", err)
 	}
 
+	// Same-name recreation guard: owner/name is reused after delete+recreate
+	// on both platforms but the numeric repo ID is not, and issue numbering
+	// restarts at #1 — so without this check the new repo's runs land in (and
+	// display alongside) the old repo's history (issue #272). Best-effort: an
+	// ID lookup failure only skips the check for this pass.
+	if ider, ok := client.(interface{ GetRepoID(string) (int64, error) }); ok {
+		if repoID, idErr := ider.GetRepoID(fullName); idErr != nil {
+			debugf("[%s] get repo id: %v (recreation check skipped)", fullName, idErr)
+		} else if archived, recErr := snapshot.ReconcileRepoIdentity(fullName, repoID); recErr != nil {
+			runLog.Warn("run/scan", "repo", fullName, "phase", "repo_identity_err", "err", recErr.Error())
+		} else if archived != "" {
+			runLog.Info("run/scan", "repo", fullName, "phase", "repo_recreated", "archived_to", archived)
+			fmt.Fprintf(os.Stderr, "⚠ %s was deleted and recreated on the platform; previous run history archived to %s\n", fullName, archived)
+		}
+	}
+
 	// GitHub sub-issues are not returned by the standard /issues list API.
 	// Walk every open issue and append any sub-issues that aren't already
 	// in the list. Two levels deep covers the current tracking→sub→sub-sub

--- a/internal/snapshot/repoident.go
+++ b/internal/snapshot/repoident.go
@@ -1,0 +1,101 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// RepoIdentity pins a repo-name slug under data/runs/ to the platform's
+// immutable numeric repository ID. owner/name is NOT a stable identifier:
+// deleting a repo and recreating it under the same name reuses the slug
+// (and restarts issue numbering at #1) but mints a new platform ID, so
+// without this file the new repo silently inherits the old repo's run
+// history (issue #272).
+type RepoIdentity struct {
+	RepoID    int64     `json:"repo_id"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// repoIdentityFile lives directly under runs/<owner__repo>/, next to the
+// issue-N subdirectories.
+const repoIdentityFile = "repo.json"
+
+// orphanInfix marks a runs/<owner__repo> directory that belonged to a
+// previous incarnation of a same-named repo. Walkers over the runs tree
+// skip these so archived history never leaks into runs.json / usage.
+const orphanInfix = ".orphaned-"
+
+// isOrphanedRepoDir reports whether a directory name under data/runs/ is
+// an archived previous-incarnation tree.
+func isOrphanedRepoDir(name string) bool {
+	return strings.Contains(name, orphanInfix)
+}
+
+// ReconcileRepoIdentity compares the platform repository ID observed this
+// scan against the one recorded in runs/<slug>/repo.json.
+//
+//   - No identity recorded yet → adopt: write the current ID and keep any
+//     existing history (backward compat for trees created before this file
+//     existed).
+//   - Same ID → no-op.
+//   - Different ID → the repo was deleted and recreated under the same
+//     name. Archive the whole runs/<slug>/ tree to
+//     runs/<slug>.orphaned-<oldID>/ so the new repo starts with a clean
+//     history, then record the new ID.
+//
+// Returns the archive directory path when history was archived, "" otherwise.
+func ReconcileRepoIdentity(repo string, currentID int64) (string, error) {
+	return reconcileRepoIdentityAt(filepath.Join(DataDir(), "runs"), repo, currentID)
+}
+
+// reconcileRepoIdentityAt is the testable core of ReconcileRepoIdentity.
+func reconcileRepoIdentityAt(runsRoot, repo string, currentID int64) (string, error) {
+	if currentID == 0 {
+		// Unknown ID (platform didn't return one) — never archive on a guess.
+		return "", nil
+	}
+	repoDir := filepath.Join(runsRoot, strings.ReplaceAll(repo, "/", "__"))
+	identPath := filepath.Join(repoDir, repoIdentityFile)
+
+	if data, err := os.ReadFile(identPath); err == nil {
+		var ident RepoIdentity
+		if json.Unmarshal(data, &ident) == nil && ident.RepoID != 0 {
+			if ident.RepoID == currentID {
+				return "", nil
+			}
+			archived := orphanTarget(repoDir, ident.RepoID)
+			if err := os.Rename(repoDir, archived); err != nil {
+				return "", fmt.Errorf("archive recreated repo %s: %w", repo, err)
+			}
+			if err := writeJSON(identPath, RepoIdentity{RepoID: currentID, CheckedAt: time.Now().UTC()}); err != nil {
+				return archived, err
+			}
+			return archived, nil
+		}
+		// Malformed / zero identity file — fall through and rewrite it.
+	}
+	if err := writeJSON(identPath, RepoIdentity{RepoID: currentID, CheckedAt: time.Now().UTC()}); err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+// orphanTarget picks a non-existing archive path for repoDir. A second
+// recreation cycle can produce the same oldID suffix only if the archive
+// was already made once and the identity file was then tampered with, but
+// colliding with an existing directory would make os.Rename nest the tree
+// inside it — so probe and append a counter just in case.
+func orphanTarget(repoDir string, oldID int64) string {
+	base := fmt.Sprintf("%s%s%d", repoDir, orphanInfix, oldID)
+	target := base
+	for i := 2; ; i++ {
+		if _, err := os.Stat(target); os.IsNotExist(err) {
+			return target
+		}
+		target = fmt.Sprintf("%s-%d", base, i)
+	}
+}

--- a/internal/snapshot/repoident_test.go
+++ b/internal/snapshot/repoident_test.go
@@ -1,0 +1,123 @@
+package snapshot
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeRunMetaAt creates runs/<slug>/issue-<n>/<ts>/meta.json under root.
+func writeRunMetaAt(t *testing.T, root, slug string, issue int, ts string, m RunMeta) {
+	t.Helper()
+	dir := filepath.Join(root, slug, fmt.Sprintf("issue-%d", issue), ts)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteRunMeta(dir, m); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcileRepoIdentityAdoptsExistingHistory(t *testing.T) {
+	root := t.TempDir()
+	repo := "owner/repo"
+	writeRunMetaAt(t, root, "owner__repo", 1, "2026-06-02T11-23-00Z", RunMeta{Repo: repo, IssueNumber: 1, Status: "success"})
+
+	archived, err := reconcileRepoIdentityAt(root, repo, 111)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived != "" {
+		t.Fatalf("first reconcile must adopt, not archive; got %q", archived)
+	}
+	// History stays in place and the identity is recorded.
+	if _, err := os.Stat(filepath.Join(root, "owner__repo", "issue-1")); err != nil {
+		t.Fatalf("existing history moved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "owner__repo", repoIdentityFile)); err != nil {
+		t.Fatalf("identity not written: %v", err)
+	}
+}
+
+func TestReconcileRepoIdentitySameIDNoop(t *testing.T) {
+	root := t.TempDir()
+	repo := "owner/repo"
+	if _, err := reconcileRepoIdentityAt(root, repo, 111); err != nil {
+		t.Fatal(err)
+	}
+	writeRunMetaAt(t, root, "owner__repo", 1, "2026-06-02T11-23-00Z", RunMeta{Repo: repo, IssueNumber: 1, Status: "success"})
+
+	archived, err := reconcileRepoIdentityAt(root, repo, 111)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived != "" {
+		t.Fatalf("same ID must be a no-op; got archive %q", archived)
+	}
+	if _, err := os.Stat(filepath.Join(root, "owner__repo", "issue-1")); err != nil {
+		t.Fatalf("history moved on no-op: %v", err)
+	}
+}
+
+func TestReconcileRepoIdentityArchivesOnIDChange(t *testing.T) {
+	root := t.TempDir()
+	repo := "owner/repo"
+	if _, err := reconcileRepoIdentityAt(root, repo, 111); err != nil {
+		t.Fatal(err)
+	}
+	writeRunMetaAt(t, root, "owner__repo", 1, "2026-06-02T11-23-00Z", RunMeta{Repo: repo, IssueNumber: 1, Status: "success"})
+
+	archived, err := reconcileRepoIdentityAt(root, repo, 222)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "owner__repo.orphaned-111")
+	if archived != want {
+		t.Fatalf("archived to %q, want %q", archived, want)
+	}
+	// Old history lives in the archive; the fresh tree only has repo.json.
+	if _, err := os.Stat(filepath.Join(archived, "issue-1")); err != nil {
+		t.Fatalf("old history missing from archive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "owner__repo", "issue-1")); !os.IsNotExist(err) {
+		t.Fatalf("old history still visible under active tree: %v", err)
+	}
+	// Third incarnation: archive again without colliding with the first one.
+	if _, err := reconcileRepoIdentityAt(root, repo, 222); err != nil {
+		t.Fatal(err)
+	}
+	archived2, err := reconcileRepoIdentityAt(root, repo, 333)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived2 != filepath.Join(root, "owner__repo.orphaned-222") {
+		t.Fatalf("second archive path: %q", archived2)
+	}
+}
+
+func TestReconcileRepoIdentityZeroIDIsIgnored(t *testing.T) {
+	root := t.TempDir()
+	repo := "owner/repo"
+	if _, err := reconcileRepoIdentityAt(root, repo, 111); err != nil {
+		t.Fatal(err)
+	}
+	archived, err := reconcileRepoIdentityAt(root, repo, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archived != "" {
+		t.Fatalf("zero ID must never archive; got %q", archived)
+	}
+}
+
+func TestCollectRunEntriesSkipsOrphanedDirs(t *testing.T) {
+	root := t.TempDir()
+	writeRunMetaAt(t, root, "owner__repo", 1, "2026-06-11T08-54-26Z", RunMeta{Repo: "owner/repo", IssueNumber: 1, Status: "success"})
+	writeRunMetaAt(t, root, "owner__repo.orphaned-111", 1, "2026-06-02T11-23-00Z", RunMeta{Repo: "owner/repo", IssueNumber: 1, Status: "success"})
+
+	entries := collectRunEntries(root)
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (orphaned tree must be excluded)", len(entries))
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -719,6 +719,9 @@ func MigrateFailedToCancelled() int {
 		if err != nil || !d.IsDir() {
 			return nil
 		}
+		if isOrphanedRepoDir(d.Name()) {
+			return filepath.SkipDir
+		}
 		metaPath := filepath.Join(path, "meta.json")
 		data, err := os.ReadFile(metaPath)
 		if err != nil {
@@ -1194,6 +1197,9 @@ func reconcileStaleRunsAt(runsRoot string, staleAfter time.Duration) (int, error
 		if err != nil || !d.IsDir() {
 			return nil
 		}
+		if isOrphanedRepoDir(d.Name()) {
+			return filepath.SkipDir
+		}
 		// A "run dir" is a leaf directory containing meta.json and/or
 		// events.jsonl. Skip the intermediate runs/<repo>/issue-<N> tree.
 		metaPath := filepath.Join(path, "meta.json")
@@ -1478,7 +1484,13 @@ func collectRunEntries(root string) []RunIndexEntry {
 	// are no runs yet — saves the dashboard a nullability check.
 	out := []RunIndexEntry{}
 	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() || d.Name() != "meta.json" {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() && isOrphanedRepoDir(d.Name()) {
+			return filepath.SkipDir
+		}
+		if d.IsDir() || d.Name() != "meta.json" {
 			return nil
 		}
 		data, err := os.ReadFile(path)

--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -1080,6 +1080,31 @@ func (c *Client) GetParentIssue(repo string, issueNumber int) (*vcs.Issue, error
 	return &vcs.Issue{ID: raw.ID, Number: raw.Number, Title: raw.Title, State: raw.State}, nil
 }
 
+// GetRepoID returns GitHub's immutable numeric repository ID. The
+// owner/name pair is NOT stable — deleting a repo and recreating it under
+// the same name mints a new ID — so callers use this to detect recreation
+// and segregate local run history (issue #272).
+func (c *Client) GetRepoID(repo string) (int64, error) {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return 0, err
+	}
+	data, status, err := c.do("GET", fmt.Sprintf("/repos/%s/%s", owner, name), nil)
+	if err != nil {
+		return 0, err
+	}
+	if status != 200 {
+		return 0, fmt.Errorf("github get repo: HTTP %d: %s", status, data)
+	}
+	var raw struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return 0, err
+	}
+	return raw.ID, nil
+}
+
 // GetIssue fetches a single issue by number.
 func (c *Client) GetIssue(repo string, number int) (*vcs.Issue, error) {
 	owner, name, err := splitRepo(repo)

--- a/internal/vcs/gitlab/client.go
+++ b/internal/vcs/gitlab/client.go
@@ -105,6 +105,27 @@ func (c *Client) doJSON(method, path string, body any) ([]byte, int, error) {
 	return data, resp.StatusCode, err
 }
 
+// GetRepoID returns GitLab's immutable numeric project ID. Like GitHub,
+// the namespace/name path is reused when a project is deleted and
+// recreated, but the ID is not — callers use this to detect recreation
+// and segregate local run history (issue #272).
+func (c *Client) GetRepoID(repo string) (int64, error) {
+	data, status, err := c.doJSON("GET", fmt.Sprintf("/projects/%s", projectID(repo)), nil)
+	if err != nil {
+		return 0, err
+	}
+	if status != 200 {
+		return 0, fmt.Errorf("gitlab get project: HTTP %d: %s", status, data)
+	}
+	var raw struct {
+		ID int64 `json:"id"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return 0, err
+	}
+	return raw.ID, nil
+}
+
 func (c *Client) ListOpenIssues(repo string) ([]vcs.Issue, error) {
 	path := fmt.Sprintf("/projects/%s/issues?state=opened&per_page=100", projectID(repo))
 	data, status, err := c.doJSON("GET", path, nil)


### PR DESCRIPTION
Closes #272

## 动机

GitHub/GitLab 上删除仓库后重建同名仓库，`owner/name` 不变、issue 编号从 #1 重新计数，但 ClawFlow 的执行记录只以 `owner/name + issue 编号` 为 key，导致新仓库直接继承旧仓库的全部历史 run（实测 `runs/zhoushoujianwork__agent_room/issue-1/` 下新旧 run 混在同一目录）。

## 实现

- **记录仓库身份**：每次 scan 通过 `GetRepoID`（GitHub `GET /repos/{owner}/{repo}`、GitLab `GET /projects/{id}`）获取平台不可变的 numeric ID，持久化到 `runs/<slug>/repo.json`
- **检测重建并归档**：scan 时 ID 与记录不一致 → 判定同名重建，把整棵 `runs/<slug>/` 树重命名为 `runs/<slug>.orphaned-<oldID>/`，新仓库从干净历史开始
- **隔离归档数据**：`collectRunEntries` / `reconcileStaleRunsAt` / `MigrateFailedToCancelled` 三处 walker 全部跳过 `.orphaned-` 目录，归档历史不再进入 runs.json / usage / reconcile
- **向后兼容**：已有目录无 `repo.json` 时首次 scan 直接采纳当前 ID，不归档；ID 获取失败仅跳过本次检查，不影响 scan
- 通过类型断言调用 `GetRepoID`，不改 `vcs.Client` 接口，测试 fake 零改动

## 测试

- 新增 `repoident_test.go`：首次采纳 / 同 ID no-op / ID 变化归档（含三代重建不碰撞）/ 零 ID 防御 / `collectRunEntries` 排除归档目录
- `go test ./...` 全量通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)