### PR TITLE
fix: 注入 CLAUDE_CODE_MAX_OUTPUT_TOKENS 并识别输出超限错误

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -1078,6 +1078,13 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	// auto-labeling agent-failed on a configuration problem (issue #204).
 	isAuthError := runErr != nil && errors.Is(runErr, operator.ErrAuthError)
 
+	// Detect output-token-limit aborts ("response exceeded the N output token
+	// maximum"). Like auth errors these are NOT fixable by retrying — the
+	// operator needs a higher max_output_tokens ceiling. Record a distinct
+	// status and skip the circuit breaker so we don't burn tokens re-firing
+	// the same doomed run every pass (issue #286).
+	isOutputLimit := runErr != nil && errors.Is(runErr, operator.ErrOutputLimit)
+
 	// Detect no-marker failures: claude produced output but omitted the
 	// outcome marker. operator.Run now returns ErrNoOutcomeMarker for this
 	// case so we can route it through the circuit breaker (status="failed")
@@ -1094,6 +1101,9 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 			fmt.Fprintf(os.Stderr, "%s ✗ claude auth error 403 (check session/API key, NOT retrying): %v\n", prefix, runErr)
 		} else if isNoMarker {
 			fmt.Fprintf(os.Stderr, "%s ✗ claude produced no outcome marker (will count toward circuit breaker): %v\n", prefix, runErr)
+		} else if isOutputLimit {
+			runLog.Warn("run/output_limit", "repo", j.repo, "issue", j.sub.Number, "op", j.op.Name, "err", runErr.Error())
+			fmt.Fprintf(os.Stderr, "%s ✗ claude output token limit exceeded (raise max_output_tokens, NOT retrying): %v\n", prefix, runErr)
 		} else {
 			fmt.Fprintf(os.Stderr, "%s ✗ claude failed: %v\n", prefix, runErr)
 		}
@@ -1125,6 +1135,16 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		// or configure an independent API key provider (issue #204).
 		rm.Status = "auth-error"
 		rm.Error = runErr.Error()
+	case isOutputLimit:
+		// Record as "output-limit" — distinct from "failed" so the dashboard
+		// surfaces the specific cause (raise max_output_tokens). Unlike
+		// rate-limit (self-resolves) and auth (fails fast), an output-limit run
+		// deterministically fails AND burns a full large-diff generation every
+		// pass, so it DOES count toward the circuit breaker to bound the token
+		// bleed — eventually labeling agent-failed until the owner raises the
+		// ceiling. Each pass also emits a WARN log for patrol (issue #286).
+		rm.Status = "output-limit"
+		rm.Error = runErr.Error()
 	case isNoMarker:
 		// No-marker runs are recorded as "no-marker" (distinct from generic
 		// "failed") so the dashboard can surface the specific cause. They DO
@@ -1150,7 +1170,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	// partial work instead of starting from scratch.
 	// skipped-empty, no-marker, and auth-error have no partial work worth
 	// resuming, so clean up to avoid accumulating stale worktrees.
