### PR TITLE
feat: 按阶段算子配置不同模型（新增 RoleLight 轻量档位）

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -42,11 +42,17 @@ var runLog *clog.Logger
 // roleForOperator picks which config.Role slot an operator should
 // resolve its model from. evaluate-* operators read existing context
 // and produce structured analysis, so they get the heavier eval model
-// (Opus by default). Everything else (implement, reply-comment,
-// user-supplied skills) gets the cheaper operator model (Sonnet).
+// (Opus by default). Lightweight operators (classify, reply-comment,
+// reply-question, track-progress) use the cheap light model (Haiku by
+// default). Everything else (implement, user-supplied skills) gets the
+// operator model (Sonnet by default).
 func roleForOperator(opName string) string {
 	if strings.HasPrefix(opName, "evaluate-") {
 		return config.RoleEval
+	}
+	switch opName {
+	case "classify", "reply-comment", "reply-question", "track-progress":
+		return config.RoleLight
 	}
 	return config.RoleOperator
 }

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -19,7 +19,7 @@ import (
 // providerView is the safe representation of a ClaudeProvider for the API.
 // The api_key is never returned in full — only a masked hint.
 //
-// Each role (chat / eval / operator) has its own stored value plus the
+// Each role (chat / eval / operator / light) has its own stored value plus the
 // built-in default the runner will fall back to when the stored value
 // is empty. Exposing the default lets the dashboard render it as a
 // placeholder without having to duplicate the constants.
@@ -31,9 +31,11 @@ type providerView struct {
 	ChatModel            string `json:"chat_model"`
 	EvalModel            string `json:"eval_model"`
 	OperatorModel        string `json:"operator_model"`
+	LightModel           string `json:"light_model"`
 	ChatModelDefault     string `json:"chat_model_default"`
 	EvalModelDefault     string `json:"eval_model_default"`
 	OperatorModelDefault string `json:"operator_model_default"`
+	LightModelDefault    string `json:"light_model_default"`
 	Enabled              bool   `json:"enabled"`
 	Index                int    `json:"index"`
 }
@@ -47,9 +49,11 @@ func toProviderView(p config.ClaudeProvider, idx int) providerView {
 		ChatModel:            p.ChatModel,
 		EvalModel:            p.EvalModel,
 		OperatorModel:        p.OperatorModel,
+		LightModel:           p.LightModel,
 		ChatModelDefault:     config.DefaultChatModel,
 		EvalModelDefault:     config.DefaultEvalModel,
 		OperatorModelDefault: config.DefaultOperatorModel,
+		LightModelDefault:    config.DefaultLightModel,
 		Enabled:              p.Enabled,
 		Index:                idx,
 	}
@@ -81,6 +85,7 @@ type providerAddRequest struct {
 	ChatModel     string `json:"chat_model,omitempty"`
 	EvalModel     string `json:"eval_model,omitempty"`
 	OperatorModel string `json:"operator_model,omitempty"`
+	LightModel    string `json:"light_model,omitempty"`
 	Enabled       *bool  `json:"enabled,omitempty"`
 }
 
@@ -115,6 +120,7 @@ func HandleAddProvider(w http.ResponseWriter, r *http.Request) {
 		ChatModel:     strings.TrimSpace(req.ChatModel),
 		EvalModel:     strings.TrimSpace(req.EvalModel),
 		OperatorModel: strings.TrimSpace(req.OperatorModel),
+		LightModel:    strings.TrimSpace(req.LightModel),
 		Enabled:       enabled,
 	}
 	creds.ClaudeProviders = append(creds.ClaudeProviders, p)
@@ -135,6 +141,7 @@ type providerUpdateRequest struct {
 	ChatModel     *string `json:"chat_model,omitempty"`
 	EvalModel     *string `json:"eval_model,omitempty"`
 	OperatorModel *string `json:"operator_model,omitempty"`
+	LightModel    *string `json:"light_model,omitempty"`
 	Enabled       *bool   `json:"enabled,omitempty"`
 }
 
@@ -180,6 +187,9 @@ func HandleUpdateProvider(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.OperatorModel != nil {
 		p.OperatorModel = strings.TrimSpace(*req.OperatorModel)
+	}
+	if req.LightModel != nil {
+		p.LightModel = strings.TrimSpace(*req.LightModel)
 	}
 	if req.Enabled != nil {
 		p.Enabled = *req.Enabled

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,6 +257,7 @@ type ClaudeProvider struct {
 	ChatModel     string `yaml:"chat_model,omitempty"`     // used by `clawflow chat` and project Pilot
 	EvalModel     string `yaml:"eval_model,omitempty"`     // used by evaluate-* operators
 	OperatorModel string `yaml:"operator_model,omitempty"` // used by every other operator
+	LightModel    string `yaml:"light_model,omitempty"`    // used by lightweight operators (classify, reply-*, track-progress)
 	// Deprecated: Model is the legacy single-slot override. Non-empty on
 	// load triggers migration into the three role-specific fields above.
 	// Kept here so old credentials.yaml entries round-trip without loss.
@@ -292,8 +293,17 @@ func (p *ClaudeProvider) EffectiveOperatorModel() string {
 	return p.OperatorModel
 }
 
+// EffectiveLightModel returns the light model this provider should use,
+// falling back to DefaultLightModel when unset.
+func (p *ClaudeProvider) EffectiveLightModel() string {
+	if p == nil || p.LightModel == "" {
+		return DefaultLightModel
+	}
+	return p.LightModel
+}
+
 // EffectiveModelForRole returns the provider's model for the given role
-// ("chat" / "eval" / "operator"). Unknown roles fall back to the
+// ("chat" / "eval" / "operator" / "light"). Unknown roles fall back to the
 // operator model — the safest default for user-supplied skills.
 func (p *ClaudeProvider) EffectiveModelForRole(role string) string {
 	switch role {
@@ -301,6 +311,8 @@ func (p *ClaudeProvider) EffectiveModelForRole(role string) string {
 		return p.EffectiveChatModel()
 	case RoleEval:
 		return p.EffectiveEvalModel()
+	case RoleLight:
+		return p.EffectiveLightModel()
 	default:
 		return p.EffectiveOperatorModel()
 	}
@@ -379,8 +391,8 @@ type Credentials struct {
 	// `clawflow chat` overrides this per-session.
 	ChatDefaultMode string `yaml:"chat_default_mode,omitempty"`
 
-	// envChatModel / envEvalModel / envOperatorModel capture env-var
-	// overrides applied at LoadCredentials time. They take precedence
+	// envChatModel / envEvalModel / envOperatorModel / envLightModel capture
+	// env-var overrides applied at LoadCredentials time. They take precedence
 	// over per-provider fields in ResolveModelForRole, but are NOT
 	// consulted by the per-provider failover loop (which reads
 	// ClaudeProvider.*Model directly). Not persisted — the `-` tag
@@ -388,6 +400,7 @@ type Credentials struct {
 	envChatModel     string `yaml:"-"`
 	envEvalModel     string `yaml:"-"`
 	envOperatorModel string `yaml:"-"`
+	envLightModel    string `yaml:"-"`
 
 	// envClaudeAPIKey / envClaudeBaseURL capture env-var overrides so
 	// provider-aware callers can preserve env > provider > legacy
@@ -406,6 +419,7 @@ const (
 	RoleChat     = "chat"     // `clawflow chat` REPL + project-gen
 	RoleEval     = "eval"     // operators whose name starts with "evaluate-"
 	RoleOperator = "operator" // every other operator + project Pilot
+	RoleLight    = "light"    // lightweight operators: classify, reply-comment, reply-question, track-progress
 )
 
 // Default model identifiers used when no provider is configured for a
@@ -429,6 +443,7 @@ const (
 	DefaultChatModel     = "haiku"
 	DefaultEvalModel     = "opus"
 	DefaultOperatorModel = "sonnet"
+	DefaultLightModel    = "haiku" // lightweight operators use the cheapest tier
 )
 
 // DefaultModelForRole returns the built-in default for role. Unknown
@@ -439,6 +454,8 @@ func DefaultModelForRole(role string) string {
 		return DefaultChatModel
 	case RoleEval:
 		return DefaultEvalModel
+	case RoleLight:
+		return DefaultLightModel
 	default:
 		return DefaultOperatorModel
 	}
@@ -532,6 +549,8 @@ func (c *Credentials) envRoleOverride(role string) string {
 		return c.envEvalModel
 	case RoleOperator:
 		return c.envOperatorModel
+	case RoleLight:
+		return c.envLightModel
 	}
 	return ""
 }
@@ -780,6 +799,7 @@ func LoadCredentials() (*Credentials, error) {
 	c.envChatModel = os.Getenv("CLAWFLOW_CLAUDE_CHAT_MODEL")
 	c.envEvalModel = os.Getenv("CLAWFLOW_CLAUDE_EVAL_MODEL")
 	c.envOperatorModel = os.Getenv("CLAWFLOW_CLAUDE_OPERATOR_MODEL")
+	c.envLightModel = os.Getenv("CLAWFLOW_CLAUDE_LIGHT_MODEL")
 
 	// Auto-migrate legacy single-provider fields to the providers list,
 	// seed the built-in OAuth fallback entry on first load, and push old

--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -223,6 +223,7 @@ type providerEntry struct {
 	chatModel     string
 	evalModel     string
 	operatorModel string
+	lightModel    string
 }
 
 // modelForRole returns the model this provider should use for role,
@@ -236,6 +237,8 @@ func (p providerEntry) modelForRole(role string) string {
 		v = p.chatModel
 	case config.RoleEval:
 		v = p.evalModel
+	case config.RoleLight:
+		v = p.lightModel
 	default:
 		v = p.operatorModel
 	}
@@ -264,6 +267,7 @@ func buildProviderList(creds *config.Credentials) []providerEntry {
 				chatModel:     p.ChatModel,
 				evalModel:     p.EvalModel,
 				operatorModel: p.OperatorModel,
+				lightModel:    p.LightModel,
 			}
 		}
 		return out

--- a/web/src/components/ProvidersSection.tsx
+++ b/web/src/components/ProvidersSection.tsx
@@ -45,9 +45,11 @@ interface ProviderView {
   chat_model: string
   eval_model: string
   operator_model: string
+  light_model: string
   chat_model_default: string
   eval_model_default: string
   operator_model_default: string
+  light_model_default: string
   enabled: boolean
   index: number
 }
@@ -69,6 +71,7 @@ async function addProvider(body: {
   chat_model?: string
   eval_model?: string
   operator_model?: string
+  light_model?: string
   enabled: boolean
 }): Promise<ProviderView> {
   const r = await fetch('/api/providers', {
@@ -83,7 +86,7 @@ async function addProvider(body: {
 
 async function updateProvider(
   idx: number,
-  body: { name?: string; base_url?: string; api_key?: string; chat_model?: string; eval_model?: string; operator_model?: string; enabled?: boolean },
+  body: { name?: string; base_url?: string; api_key?: string; chat_model?: string; eval_model?: string; operator_model?: string; light_model?: string; enabled?: boolean },
 ): Promise<ProviderView> {
   const r = await fetch(`/api/providers/${idx}`, {
     method: 'PUT',
@@ -199,11 +202,12 @@ function SortableRow({ provider, onEdit, onDelete, onToggle, onTest, testState }
       </span>
 
       {/* Models */}
-      <span className="text-muted-foreground text-xs w-36 shrink-0 truncate" title={`chat:${provider.chat_model||'default'} eval:${provider.eval_model||'default'} op:${provider.operator_model||'default'}`}>
+      <span className="text-muted-foreground text-xs w-36 shrink-0 truncate" title={`chat:${provider.chat_model||'default'} eval:${provider.eval_model||'default'} op:${provider.operator_model||'default'} light:${provider.light_model||'default'}`}>
         {[
           provider.chat_model || provider.chat_model_default,
           provider.eval_model || provider.eval_model_default,
           provider.operator_model || provider.operator_model_default,
+          provider.light_model || provider.light_model_default,
         ].join(' / ')}
       </span>
 
@@ -300,6 +304,7 @@ interface ProviderModalProps {
     chat_model: string
     eval_model: string
     operator_model: string
+    light_model: string
     enabled: boolean
   }) => Promise<void>
   onClose: () => void
@@ -313,6 +318,7 @@ function ProviderModal({ initial, onSave, onClose }: ProviderModalProps) {
   const [chatModel, setChatModel] = useState(initial?.chat_model ?? '')
   const [evalModel, setEvalModel] = useState(initial?.eval_model ?? '')
   const [operatorModel, setOperatorModel] = useState(initial?.operator_model ?? '')
+  const [lightModel, setLightModel] = useState(initial?.light_model ?? '')
   const [enabled, setEnabled] = useState(initial?.enabled ?? true)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
@@ -335,7 +341,7 @@ function ProviderModal({ initial, onSave, onClose }: ProviderModalProps) {
     if (!name.trim()) { setErr('Name is required'); return }
     setBusy(true); setErr(null)
     try {
-      await onSave({ name: name.trim(), base_url: baseURL.trim(), api_key: apiKey, chat_model: chatModel.trim(), eval_model: evalModel.trim(), operator_model: operatorModel.trim(), enabled })
+      await onSave({ name: name.trim(), base_url: baseURL.trim(), api_key: apiKey, chat_model: chatModel.trim(), eval_model: evalModel.trim(), operator_model: operatorModel.trim(), light_model: lightModel.trim(), enabled })
       onClose()
     } catch (e: unknown) {
       setErr(e instanceof Error ? e.message : String(e))
@@ -438,6 +444,15 @@ function ProviderModal({ initial, onSave, onClose }: ProviderModalProps) {
             />
           </Field>
 
+          <Field label="Light model" hint={`default: ${initial?.light_model_default ?? 'haiku'}`}>
+            <ModelSelect
+              value={lightModel}
+              onChange={setLightModel}
+              defaultLabel={initial?.light_model_default ?? 'haiku'}
+              ariaLabel="Light model"
+            />
+          </Field>
+
           <div className="flex items-start gap-3">
             <div className="w-28 shrink-0" />
             <p className="flex-1 text-[10px] text-muted-foreground/70 leading-relaxed">
@@ -445,6 +460,12 @@ function ProviderModal({ initial, onSave, onClose }: ProviderModalProps) {
               latest model; type a full model ID to pin that exact version;
               custom providers can enter any model name they expose. Leave blank
               to use the default shown above.
+              <br />
+              <span className="text-muted-foreground/50">
+                Eval = evaluate-* operators · Operator = implement + user skills ·
+                Light = classify / reply-comment / reply-question / track-progress ·
+                Chat = REPL &amp; project-gen
+              </span>
             </p>
           </div>
 


### PR DESCRIPTION
Fixes #280

## 变更内容

新增 `RoleLight` 作为第四个算子角色档位，让 `classify`、`reply-comment`、`reply-question`、`track-progress` 这类轻量算子走独立的模型槽（默认 haiku），与执行类算子（sonnet）和评估类算子（opus）区分开来。

### 改动文件

**`internal/config/config.go`**
- 新增 `RoleLight = "light"` 常量
- 新增 `DefaultLightModel = "haiku"`
- `ClaudeProvider` 新增 `LightModel string `yaml:"light_model,omitempty"`` 字段
- 新增 `EffectiveLightModel()` 方法
- `EffectiveModelForRole`、`DefaultModelForRole`、`envRoleOverride` 均扩展支持 `RoleLight`
- 新增 `CLAWFLOW_CLAUDE_LIGHT_MODEL` 环境变量覆盖

**`internal/operator/claude.go`**
- `providerEntry` 新增 `lightModel` 字段
- `modelForRole` 扩展 `RoleLight` 分支
- `buildProviderList` 从 provider config 填充 `lightModel`

**`cmd/clawflow/commands/run.go`**
- `roleForOperator` 把 `classify`、`reply-comment`、`reply-question`、`track-progress` 归入 `RoleLight`

**`internal/api/providers.go`**
- `providerView` / `providerAddRequest` / `providerUpdateRequest` 全部加入 `light_model` 字段
- `toProviderView` 填充 `LightModel` 和 `LightModelDefault`

**`web/src/components/ProvidersSection.tsx`**
- `ProviderView` interface 新增 `light_model` / `light_model_default` 字段
- `addProvider` / `updateProvider` 函数签名扩展
- ProviderModal 新增 Light model 表单字段（紧跟 Operator model 后）
- provider 行 tooltip 加入 light 档位展示
- 底部说明文字标注各角色对应的算子名称

## 覆盖链（不变）

`CLAWFLOW_CLAUDE_LIGHT_MODEL` env → 第一个启用 provider 的 `light_model` → 内建默认 `haiku`

## 已验证

- `go test ./internal/config/... ./internal/operator/... ./internal/api/...` 全部通过
- `tsc --noEmit` 无类型错误

## 未覆盖（按评估意见确认推迟）

- Fable 档位：尚非 Anthropic 公开 CLI 别名，暂不添加到 `MODEL_PRESETS`，用户可自由输入
- 三层覆盖（全局 → 阶段 → per-provider）：当前已有 env → provider per-role → 内建默认，per-repo / per-operator 维度需单独立项