### PR TITLE
fix: 版本徽章移至右侧顶栏，消除刷新时菜单挤动

### DIFF
--- a/web/src/routes/_app.tsx
+++ b/web/src/routes/_app.tsx
@@ -95,52 +95,6 @@ function AppLayout() {
                 local
               </span>
             </a>
-            {/* Version badge with upgrade indicator */}
-            {currentVersion && (
-              <div className="relative">
-                <button
-                  onClick={updateAvailable ? triggerUpdate : undefined}
-                  onMouseEnter={() => setShowTooltip(true)}
-                  onMouseLeave={() => setShowTooltip(false)}
-                  disabled={!updateAvailable || updating || restarting}
-                  className={`relative inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-mono transition-colors ${
-                    updateAvailable && !updating && !restarting
-                      ? 'cursor-pointer hover:bg-[hsl(var(--brand)/0.1)] text-[hsl(var(--text-mid,var(--text-low)))]'
-                      : 'cursor-default text-[hsl(var(--text-low))]'
-                  }`}
-                  style={{ color: 'hsl(var(--text-low))' }}
-                  aria-label={updateAvailable ? `Upgrade to ${latestVersion}` : `Version ${currentVersion}`}
-                >
-                  {restarting ? (
-                    <><Loader2 className="w-3 h-3 animate-spin" /> Restarting…</>
-                  ) : updating ? (
-                    <><Loader2 className="w-3 h-3 animate-spin" /> Updating…</>
-                  ) : (
-                    <>
-                      {currentVersion}
-                      {updateAvailable && (
-                        <svg className="w-2 h-2 shrink-0" viewBox="0 0 8 8" aria-hidden="true">
-                          <circle cx="4" cy="4" r="4" fill="#ef4444" />
-                        </svg>
-                      )}
-                    </>
-                  )}
-                </button>
-                {/* Tooltip */}
-                {showTooltip && updateAvailable && !updating && !restarting && (
-                  <div
-                    className="absolute top-full left-1/2 -translate-x-1/2 mt-1.5 px-2.5 py-1.5 rounded-md text-[11px] whitespace-nowrap shadow-lg z-50 border"
-                    style={{
-                      background: 'hsl(var(--bg-panel))',
-                      borderColor: 'hsl(var(--border))',
-                      color: 'hsl(var(--text-high))',
-                    }}
-                  >
-                    Click to upgrade to <span className="font-semibold">{latestVersion}</span>
-                  </div>
-                )}
-              </div>
-            )}
             <nav className="flex gap-1">
               <Link
                 to="/dashboard"
@@ -194,6 +148,56 @@ function AppLayout() {
           </div>
 
           <div className="flex items-center gap-2">
+            {/* Version badge with upgrade indicator.
+                Lives in the right-hand cluster (anchored to the right edge by
+                the header's justify-between) so its async appearance after the
+                /api/version fetch never shifts the left-side nav — regardless
+                of how long the version string is. See issue #284. */}
+            {currentVersion && (
+              <div className="relative">
+                <button
+                  onClick={updateAvailable ? triggerUpdate : undefined}
+                  onMouseEnter={() => setShowTooltip(true)}
+                  onMouseLeave={() => setShowTooltip(false)}
+                  disabled={!updateAvailable || updating || restarting}
+                  className={`relative inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-mono tabular-nums whitespace-nowrap transition-colors ${
+                    updateAvailable && !updating && !restarting
+                      ? 'cursor-pointer hover:bg-[hsl(var(--brand)/0.1)] text-[hsl(var(--text-mid,var(--text-low)))]'
+                      : 'cursor-default text-[hsl(var(--text-low))]'
+                  }`}
+                  style={{ color: 'hsl(var(--text-low))' }}
+                  aria-label={updateAvailable ? `Upgrade to ${latestVersion}` : `Version ${currentVersion}`}
+                >
+                  {restarting ? (
+                    <><Loader2 className="w-3 h-3 animate-spin" /> Restarting…</>
+                  ) : updating ? (
+                    <><Loader2 className="w-3 h-3 animate-spin" /> Updating…</>
+                  ) : (
+                    <>
+                      {currentVersion}
+                      {updateAvailable && (
+                        <svg className="w-2 h-2 shrink-0" viewBox="0 0 8 8" aria-hidden="true">
+                          <circle cx="4" cy="4" r="4" fill="#ef4444" />
+                        </svg>
+                      )}
+                    </>
+                  )}
+                </button>
+                {/* Tooltip */}
+                {showTooltip && updateAvailable && !updating && !restarting && (
+                  <div
+                    className="absolute top-full right-0 mt-1.5 px-2.5 py-1.5 rounded-md text-[11px] whitespace-nowrap shadow-lg z-50 border"
+                    style={{
+                      background: 'hsl(var(--bg-panel))',
+                      borderColor: 'hsl(var(--border))',
+                      color: 'hsl(var(--text-high))',
+                    }}
+                  >
+                    Click to upgrade to <span className="font-semibold">{latestVersion}</span>
+                  </div>
+                )}
+              </div>
+            )}
             <ReportIssueButton />
             <a
               href="https://github.com/zhoushoujianwork/clawflow"


### PR DESCRIPTION
Fixes #284

## 问题
左上角版本徽章在挂载后才异步 `fetch('/api/version')`，原本位于 Logo 与导航菜单之间并采用条件渲染。每次刷新都会经历两帧：首帧徽章不存在 → 菜单紧贴 Logo；fetch 返回后徽章插入 → 把右侧 Dashboard/Repos/… 菜单整体右移，产生抖动。

## 改动
- 将版本徽章从左侧组（Logo 与 `<nav>` 之间）移到右侧图标簇首位。
- 右侧簇由 header 的 `justify-between` 右对齐锚定，徽章异步出现时只向左扩展，既不挤动左侧菜单、也不位移右侧既有图标（ReportIssue/GitHub/Sync/主题）。
- 此方案对任意版本号长度都彻底有效，包括 issue 报告者的 git-describe 长版本号 `v0.71.0-15-g7b344ca`（仅靠 min-width 占位无法覆盖超长版本）。
- 徽章额外加 `tabular-nums whitespace-nowrap` 固定字宽，避免 Updating…/Restarting… 更新态切换时的轻微位移。
- tooltip 由居中改为 `right-0` 右对齐，防止移到右侧后溢出视口。

## 测试
- `npx tsc --noEmit` 通过
- `npm run build`（vite + tsc）通过
- web 前端为纯前端布局改动，无后端/单测框架（仓库未配置 vitest/jest）。建议人工在 `clawflow web` 下慢速刷新肉眼确认菜单不再抖动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)