-	if rm.Status == "success" || rm.Status == "skipped-empty" || rm.Status == "no-marker" || rm.Status == "auth-error" {
+	if rm.Status == "success" || rm.Status == "skipped-empty" || rm.Status == "no-marker" || rm.Status == "auth-error" || rm.Status == "output-limit" {
 		cleanup()
 	} else {
 		fmt.Fprintf(os.Stderr, "%s → preserving worktree for resume on next run: %s\n", prefix, workdir)
@@ -1165,7 +1185,7 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	// Upgrade to WARN for non-success statuses so deployment.md patrol's
 	// "grep -E ERROR|WARN" actively catches failures (issue #204).
 	logFn := runLog.Info
-	if rm.Status == "failed" || rm.Status == "auth-error" {
+	if rm.Status == "failed" || rm.Status == "auth-error" || rm.Status == "output-limit" {
 		logFn = runLog.Warn
 	}
 	logFn("run/end",
@@ -1198,6 +1218,10 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		return false, false
 	case "no-marker":
 		fmt.Printf("%s ✗ no outcome marker (circuit breaker counting)\n", prefix)
+		checkCircuitBreaker(j, prefix)
+		return false, false
+	case "output-limit":
+		fmt.Printf("%s ✗ output token limit (raise max_output_tokens; circuit breaker counting)\n", prefix)
 		checkCircuitBreaker(j, prefix)
 		return false, false
 	case "skipped-empty":

--- a/internal/claude/resolve.go
+++ b/internal/claude/resolve.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -67,4 +68,28 @@ func EnvWithCredentials(env []string, apiKey, baseURL string) []string {
 		out = append(out, "ANTHROPIC_BASE_URL="+baseURL)
 	}
 	return out
+}
+
+// EnvWithMaxOutputTokens returns env with CLAUDE_CODE_MAX_OUTPUT_TOKENS set to
+// maxTokens, UNLESS the variable is already present in env (an explicit
+// user/shell override always wins — env > config > built-in default, matching
+// the precedence used elsewhere in clawflow).
+//
+// maxTokens <= 0 is a no-op: the caller has nothing to inject, so the claude
+// CLI keeps its own built-in default (the historical behaviour). Operators
+// that emit large diffs (e.g. `implement`) hit the default 64000 ceiling and
+// fail with "Claude's response exceeded the N output token maximum" — raising
+// this ceiling via config is the fix (issue #286).
+func EnvWithMaxOutputTokens(env []string, maxTokens int) []string {
+	if maxTokens <= 0 {
+		return env
+	}
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CLAUDE_CODE_MAX_OUTPUT_TOKENS=") {
+			return env // explicit override present — don't clobber it.
+		}
+	}
+	out := make([]string, len(env), len(env)+1)
+	copy(out, env)
+	return append(out, "CLAUDE_CODE_MAX_OUTPUT_TOKENS="+strconv.Itoa(maxTokens))
 }

--- a/internal/claude/resolve_test.go
+++ b/internal/claude/resolve_test.go
@@ -57,3 +57,34 @@ func TestEnvWithCredentials_AddsBoth(t *testing.T) {
 		t.Errorf("expected both keys appended; got %v", got)
 	}
 }
