### PR TITLE
fix: VCS 写回阶段增加指数退避重试与评论幂等去重

### DIFF
--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -74,6 +75,10 @@ type VCS interface {
 	AddLabel(repo string, issueNumber int, labels ...string) error
 	RemoveLabel(repo string, issueNumber int, labels ...string) error
 	PostIssueComment(repo string, issueNumber int, body string) error
+	// PostIssueCommentIdempotent posts a comment with dedup: if a comment
+	// carrying the given runID marker already exists it is a no-op. Falls
+	// back to a plain PostIssueComment when runID is empty.
+	PostIssueCommentIdempotent(repo string, issueNumber int, body, runID string) error
 	CloseIssue(repo string, issueNumber int) error
 }
 
@@ -126,6 +131,19 @@ type RunOptions struct {
 	// on the runner's goroutine, so callers should keep it cheap and must not
 	// block. Nil is the common case for tests and non-dashboard callers.
 	StageFunc func(stage string)
+
+	// RunID is a unique identifier for this operator invocation (typically the
+	// run directory timestamp slug). When non-empty it is embedded in the
+	// result comment as <!-- clawflow:run-id=<RunID> --> so that retried
+	// PostIssueComment calls can detect and skip duplicate deliveries.
+	RunID string
+
+	// CommentSaveDir, if non-empty, is a directory path where the operator's
+	// result comment body will be written as comment.md before the VCS
+	// write-back. This ensures the output survives even if all write-back
+	// retries are exhausted — a human (or future recovery logic) can read the
+	// file and re-post manually.
+	CommentSaveDir string
 }
 
 // emitStage safely invokes a (possibly nil) stage callback. Centralizing the
