### PR TITLE
feat(api): add pr close subcommand to close PRs

### DIFF
--- a/cmd/clawflow/commands/pr.go
+++ b/cmd/clawflow/commands/pr.go
@@ -22,6 +22,7 @@ func NewPRCmd() *cobra.Command {
 	cmd.AddCommand(newPRCommentCmd())
 	cmd.AddCommand(newPRCIWaitCmd())
 	cmd.AddCommand(newPRMergeCmd())
+	cmd.AddCommand(newPRCloseCmd())
 	cmd.AddCommand(newPRRebaseCmd())
 	return cmd
 }
@@ -272,6 +273,33 @@ func newPRMergeCmd() *cobra.Command {
 	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
 	cmd.Flags().IntVar(&number, "pr", 0, "PR number (required)")
 	cmd.Flags().BoolVar(&noDeleteBranch, "no-delete-branch", false, "keep the source branch after merging (default: delete)")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("pr")
+	return cmd
+}
+
+func newPRCloseCmd() *cobra.Command {
+	var repo string
+	var number int
+
+	cmd := &cobra.Command{
+		Use:     "close",
+		Short:   "Close a pull request / merge request without merging",
+		Example: "  clawflow pr close --repo owner/repo --pr 7",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _, err := newVCSClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			if err := client.ClosePR(repo, number); err != nil {
+				return err
+			}
+			fmt.Printf("closed %s PR #%d\n", repo, number)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "owner/repo (required)")
+	cmd.Flags().IntVar(&number, "pr", 0, "PR number (required)")
 	_ = cmd.MarkFlagRequired("repo")
 	_ = cmd.MarkFlagRequired("pr")
 	return cmd

--- a/internal/pilot/budget/client.go
+++ b/internal/pilot/budget/client.go
@@ -110,6 +110,13 @@ func (b *budgetClient) MergePR(repo string, n int) error {
 	return b.Client.MergePR(repo, n)
 }
 
+func (b *budgetClient) ClosePR(repo string, n int) error {
+	if err := Reserve("ClosePR"); err != nil {
+		return err
+	}
+	return b.Client.ClosePR(repo, n)
+}
+
 func (b *budgetClient) DeleteBranch(repo, branch string) error {
 	if err := Reserve("DeleteBranch"); err != nil {
 		return err

--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -863,6 +863,25 @@ func (c *Client) MergePR(repo string, prNumber int) error {
 	return err
 }
 
+// ClosePR closes a PR without merging via PATCH /repos/:owner/:name/pulls/:n
+// with {"state":"closed"}. Note the path is /pulls/ (not /issues/), though
+// GitHub also accepts the issues endpoint for the shared number space.
+func (c *Client) ClosePR(repo string, prNumber int) error {
+	owner, name, err := splitRepo(repo)
+	if err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/repos/%s/%s/pulls/%d", owner, name, prNumber)
+	data, status, err := c.do("PATCH", path, map[string]string{"state": "closed"})
+	if err != nil {
+		return err
+	}
+	if status != 200 {
+		return fmt.Errorf("github close PR: HTTP %d: %s", status, data)
+	}
+	return nil
+}
+
 // MergePRDetailed merges a PR and returns the resulting merge commit SHA.
 // GitHub's PUT /pulls/:n/merge returns { sha, merged, message } on 200.
 func (c *Client) MergePRDetailed(repo string, prNumber int) (string, error) {

--- a/internal/vcs/github/client_test.go
+++ b/internal/vcs/github/client_test.go
@@ -184,6 +184,30 @@ func TestUpdateIssue(t *testing.T) {
 	}
 }
 
+func TestClosePR(t *testing.T) {
+	var got map[string]string
+	hit := false
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"PATCH /repos/owner/repo/pulls/7": func(w http.ResponseWriter, r *http.Request) {
+			hit = true
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatal(err)
+			}
+			jsonResp(w, 200, map[string]any{"number": 7, "state": "closed"})
+		},
+	})
+
+	if err := client.ClosePR("owner/repo", 7); err != nil {
+		t.Fatal(err)
+	}
+	if !hit {
+		t.Fatal("expected PATCH /pulls/7 to be called")
+	}
+	if got["state"] != "closed" {
+		t.Fatalf("payload = %#v, want state=closed", got)
+	}
+}
+
 func TestGetIssue(t *testing.T) {
 	client := newTestClient(t, map[string]http.HandlerFunc{
 		"GET /repos/owner/repo/issues/7": func(w http.ResponseWriter, r *http.Request) {

--- a/internal/vcs/gitlab/client.go
+++ b/internal/vcs/gitlab/client.go
@@ -662,6 +662,21 @@ func (c *Client) ListIssuesByBodyKeyword(repo string, keyword string) ([]vcs.Iss
 	return out, nil
 }
 
+// ClosePR closes a merge request without merging via
+// PUT /projects/:id/merge_requests/:iid with state_event=close.
+func (c *Client) ClosePR(repo string, prNumber int) error {
+	path := fmt.Sprintf("/projects/%s/merge_requests/%d", projectID(repo), prNumber)
+	form := url.Values{"state_event": {"close"}}
+	data, status, err := c.do("PUT", path, form)
+	if err != nil {
+		return err
+	}
+	if status != 200 {
+		return fmt.Errorf("gitlab close MR: HTTP %d: %s", status, data)
+	}
+	return nil
+}
+
 func (c *Client) MergePR(repo string, prNumber int) error {
 	path := fmt.Sprintf("/projects/%s/merge_requests/%d/merge", projectID(repo), prNumber)
 	data, status, err := c.doJSON("PUT", path, map[string]string{"merge_when_pipeline_succeeds": "false"})

--- a/internal/vcs/interface.go
+++ b/internal/vcs/interface.go
@@ -174,6 +174,10 @@ type Client interface {
 	MergePR(repo string, prNumber int) error
 	GetPRMergeability(repo string, prNumber int) (MergeStatus, error)
 
+	// Close
+	// ClosePR closes a pull request / merge request without merging it.
+	ClosePR(repo string, prNumber int) error
+
 	// Branches
 	// DeleteBranch removes a branch from the remote. Implementations should
 	// treat "branch already gone" as a non-error (idempotent).


### PR DESCRIPTION
Fixes #282

## 变更内容
为 `clawflow pr` 增加 `close` 子命令，让用户在终端直接关闭（而非合并）一个悬挂 / 不再需要的 PR，无需跳转 GitHub/GitLab 网页。

- **`internal/vcs/interface.go`**：`VCS` 接口新增 `ClosePR(repo string, prNumber int) error`，紧邻 `MergePR`。
- **`internal/vcs/github/client.go`**：实现 `ClosePR`，走 `PATCH /repos/{owner}/{name}/pulls/{n}`，body `{"state":"closed"}`，校验 HTTP 200。
- **`internal/vcs/gitlab/client.go`**：实现 `ClosePR`，走 `PUT /projects/{id}/merge_requests/{iid}` 带 `state_event=close`。
- **`internal/pilot/budget/client.go`**：与 `MergePR`/`DeleteBranch` 一致，为这个破坏性写操作加上 `Reserve("ClosePR")` 预算追踪包装。
- **`cmd/clawflow/commands/pr.go`**：新增 `newPRCloseCmd()`，沿用现有 `pr merge` 的 `--repo` + `--pr` flag 风格（与 issue 里的位置参数建议不同，保持与现有子命令一致），成功后打印 `closed {repo} PR #{n}`。

## 设计决策
- **参数风格**：采用 `--repo`/`--pr` flag 而非位置参数，与现有 `pr merge`/`pr view`/`pr comment` 保持一致（evaluation 中的建议）。
- **分支清理**：`close` 默认**不**删源分支（关闭 ≠ 已合并，分支可能仍需保留），后续如需可加 `--delete-branch` opt-in。

## 测试
- 新增 `internal/vcs/github/client_test.go` 中的 `TestClosePR`：用 httptest 验证发出的是 `PATCH .../pulls/7` 且 body `state=closed`。
- `go test ./internal/vcs/... ./internal/pilot/budget/...` 全部通过。
- 注：根包 `go build .` 因 `web/dist` 未构建（embed.FS）报错，属预存在环境约束，与本次改动无关；受影响的 `cmd/...` 与 `internal/...` 包均可独立编译通过。