+
+func TestEnvWithMaxOutputTokens_Injects(t *testing.T) {
+	in := []string{"PATH=/usr/bin"}
+	got := EnvWithMaxOutputTokens(in, 96000)
+	if !slices.Contains(got, "CLAUDE_CODE_MAX_OUTPUT_TOKENS=96000") {
+		t.Errorf("expected CLAUDE_CODE_MAX_OUTPUT_TOKENS=96000 in %v", got)
+	}
+}
+
+func TestEnvWithMaxOutputTokens_NonPositiveIsNoop(t *testing.T) {
+	in := []string{"PATH=/usr/bin"}
+	for _, n := range []int{0, -1} {
+		got := EnvWithMaxOutputTokens(in, n)
+		for _, kv := range got {
+			if len(kv) >= 30 && kv[:30] == "CLAUDE_CODE_MAX_OUTPUT_TOKENS=" {
+				t.Errorf("n=%d should be a no-op, got %v", n, got)
+			}
+		}
+	}
+}
+
+func TestEnvWithMaxOutputTokens_PreservesExistingOverride(t *testing.T) {
+	in := []string{"PATH=/usr/bin", "CLAUDE_CODE_MAX_OUTPUT_TOKENS=200000"}
+	got := EnvWithMaxOutputTokens(in, 64000)
+	if !slices.Contains(got, "CLAUDE_CODE_MAX_OUTPUT_TOKENS=200000") {
+		t.Errorf("explicit override should win; got %v", got)
+	}
+	if slices.Contains(got, "CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000") {
+		t.Errorf("should not append a second value; got %v", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -258,6 +258,13 @@ type ClaudeProvider struct {
 	EvalModel     string `yaml:"eval_model,omitempty"`     // used by evaluate-* operators
 	OperatorModel string `yaml:"operator_model,omitempty"` // used by every other operator
 	LightModel    string `yaml:"light_model,omitempty"`    // used by lightweight operators (classify, reply-*, track-progress)
+	// MaxOutputTokens raises the CLAUDE_CODE_MAX_OUTPUT_TOKENS ceiling for
+	// this provider's subprocesses. Zero means "use the built-in default"
+	// (DefaultMaxOutputTokens). Operators that emit large diffs (implement)
+	// blow past claude's own 64000 default and fail; raising this fixes it
+	// (issue #286). Note: must not exceed the target model's real output
+	// ceiling, so it's configurable rather than hard-coded high.
+	MaxOutputTokens int `yaml:"max_output_tokens,omitempty"`
 	// Deprecated: Model is the legacy single-slot override. Non-empty on
 	// load triggers migration into the three role-specific fields above.
 	// Kept here so old credentials.yaml entries round-trip without loss.
@@ -300,6 +307,16 @@ func (p *ClaudeProvider) EffectiveLightModel() string {
 		return DefaultLightModel
 	}
 	return p.LightModel
+}
+
+// EffectiveMaxOutputTokens returns the CLAUDE_CODE_MAX_OUTPUT_TOKENS ceiling
+// this provider should inject, falling back to DefaultMaxOutputTokens when
+// unset (<= 0).
+func (p *ClaudeProvider) EffectiveMaxOutputTokens() int {
+	if p == nil || p.MaxOutputTokens <= 0 {
+		return DefaultMaxOutputTokens
+	}
+	return p.MaxOutputTokens
 }
 
 // EffectiveModelForRole returns the provider's model for the given role
@@ -445,6 +462,16 @@ const (
 	DefaultOperatorModel = "sonnet"
 	DefaultLightModel    = "haiku" // lightweight operators use the cheapest tier
 )
+
+// DefaultMaxOutputTokens is the CLAUDE_CODE_MAX_OUTPUT_TOKENS ceiling
+// clawflow injects when a provider doesn't override it. The claude CLI's
+// own built-in default is 64000; large-diff operators (implement) exceed it
+// and fail with "Claude's response exceeded the N output token maximum"
+// (issue #286). 64000 is a known per-model ceiling — we set the env var
+// explicitly to that value so the behaviour is visible/overridable rather
+// than relying on the CLI's implicit default, and let config raise it where
+// a model supports more.
+const DefaultMaxOutputTokens = 64000
 
 // DefaultModelForRole returns the built-in default for role. Unknown
 // roles fall back to the operator default (safest for user skills).

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -478,3 +478,28 @@ func TestResolveClaudeCredentials(t *testing.T) {
 		}
 	})
 }
+
+// TestEffectiveMaxOutputTokens verifies the per-provider output-token ceiling
+// falls back to the built-in default when unset and honors explicit overrides
+// (issue #286).
+func TestEffectiveMaxOutputTokens(t *testing.T) {
+	var nilP *config.ClaudeProvider
+	if got := nilP.EffectiveMaxOutputTokens(); got != config.DefaultMaxOutputTokens {
+		t.Errorf("nil provider: got %d, want default %d", got, config.DefaultMaxOutputTokens)
+	}
+
+	unset := &config.ClaudeProvider{Name: "A"}
+	if got := unset.EffectiveMaxOutputTokens(); got != config.DefaultMaxOutputTokens {
+		t.Errorf("unset: got %d, want default %d", got, config.DefaultMaxOutputTokens)
+	}
+
+	custom := &config.ClaudeProvider{Name: "B", MaxOutputTokens: 96000}
+	if got := custom.EffectiveMaxOutputTokens(); got != 96000 {
+		t.Errorf("custom: got %d, want 96000", got)
+	}
+
+	zeroOrNeg := &config.ClaudeProvider{Name: "C", MaxOutputTokens: -1}
+	if got := zeroOrNeg.EffectiveMaxOutputTokens(); got != config.DefaultMaxOutputTokens {
+		t.Errorf("negative: got %d, want default %d", got, config.DefaultMaxOutputTokens)
+	}
+}