@@ -237,8 +255,20 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 // via a goroutine in Run.
 func runWriteBack(v VCS, op *Operator, sub *Subject, opts RunOptions, body, outcome string) error {
 	if body != "" {
+		// Persist the comment body to disk before attempting VCS write-back.
+		// If all retries are exhausted the output is not lost — it can be
+		// recovered from comment.md in the run directory (issue #278).
+		if opts.CommentSaveDir != "" {
+			savePath := filepath.Join(opts.CommentSaveDir, "comment.md")
+			if err := os.WriteFile(savePath, []byte(body), 0o644); err != nil {
+				// Non-fatal: log and continue. Losing the file is bad but
+				// should not prevent the VCS write-back attempt.
+				fmt.Fprintf(os.Stderr, "  ⚠ could not save comment to disk: %v\n", err)
+			}
+		}
+
 		emitStage(opts.StageFunc, StagePostingComment)
-		if err := v.PostIssueComment(opts.Repo, sub.Number, body); err != nil {
+		if err := v.PostIssueCommentIdempotent(opts.Repo, sub.Number, body, opts.RunID); err != nil {
 			return fmt.Errorf("post result comment: %w", err)
 		}
 		fmt.Fprintf(os.Stderr, "  ✓ comment posted (%d chars)\n", len(body))

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -70,6 +70,11 @@ func (f *fakeVCS) PostIssueComment(repo string, issueNumber int, body string) er
 	return nil
 }
 
+func (f *fakeVCS) PostIssueCommentIdempotent(repo string, issueNumber int, body, runID string) error {
+	// In tests, delegate to PostIssueComment (no dedup needed).
+	return f.PostIssueComment(repo, issueNumber, body)
+}
+
 func (f *fakeVCS) CloseIssue(repo string, issueNumber int) error {
 	f.closeCalls++
 	if f.errOnClose {
@@ -574,6 +579,10 @@ func (b *blockingCommentVCS) RemoveLabel(repo string, issueNumber int, labels ..
 	return nil
 }
 func (b *blockingCommentVCS) PostIssueComment(repo string, issueNumber int, body string) error {
+	<-b.block // block until test cleanup closes the channel
+	return nil
+}
+func (b *blockingCommentVCS) PostIssueCommentIdempotent(repo string, issueNumber int, body, runID string) error {
 	<-b.block // block until test cleanup closes the channel
 	return nil
 }

--- a/internal/pilot/budget/client.go
+++ b/internal/pilot/budget/client.go
@@ -41,6 +41,13 @@ func (b *budgetClient) PostIssueComment(repo string, n int, body string) error {
 	return b.Client.PostIssueComment(repo, n, body)
 }
 
+func (b *budgetClient) PostIssueCommentIdempotent(repo string, n int, body, runID string) error {
+	if err := Reserve("PostIssueComment"); err != nil {
+		return err
+	}
+	return b.Client.PostIssueCommentIdempotent(repo, n, body, runID)
+}
+
 func (b *budgetClient) DeleteIssueComment(repo string, n int, commentID int64) error {
 	if err := Reserve("DeleteIssueComment"); err != nil {
 		return err

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,70 @@
+// Package retry provides a simple exponential-backoff retry helper for
+// transient errors (network timeouts, 5xx responses, 429 rate limits).
+package retry
+
+import (
+	"context"
+	"math/rand/v2"
+	"time"
+)
+
+// Config controls retry behaviour.
+type Config struct {
+	// MaxAttempts is the total number of attempts (including the first one).
+	// Must be >= 1. Zero is treated as 1 (no retries).
+	MaxAttempts int
+
+	// BaseDelay is the wait before the second attempt.
+	BaseDelay time.Duration
+
+	// MaxDelay caps the per-attempt sleep regardless of the exponential factor.
+	MaxDelay time.Duration
+}
+
+// DefaultConfig is the project-wide default: 4 attempts with 1-2-4-8 s
+// backoff + jitter, capped at 15 s per sleep. Total worst-case budget is
+// roughly 30 s — well within the 5-minute writeBackTimeout.
+var DefaultConfig = Config{
+	MaxAttempts: 4,
+	BaseDelay:   1 * time.Second,
+	MaxDelay:    15 * time.Second,
+}
+
+// Do calls fn up to cfg.MaxAttempts times. It retries whenever fn returns a
+// non-nil error. It respects ctx cancellation both before each attempt and
+// during backoff sleeps so it does not outlive the caller's deadline. The
+// last error (or nil) is returned.
+func Do(ctx context.Context, cfg Config, fn func() error) error {
+	if cfg.MaxAttempts < 1 {
+		cfg.MaxAttempts = 1
+	}
+	var err error
+	for attempt := 0; attempt < cfg.MaxAttempts; attempt++ {
+		// Honour cancellation before each attempt, including retries.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		if attempt == cfg.MaxAttempts-1 {
+			break
+		}
+		// Compute exponential delay with ±25 % jitter.
+		delay := cfg.BaseDelay * (1 << attempt)
+		if delay > cfg.MaxDelay {
+			delay = cfg.MaxDelay
+		}
+		sleep := delay
+		if jitterRange := int64(delay) / 4; jitterRange > 0 {
+			sleep += time.Duration(rand.Int64N(jitterRange))
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(sleep):
+		}
+	}
+	return err
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,86 @@
+package retry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/retry"
+)
+
+func TestDo_SuccessFirstAttempt(t *testing.T) {
+	calls := 0
+	err := retry.Do(context.Background(), retry.Config{MaxAttempts: 3, BaseDelay: time.Millisecond}, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestDo_RetriesAndSucceeds(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("transient")
+	err := retry.Do(context.Background(), retry.Config{MaxAttempts: 3, BaseDelay: time.Millisecond}, func() error {
+		calls++
+		if calls < 3 {
+			return sentinel
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDo_ExhaustsAttempts(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("persistent")
+	err := retry.Do(context.Background(), retry.Config{MaxAttempts: 3, BaseDelay: time.Millisecond}, func() error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDo_ContextCancelDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	// Cancel after first failure so the backoff sleep is interrupted.
+	err := retry.Do(ctx, retry.Config{MaxAttempts: 4, BaseDelay: 10 * time.Second}, func() error {
+		calls++
+		cancel()
+		return errors.New("fail")
+	})
+	if err == nil {
+		t.Fatal("expected error after ctx cancel")
+	}
+	// Should have called fn exactly once (cancel fires during first backoff).
+	if calls != 1 {
+		t.Fatalf("expected 1 call before ctx cancel, got %d", calls)
+	}
+}
+
+func TestDo_ZeroMaxAttempts(t *testing.T) {
+	calls := 0
+	retry.Do(context.Background(), retry.Config{MaxAttempts: 0, BaseDelay: time.Millisecond}, func() error { //nolint:errcheck
+		calls++
+		return nil
+	})
+	if calls != 1 {
+		t.Fatalf("zero MaxAttempts should act as 1, got %d calls", calls)
+	}
+}

--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/zhoushoujianwork/clawflow/internal/retry"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 )
 
@@ -51,14 +52,19 @@ func New(token, baseURL string) *Client {
 	}
 }
 
-func (c *Client) do(method, path string, body any) ([]byte, int, error) {
-	var r io.Reader
+// doOnce sends a single HTTP request and returns the response body and status.
+func (c *Client) doOnce(method, path string, body any) ([]byte, int, error) {
+	var bodyBytes []byte
 	if body != nil {
-		b, err := json.Marshal(body)
+		var err error
+		bodyBytes, err = json.Marshal(body)
 		if err != nil {
 			return nil, 0, err
 		}
-		r = bytes.NewReader(b)
+	}
+	var r io.Reader
+	if bodyBytes != nil {
+		r = bytes.NewReader(bodyBytes)
 	}
 	req, err := http.NewRequestWithContext(c.reqContext(), method, c.baseURL+path, r)
 	if err != nil {
@@ -67,7 +73,7 @@ func (c *Client) do(method, path string, body any) ([]byte, int, error) {
 	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if body != nil {
+	if bodyBytes != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	resp, err := c.http.Do(req)
@@ -77,6 +83,111 @@ func (c *Client) do(method, path string, body any) ([]byte, int, error) {
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	return data, resp.StatusCode, err
+}
+
+// isRetryableStatus reports whether an HTTP status code is worth retrying.
+// 429 (rate limit) and transient 5xx (except 501 Not Implemented) are
+// retried. 4xx client errors and 501 are permanent failures.
+func isRetryableStatus(status int) bool {
+	return status == 429 || (status >= 500 && status != 501)
+}
+
+// do sends a request with automatic exponential-backoff retry for transient
+// network errors and retryable HTTP status codes (429, 5xx). POST requests
+// are NOT retried here because they are not idempotent; callers that need
+// retry semantics on POST must handle idempotency themselves (see
+// PostIssueCommentIdempotent).
+func (c *Client) do(method, path string, body any) ([]byte, int, error) {
+	// Only retry idempotent methods automatically.
+	if method == "POST" {
+		return c.doOnce(method, path, body)
+	}
+	cfg := retry.DefaultConfig
+	var (
+		data   []byte
+		status int
+	)
+	err := retry.Do(c.reqContext(), cfg, func() error {
+		var e error
+		data, status, e = c.doOnce(method, path, body)
+		if e != nil {
+			return e // network error — retryable
+		}
+		if isRetryableStatus(status) {
+			return fmt.Errorf("github %s %s: HTTP %d (transient)", method, path, status)
+		}
+		return nil
+	})
+	return data, status, err
+}
+
+// runIDMarker is the HTML comment appended to every result comment so a
+// retry can detect a previously delivered comment and skip re-posting.
+// Format: <!-- clawflow:run-id=<runID> -->
+func runIDMarker(runID string) string {
+	if runID == "" {
+		return ""
+	}
+	return "\n\n<!-- clawflow:run-id=" + runID + " -->"
+}
+
+// PostIssueCommentIdempotent posts a comment only if no existing comment
+// already contains the <!-- clawflow:run-id=<runID> --> marker. This makes
+// the POST safe to retry: if the first attempt succeeded but the HTTP
+// response was lost (context deadline exceeded after GitHub wrote the
+// comment), a retry will detect the duplicate and return nil without
+// posting again. When runID is empty the method falls back to a plain POST
+// without dedup.
+func (c *Client) PostIssueCommentIdempotent(repo string, issueNumber int, body, runID string) error {
+	if runID == "" {
+		return c.PostIssueComment(repo, issueNumber, body)
+	}
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return err
+	}
+	marker := "<!-- clawflow:run-id=" + runID + " -->"
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, name, issueNumber)
+	fullBody := body + runIDMarker(runID)
+
+	// Check for an existing comment with this run-id before the first attempt.
+	existing, listErr := c.ListIssueComments(repo, issueNumber)
+	if listErr == nil {
+		for _, cm := range existing {
+			if strings.Contains(cm, marker) {
+				return nil // already delivered
+			}
+		}
+	}
+
+	cfg := retry.DefaultConfig
+	attempt := 0
+	return retry.Do(c.reqContext(), cfg, func() error {
+		// On retries (not the first attempt), re-check for the marker in case
+		// the previous attempt succeeded but the HTTP response was lost.
+		if attempt > 0 {
+			comments, listErr := c.ListIssueComments(repo, issueNumber)
+			if listErr == nil {
+				for _, cm := range comments {
+					if strings.Contains(cm, marker) {
+						return nil // already delivered on a prior attempt
+					}
+				}
+			}
+		}
+		attempt++
+		_, status, doErr := c.doOnce("POST", path, map[string]string{"body": fullBody})
+		if doErr != nil {
+			return doErr
+		}
+		if status != 201 {
+			if isRetryableStatus(status) {
+				return fmt.Errorf("github post comment: HTTP %d (transient)", status)
+			}
+			return fmt.Errorf("github post comment: HTTP %d", status)
+		}
+		return nil
+	})
 }
 
 func (c *Client) ListOpenIssues(repo string) ([]vcs.Issue, error) {

--- a/internal/vcs/github/client_test.go
+++ b/internal/vcs/github/client_test.go
@@ -294,3 +294,76 @@ func TestSetRequestContextCancelsHangingCall(t *testing.T) {
 		t.Errorf("request did not abort on context deadline: took %s (expected ~150ms)", elapsed)
 	}
 }
+
+// TestGetRetries_5xxThenSuccess verifies that idempotent GET requests are
+// automatically retried on 5xx responses (issue #278).
+func TestGetRetries_5xxThenSuccess(t *testing.T) {
+	calls := 0
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/issues": func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			if calls == 1 {
+				jsonResp(w, 503, map[string]string{"message": "service unavailable"})
+				return
+			}
+			jsonResp(w, 200, []map[string]any{
+				{"number": 1, "title": "ok issue", "body": "", "labels": []map[string]string{}},
+			})
+		},
+	})
+
+	issues, err := client.ListOpenIssues("owner/repo")
+	if err != nil {
+		t.Fatalf("expected retry to succeed, got error: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue after retry, got %d", len(issues))
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 HTTP calls (1 failure + 1 success), got %d", calls)
+	}
+}
+
+// TestPostIssueCommentIdempotent_DeduplicatesOnRetry verifies that a second
+// call with the same run-id does NOT post a duplicate comment (issue #278).
+func TestPostIssueCommentIdempotent_DeduplicatesOnRetry(t *testing.T) {
+	const runID = "test-run-42"
+	marker := "<!-- clawflow:run-id=" + runID + " -->"
+
+	postCalls := 0
+	listCalls := 0
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET /repos/owner/repo/issues/3/comments": func(w http.ResponseWriter, r *http.Request) {
+			listCalls++
+			if listCalls == 1 {
+				// First list: no existing comments.
+				jsonResp(w, 200, []map[string]any{})
+				return
+			}
+			// Subsequent lists: a comment with the marker already exists.
+			jsonResp(w, 200, []map[string]any{
+				{"id": 1, "body": "hello " + marker, "created_at": "2026-01-01T00:00:00Z", "user": map[string]string{"login": "bot"}},
+			})
+		},
+		"POST /repos/owner/repo/issues/3/comments": func(w http.ResponseWriter, r *http.Request) {
+			postCalls++
+			jsonResp(w, 201, map[string]any{"id": 1})
+		},
+	})
+
+	// First call: should post (no existing comment with marker).
+	if err := client.PostIssueCommentIdempotent("owner/repo", 3, "hello", runID); err != nil {
+		t.Fatalf("first call failed: %v", err)
+	}
+	if postCalls != 1 {
+		t.Fatalf("expected 1 POST on first call, got %d", postCalls)
+	}
+
+	// Second call (simulating a retry): should detect the marker and skip.
+	if err := client.PostIssueCommentIdempotent("owner/repo", 3, "hello", runID); err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+	if postCalls != 1 {
+		t.Errorf("expected still 1 POST after dedup retry, got %d (duplicate comment posted)", postCalls)
+	}
+}

--- a/internal/vcs/gitlab/client.go
+++ b/internal/vcs/gitlab/client.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/zhoushoujianwork/clawflow/internal/retry"
 	"github.com/zhoushoujianwork/clawflow/internal/vcs"
 )
 
@@ -874,4 +875,54 @@ func (c *Client) UploadAttachment(repo string, filePath string) (string, error) 
 		return fmt.Sprintf("![%s](%s)", out.Alt, out.URL), nil
 	}
 	return "", fmt.Errorf("gitlab upload attachment: response missing markdown/url: %s", data)
+}
+
+// PostIssueCommentIdempotent posts a comment with run-id dedup. If a
+// comment containing <!-- clawflow:run-id=<runID> --> already exists the
+// method returns nil without posting again, making retries safe. Falls back
+// to a plain PostIssueComment when runID is empty (issue #278).
+func (c *Client) PostIssueCommentIdempotent(repo string, issueNumber int, body, runID string) error {
+	if runID == "" {
+		return c.PostIssueComment(repo, issueNumber, body)
+	}
+	marker := "<!-- clawflow:run-id=" + runID + " -->"
+	fullBody := body + "\n\n" + marker
+
+	// Pre-check: avoid posting if comment already exists.
+	existing, listErr := c.ListIssueComments(repo, issueNumber)
+	if listErr == nil {
+		for _, cm := range existing {
+			if strings.Contains(cm, marker) {
+				return nil
+			}
+		}
+	}
+
+	path := fmt.Sprintf("/projects/%s/issues/%d/notes", projectID(repo), issueNumber)
+	attempt := 0
+	return retry.Do(c.reqContext(), retry.DefaultConfig, func() error {
+		if attempt > 0 {
+			comments, err := c.ListIssueComments(repo, issueNumber)
+			if err == nil {
+				for _, cm := range comments {
+					if strings.Contains(cm, marker) {
+						return nil // delivered on prior attempt
+					}
+				}
+			}
+		}
+		attempt++
+		form := url.Values{"body": {fullBody}}
+		_, status, doErr := c.do("POST", path, form)
+		if doErr != nil {
+			return doErr
+		}
+		if status != 201 {
+			if status == 429 || (status >= 500 && status != 501) {
+				return fmt.Errorf("gitlab post comment: HTTP %d (transient)", status)
+			}
+			return fmt.Errorf("gitlab post comment: HTTP %d", status)
+		}
+		return nil
+	})
 }

--- a/internal/vcs/interface.go
+++ b/internal/vcs/interface.go
@@ -120,6 +120,10 @@ type Client interface {
 	CreateIssue(repo string, title, body string) (Issue, error)
 	UpdateIssue(repo string, issueNumber int, update IssueUpdate) (Issue, error)
 	PostIssueComment(repo string, issueNumber int, body string) error
+	// PostIssueCommentIdempotent posts a comment only if no existing comment
+	// carries the <!-- clawflow:run-id=<runID> --> marker, making retries
+	// safe. Falls back to PostIssueComment when runID is empty.
+	PostIssueCommentIdempotent(repo string, issueNumber int, body, runID string) error
 	DeleteIssueComment(repo string, issueNumber int, commentID int64) error
 	// ListIssuesByBodyKeyword returns open issues whose body contains keyword.
 	ListIssuesByBodyKeyword(repo string, keyword string) ([]Issue, error)


### PR DESCRIPTION
Fixes #278

## 改动说明

### 问题根因
收尾阶段（向 GitHub 回写评论/label）遇到单次网络超时就直接判定任务 failed，已耗费数美元和十几分钟的 claude 输出全部作废。

### 方案

**1. `internal/retry` 新包**
通用指数退避重试：默认 4 次、基础延迟 1s（序列 1/2/4/8s + jitter），总预算 ≤ 30s，感知 ctx 取消，不会撑过 writeBackTimeout 的 5 分钟。

**2. GitHub/GitLab client 重试**
- `do()` 对幂等方法（GET/PUT/DELETE/PATCH）自动重试 5xx / 429
- POST 不自动重试（非幂等），通过新方法单独处理

**3. `PostIssueCommentIdempotent`（GitHub + GitLab）**
在 comment body 末尾附加 `<!-- clawflow:run-id=<id> -->` marker。重试前先 `ListIssueComments` 扫描 marker，若已存在则跳过 POST，消除第一次请求已被