### PR TITLE
fix(vcs): STATE 列在默认 --state open 过滤时留空

### DIFF
--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -112,7 +112,11 @@ func (c *Client) ListOpenIssues(repo string) ([]vcs.Issue, error) {
 		if r.PullRequest != nil {
 			continue // GitHub returns PRs in /issues — skip them
 		}
-		issue := vcs.Issue{Number: r.Number, Title: r.Title, Body: r.Body, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt, ClosedAt: r.ClosedAt}
+		// This endpoint is queried with state=open, so every returned issue is
+		// open. Set State explicitly — the list table prints i.State and would
+		// otherwise show a blank STATE column on the default --state open path
+		// (issue #274).
+		issue := vcs.Issue{Number: r.Number, State: "open", Title: r.Title, Body: r.Body, CreatedAt: r.CreatedAt, UpdatedAt: r.UpdatedAt, ClosedAt: r.ClosedAt}
 		for _, l := range r.Labels {
 			issue.Labels = append(issue.Labels, l.Name)
 		}

--- a/internal/vcs/github/client_test.go
+++ b/internal/vcs/github/client_test.go
@@ -53,6 +53,9 @@ func TestListOpenIssues(t *testing.T) {
 	if issues[0].Number != 1 || issues[0].Title != "real issue" {
 		t.Errorf("unexpected issue: %+v", issues[0])
 	}
+	if issues[0].State != "open" {
+		t.Errorf("expected State \"open\", got %q (issue #274: STATE column blank on default --state open)", issues[0].State)
+	}
 	if !issues[0].HasLabel("bug") {
 		t.Error("expected label 'bug'")
 	}


### PR DESCRIPTION
Fixes #274

## 问题
`clawflow issue list` 默认走 `--state open` 路径（`len(labels)==0` 时调用 GitHub 客户端的 `ListOpenIssues`），但该函数构造 `vcs.Issue` 时未给 `State` 赋值，导致表格 STATE 列留空。

## 修复
在 `internal/vcs/github/client.go` 的 `ListOpenIssues` 中硬编码 `State: "open"`——该接口以 `state=open` 查询，返回的 issue 必然是 open。最小且语义正确。

## 关于 --state closed / --state all
经核实，二者均走 `ListIssues`，已正确设置 `State: r.State`，本就正常。报告中 `--state closed` 留空很可能是该 repo 下无符合条件的 closed issue（输出 "no issues"）导致的误判。代码层面确定的缺陷仅默认 open 路径。

## 测试
- 在 `TestListOpenIssues` 中新增断言 `issues[0].State == "open"`（此前仅 `ListIssues` 覆盖了 State，`ListOpenIssues` 是漏网处）。
- `go test ./internal/vcs/github/...` 通过。