--- a/internal/operator/claude.go
+++ b/internal/operator/claude.go
@@ -30,6 +30,23 @@ var ErrRateLimit = errors.New("claude rate limit")
 // or API-key configuration rather than burning quota on an infinite loop.
 var ErrAuthError = errors.New("claude auth error")
 
+// ErrOutputLimit is returned by RunClaude when the claude CLI aborts because
+// its response exceeded the configured CLAUDE_CODE_MAX_OUTPUT_TOKENS ceiling
+// ("Claude's response exceeded the N output token maximum"). Like rate limits
+// this is NOT a permanent operator failure — the issue keeps its trigger
+// labels and blindly retrying just burns more tokens. Callers should record a
+// distinct status and surface it so the owner can raise max_output_tokens
+// rather than counting it toward the circuit breaker (issue #286).
+var ErrOutputLimit = errors.New("claude output token limit")
+
+// outputLimitPatterns are substrings (case-insensitive) that identify an
+// output-token-ceiling abort from the claude CLI. The CLI emits a message of
+// the form "Claude's response exceeded the 64000 output token maximum."
+var outputLimitPatterns = []string{
+	"output token maximum",
+	"exceeded the maximum output",
+}
+
 // authErrorPatterns are substrings (case-insensitive) that identify a
 // 403 / authentication-failure response from the claude CLI. Matching any
 // one of them triggers ErrAuthError rather than the generic failure path.
