### PR TITLE
fix(web): add git pull/push to repo detail toolbar

### DIFF
--- a/web/src/routes/_app.repos.$.tsx
+++ b/web/src/routes/_app.repos.$.tsx
@@ -8,6 +8,7 @@ import { VcsIcon } from '../components/VcsIcon'
 import { useChatDrawer } from '../lib/chatContext'
 import { useConfigChanged } from '../lib/configEvents'
 import { findProjectsForRepo, type ProjectEntry } from '../lib/projectMembership'
+import { GitSyncCell, type GitStatus } from '../components/GitSyncCell'
 import {
   IssueList,
   REPO_SECTIONS,
@@ -58,6 +59,10 @@ function RepoDetail() {
   const [hostname, setHostname] = useState<string>('')
   const [ideScheme, setIdeScheme] = useState('vscode://file/')
   const [owningProjects, setOwningProjects] = useState<string[]>([])
+  // Git sync status for this single repo. Seeded from the cached
+  // /api/repo/git-status (instant) then refreshed in the background. Mirrors
+  // the index page's gitStatus map, scoped to one repo.
+  const [gitStatus, setGitStatus] = useState<GitStatus | undefined>(undefined)
 
   const cloneNow = useCallback(() => {
     if (!repo || cloning) return
@@ -92,7 +97,8 @@ function RepoDetail() {
       fetch('/data/issues.json', { cache: 'no-store' }).then(r => (r.ok ? r.json() : [])).catch(() => []),
       fetch('/api/settings', { cache: 'no-store' }).then(r => (r.ok ? r.json() : null)).catch(() => null),
       fetch('/data/projects.json', { cache: 'no-store' }).then(r => (r.ok ? r.json() : [])).catch(() => []),
-    ]).then(([repos, allRuns, allPending, allIssuesData, settings, projects]) => {
+      fetch('/api/repo/git-status', { cache: 'no-store' }).then(r => (r.ok ? r.json() : [])).catch(() => []),
+    ]).then(([repos, allRuns, allPending, allIssuesData, settings, projects, gitStatuses]) => {
       const match = (Array.isArray(repos) ? repos : []).find((x: Repo) => x.full_name === fullName) || null
       setRepo(match)
       setRuns((Array.isArray(allRuns) ? allRuns : []).filter((r: Run) => r.repo === fullName))
@@ -110,7 +116,16 @@ function RepoDetail() {
         setIdeScheme(schemeMap[ide] ?? 'vscode://file/')
       }
       setOwningProjects(findProjectsForRepo(fullName, Array.isArray(projects) ? projects as ProjectEntry[] : []))
+      if (Array.isArray(gitStatuses)) {
+        setGitStatus((gitStatuses as GitStatus[]).find(s => s?.repo === fullName))
+      }
     })
+  }, [fullName])
+
+  // Apply this repo's refreshed git status (called by GitSyncCell on pull/push).
+  const updateGitStatus = useCallback((s: GitStatus) => {
+    if (s?.repo !== fullName) return
+    setGitStatus(s)
   }, [fullName])
 
   const syncNow = useCallback(() => {
@@ -174,6 +189,26 @@ function RepoDetail() {
     refreshData().then(() => setLoading(false))
   }, [fullName, refreshData])
   useConfigChanged(refreshData)
+
+  // Background git fetch+recompute for this repo so ahead/behind reflects the
+  // latest remote without blocking first paint. Runs once per fullName.
+  useEffect(() => {
+    if (!fullName) return
+    let cancelled = false
+    fetch('/api/repo/git-status/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repo: fullName }),
+    })
+      .then(r => (r.ok ? r.json() : []))
+      .then((arr: GitStatus[]) => {
+        if (cancelled || !Array.isArray(arr)) return
+        const s = arr.find(x => x?.repo === fullName)
+        if (s) setGitStatus(s)
+      })
+      .catch(() => { /* background best-effort */ })
+    return () => { cancelled = true }
+  }, [fullName])
 
   const repoMap = useMemo<RepoInfoMap>(() => {
     if (!repo) return {}
@@ -321,6 +356,8 @@ function RepoDetail() {
                   </a>
                 </>
               )}
+              <span>·</span>
+              <GitSyncCell repo={fullName} status={gitStatus} onUpdate={updateGitStatus} />
             </div>
           </div>
 


### PR DESCRIPTION
Fixes #276

## 变更内容
在仓库详情页顶部工具栏（`github · base · view · chat · open` 这一行）的 `open` 右侧新增 git pull / push 入口，与仓库列表页能力对齐，用户无需返回列表页即可在详情页完成拉取/推送。

## 实现方式
- 复用已有的 surface-agnostic 组件 `GitSyncCell`（其注释明确支持 repo detail 场景），无需改后端、无需改组件。
- 在 `web/src/routes/_app.repos.$.tsx` 中：
  - 新增单仓库 `gitStatus` state 与 `updateGitStatus` 回调，镜像列表页的 `gitStatus` map 模式（scope 到当前 repo）。
  - 在 `refreshData` 的 `Promise.all` 中并行拉取 `/api/repo/git-status`，按 `full_name` 过滤出当前仓库的 status 作为即时种子。
  - 新增一个后台 `git-status/refresh`（POST `{repo}`）的 effect，按当前仓库刷新 ahead/behind，不阻塞首屏。
  - 在工具栏 `open` 块后插入 `· <GitSyncCell repo={fullName} status={gitStatus} onUpdate={updateGitStatus} />`，分隔符风格与现有一致。

## 降级行为
`GitSyncCell` 已内建降级：未 clone（`!has_clone`）显示一个 muted 的 CloudOff 图标；HEAD 偏离 base 时禁用 pull/push。未绑定本地路径的仓库不会出现可操作按钮。

## 测试
- `npm run typecheck`（tsc --noEmit）通过。
- `npm run build`（vite build + tsc）通过。
- 纯前端变更，无 Go 改动；web/ 目录当前无单元测试框架（见 testing.md TODO），未新增前端测试。建议在已绑定本地仓库的详情页人工确认 pull/push 按钮与列表页行为一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)