@@ -89,6 +106,23 @@ func IsAuthError(err error, output string) bool {
 	}
 	combined := strings.ToLower(err.Error() + " " + output)
 	for _, pat := range authErrorPatterns {
+		if strings.Contains(combined, strings.ToLower(pat)) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsOutputLimitError reports whether err or the captured claude output text
+// indicates the response exceeded the CLAUDE_CODE_MAX_OUTPUT_TOKENS ceiling.
+// Both are checked because the claude CLI writes the human-readable message
+// to stdout while the Go error only carries "exit status 1".
+func IsOutputLimitError(err error, output string) bool {
+	if err == nil {
+		return false
+	}
+	combined := strings.ToLower(err.Error() + " " + output)
+	for _, pat := range outputLimitPatterns {
 		if strings.Contains(combined, strings.ToLower(pat)) {
 			return true
 		}
@@ -165,7 +199,7 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 
 	for i, p := range providers {
 		model := p.modelForRole(role)
-		output, err := runClaudeWithProvider(ctx, prompt, workdir, model, p.apiKey, p.baseURL, events, systemPrompt...)
+		output, err := runClaudeWithProvider(ctx, prompt, workdir, model, p.apiKey, p.baseURL, p.maxOutputTokens, events, systemPrompt...)
 		if err == nil {
 			if i > 0 {
 				fmt.Fprintf(os.Stderr, "  ✓ provider %q succeeded (after %d failed attempt(s))\n", p.name, i)
@@ -181,6 +215,17 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 		if IsAuthError(err, output) {
 			wrapped := fmt.Errorf("claude: %w", err)
 			return output, fmt.Errorf("%w: %w", ErrAuthError, wrapped)
+		}
+
+		// Output-token-limit aborts ("response exceeded the N output token
+		// maximum") are not fixable by retrying or switching provider — the
+		// operator needs a higher max_output_tokens ceiling. Return
+		// ErrOutputLimit immediately so the caller records a distinct status
+		// and skips the circuit breaker instead of blindly re-firing every
+		// run and burning tokens (issue #286).
+		if IsOutputLimitError(err, output) {
+			wrapped := fmt.Errorf("claude: %w", err)
+			return output, fmt.Errorf("%w: %w", ErrOutputLimit, wrapped)
 		}
 
 		// Determine whether this is a provider-level failure (failover) or
@@ -217,13 +262,14 @@ func RunClaude(ctx context.Context, prompt, workdir string, timeout time.Duratio
 // tuple used during a single RunClaude invocation. Constructed from
 // config.ClaudeProvider or the legacy single-provider fields.
 type providerEntry struct {
-	name          string
-	apiKey        string
-	baseURL       string
-	chatModel     string
-	evalModel     string
-	operatorModel string
-	lightModel    string
+	name            string
+	apiKey          string
+	baseURL         string
+	chatModel       string
+	evalModel       string
+	operatorModel   string
+	lightModel      string
+	maxOutputTokens int
 }
 
 // modelForRole returns the model this provider should use for role,
@@ -254,35 +300,37 @@ func (p providerEntry) modelForRole(role string) string {
 // zero-value entry is returned so the caller falls through to OAuth/keychain.
 func buildProviderList(creds *config.Credentials) []providerEntry {
 	if creds == nil {
-		return []providerEntry{{name: "default"}}
+		return []providerEntry{{name: "default", maxOutputTokens: config.DefaultMaxOutputTokens}}
 	}
 	enabled := creds.EnabledProviders()
 	if len(enabled) > 0 {
 		out := make([]providerEntry, len(enabled))
 		for i, p := range enabled {
 			out[i] = providerEntry{
-				name:          p.Name,
-				apiKey:        p.APIKey,
-				baseURL:       p.BaseURL,
-				chatModel:     p.ChatModel,
-				evalModel:     p.EvalModel,
-				operatorModel: p.OperatorModel,
-				lightModel:    p.LightModel,
+				name:            p.Name,
+				apiKey:          p.APIKey,
+				baseURL:         p.BaseURL,
+				chatModel:       p.ChatModel,
+				evalModel:       p.EvalModel,
+				operatorModel:   p.OperatorModel,
+				lightModel:      p.LightModel,
+				maxOutputTokens: p.EffectiveMaxOutputTokens(),
 			}
 		}
 		return out
 	}
 	// No providers list — use legacy fields (may both be empty = OAuth).
 	return []providerEntry{{
-		name:    "default",
-		apiKey:  creds.ClaudeAPIKey,
-		baseURL: creds.ClaudeBaseURL,
+		name:            "default",
+		apiKey:          creds.ClaudeAPIKey,
+		baseURL:         creds.ClaudeBaseURL,
+		maxOutputTokens: config.DefaultMaxOutputTokens,
 	}}
 }
 
 // runClaudeWithProvider executes a single claude subprocess with the given
 // provider credentials. It is the inner loop body extracted from RunClaude.
-func runClaudeWithProvider(ctx context.Context, prompt, workdir, model, apiKey, baseURL string, events io.Writer, systemPrompt ...string) (string, error) {
+func runClaudeWithProvider(ctx context.Context, prompt, workdir, model, apiKey, baseURL string, maxOutputTokens int, events io.Writer, systemPrompt ...string) (string, error) {
 	args := []string{
 		"-p",
 		"--dangerously-skip-permissions",
@@ -309,6 +357,11 @@ func runClaudeWithProvider(ctx context.Context, prompt, workdir, model, apiKey, 
 	cmd := exec.CommandContext(ctx, claude.Resolve(), args...)
 	cmd.Dir = workdir
 	cmd.Env = claude.EnvWithCredentials(os.Environ(), apiKey, baseURL)
+	// Raise the output-token ceiling so large-diff operators (implement)
+	// don't fail with "Claude's response exceeded the N output token
+	// maximum" (issue #286). A pre-existing CLAUDE_CODE_MAX_OUTPUT_TOKENS in
+	// the inherited env wins, so explicit user overrides are preserved.
+	cmd.Env = claude.EnvWithMaxOutputTokens(cmd.Env, maxOutputTokens)
 	// Tee claude's stderr: the user still sees it live on os.Stderr, but we
 	// also retain its tail so a non-zero exit carries claude's actual failure
 	// text (rate-limit / auth 403 / panic) instead of a bare "exit status 1".

--- a/internal/operator/claude_test.go
+++ b/internal/operator/claude_test.go
@@ -295,6 +295,49 @@ func TestIsAuthError(t *testing.T) {
 	}
 }
 
+func TestIsOutputLimitError(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		output string
+		want   bool
+	}{
+		{name: "nil error", err: nil, output: "", want: false},
+		{
+			name:   "exact claude output token maximum message",
+			err:    errors.New("claude: exit status 1"),
+			output: "API Error: Claude's response exceeded the 64000 output token maximum.",
+			want:   true,
+		},
+		{
+			name:   "case-insensitive output token maximum",
+			err:    errors.New("claude: exit status 1"),
+			output: "EXCEEDED THE 64000 OUTPUT TOKEN MAXIMUM",
+			want:   true,
+		},
+		{
+			name:   "rate limit should not match",
+			err:    errors.New("claude: exit status 1"),
+			output: "You've hit your limit",
+			want:   false,
+		},
+		{
+			name:   "generic failure should not match",
+			err:    errors.New("claude: exit status 1"),
+			output: "some unrelated compilation error",
+			want:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsOutputLimitError(tc.err, tc.output)
+			if got != tc.want {
+				t.Errorf("IsOutputLimitError(%v, %q) = %v, want %v", tc.err, tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsRateLimitError(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -1434,7 +1434,7 @@ func ConsecutiveFailures(repo string, issueNum int) int {
 	})
 	count := 0
 	for _, r := range runs {
-		if r.status != "failed" && r.status != "no-marker" && r.status != "skipped-empty" {
+		if r.status != "failed" && r.status != "no-marker" && r.status != "skipped-empty" && r.status != "output-limit" {
 			break
 		}
 		count++


### PR DESCRIPTION
Fixes #286

## 根因
runner 构造 `claude -p` 子进程环境时从不注入 `CLAUDE_CODE_MAX_OUTPUT_TOKENS`（`internal/operator/claude.go` 的 `EnvWithCredentials` 只补 credentials/baseURL）。`implement` 这类大 diff 算子稳定超过 claude 默认 64000 输出上限后直接 `exit status 1`，无 PR 产出；错误分类器又不识别该模式，每轮 `clawflow run` 盲目重试持续烧 token（与 #107 同源：可配置错误被当永久失败）。

## 改动
- `internal/claude/resolve.go`：新增 `EnvWithMaxOutputTokens`，按 env > config 优先级注入上限；inherited env 中已有 `CLAUDE_CODE_MAX_OUTPUT_TOKENS` 则不覆盖（保留用户显式 override）。
- `internal/config/config.go`：`ClaudeProvider` 新增可选 `max_output_tokens` 字段 + `EffectiveMaxOutputTokens` 访问器，默认常量 `DefaultMaxOutputTokens=64000`（可按模型上限在 config 调高，例如给 implement 配更高 provider）。
- `internal/operator/claude.go`：`providerEntry` 透传上限到子进程 env；新增 `ErrOutputLimit` 哨兵 + `IsOutputLimitError`（匹配 `output token maximum`），命中即立即返回而非盲目重试/failover。
- `cmd/clawflow/commands/run.go`：新增 `output-limit` 运行状态，WARN 级日志 `run/output_limit` 便于巡检，计入熔断器以限制 token 流失（区别于 rate-limit 的可重试与 auth 的快速失败）。
- `internal/snapshot/snapshot.go`：`ConsecutiveFailures` 计入 `output-limit` 状态。

## 测试
- `go test ./internal/claude/... ./internal/operator/... ./internal/config/... ./internal/snapshot/...` 全部通过。
- 新增用例：env 注入（缺失时注入/已有 override 保留/非正数 no-op）、`IsOutputLimitError` 分类、`EffectiveMaxOutputTokens` 回退。
- `go vet` 干净；`go build ./cmd/...` 通过（需先有 `web/dist` 构建产物，与本改动无关）。

## 未覆盖
- 端到端复现需要一个会产生超大 diff 的安全整改类 issue，无法用单条命令稳定触发；本改动经单元测试覆盖核心逻辑（env 注入 + 错误分类 + 状态路由）。