### PR TITLE
feat(cli): 新增 clawflow ci 命令组支持 GitLab CI/CD 只读查询（runner/pipeline/job log）

### DIFF
--- a/cmd/clawflow/commands/ci.go
+++ b/cmd/clawflow/commands/ci.go
@@ -1,0 +1,314 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zhoushoujianwork/clawflow/internal/vcs/gitlab"
+)
+
+// NewCICmd exposes GitLab CI/CD read operations: runners, pipelines, and job
+// logs. These are GitLab-only (GitHub Actions has no equivalent object model),
+// so every subcommand resolves a concrete *gitlab.Client and errors on
+// non-GitLab repos.
+func NewCICmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ci",
+		Short: "Query GitLab CI/CD runners, pipelines, and job logs",
+		Long:  "GitLab-only. Inspect project runners, list/view pipelines, and read job logs (traces).",
+	}
+	cmd.AddCommand(newCIRunnerCmd())
+	cmd.AddCommand(newCIPipelineCmd())
+	cmd.AddCommand(newCIJobCmd())
+	return cmd
+}
+
+// ---- runner ----
+
+func newCIRunnerCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runner",
+		Short: "Inspect CI/CD runners",
+	}
+	cmd.AddCommand(newCIRunnerListCmd())
+	return cmd
+}
+
+func newCIRunnerListCmd() *cobra.Command {
+	var repo string
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List runners available to a project",
+		Example: "  clawflow ci runner list --repo group/proj",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, repo, err := newGitLabClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			runners, err := client.ListProjectRunners(repo)
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				return printJSON(runners)
+			}
+			if len(runners) == 0 {
+				fmt.Println("no runners")
+				return nil
+			}
+			fmt.Printf("%-8s  %-8s  %-9s  %-8s  %s\n", "ID", "ONLINE", "STATUS", "TYPE", "DESCRIPTION")
+			for _, r := range runners {
+				online := "-"
+				if r.Online {
+					online = "online"
+				}
+				// runner_type is absent on older GitLab (≤11.x); fall back to
+				// the is_shared bool so the column is never blank.
+				rtype := r.RunnerType
+				if rtype == "" {
+					if r.IsShared {
+						rtype = "shared"
+					} else {
+						rtype = "project"
+					}
+				}
+				desc := r.Description
+				if r.Name != "" && desc == "" {
+					desc = r.Name
+				}
+				if len(r.TagList) > 0 {
+					desc = fmt.Sprintf("%s  [%s]", desc, strings.Join(r.TagList, ","))
+				}
+				fmt.Printf("%-8d  %-8s  %-9s  %-8s  %s\n", r.ID, online, r.Status, rtype, desc)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "GitLab group/project or URL (required)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	_ = cmd.MarkFlagRequired("repo")
+	return cmd
+}
+
+// ---- pipeline ----
+
+func newCIPipelineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pipeline",
+		Short: "List and view CI/CD pipelines",
+	}
+	cmd.AddCommand(newCIPipelineListCmd())
+	cmd.AddCommand(newCIPipelineViewCmd())
+	return cmd
+}
+
+func newCIPipelineListCmd() *cobra.Command {
+	var repo, ref, status string
+	var limit int
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List recent pipelines (newest first)",
+		Example: "  clawflow ci pipeline list --repo group/proj --ref main --status failed --limit 20",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, repo, err := newGitLabClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			pipelines, err := client.ListPipelines(repo, gitlab.PipelineListOpts{
+				Ref:    ref,
+				Status: status,
+				Limit:  limit,
+			})
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				return printJSON(pipelines)
+			}
+			if len(pipelines) == 0 {
+				fmt.Println("no pipelines")
+				return nil
+			}
+			// created_at is omitted from the pipeline *list* response on
+			// GitLab 11.x — only the single-pipeline GET returns it — so the
+			// list shows SHA (always present) and `pipeline view` shows the
+			// timestamp.
+			fmt.Printf("%-8s  %-10s  %-24s  %s\n", "ID", "STATUS", "REF", "SHA")
+			for _, p := range pipelines {
+				fmt.Printf("%-8d  %-10s  %-24s  %s\n", p.ID, p.Status, truncate(p.Ref, 24), shortSHA(p.SHA))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "GitLab group/project or URL (required)")
+	cmd.Flags().StringVar(&ref, "ref", "", "filter by branch/tag")
+	cmd.Flags().StringVar(&status, "status", "", "filter by status (success/failed/running/pending/...)")
+	cmd.Flags().IntVar(&limit, "limit", 20, "max pipelines to list (1-100)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	_ = cmd.MarkFlagRequired("repo")
+	return cmd
+}
+
+func newCIPipelineViewCmd() *cobra.Command {
+	var repo string
+	var id int64
+	var asJSON bool
+
+	cmd := &cobra.Command{
+		Use:     "view",
+		Short:   "View a pipeline and its jobs",
+		Example: "  clawflow ci pipeline view --repo group/proj --id 12345",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, repo, err := newGitLabClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			p, err := client.GetPipeline(repo, id)
+			if err != nil {
+				return err
+			}
+			jobs, err := client.ListPipelineJobs(repo, id)
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				return printJSON(struct {
+					Pipeline gitlab.Pipeline `json:"pipeline"`
+					Jobs     []gitlab.Job    `json:"jobs"`
+				}{p, jobs})
+			}
+			fmt.Printf("pipeline #%d  [%s]\n", p.ID, p.Status)
+			fmt.Printf("ref:     %s\n", p.Ref)
+			fmt.Printf("sha:     %s\n", p.SHA)
+			if p.CreatedAt != "" {
+				fmt.Printf("created: %s\n", p.CreatedAt)
+			}
+			if p.WebURL != "" {
+				fmt.Printf("url:     %s\n", p.WebURL)
+			}
+			fmt.Println()
+			if len(jobs) == 0 {
+				fmt.Println("no jobs")
+				return nil
+			}
+			fmt.Printf("%-10s  %-10s  %-12s  %s\n", "JOB", "STATUS", "STAGE", "NAME")
+			for _, j := range jobs {
+				fmt.Printf("%-10d  %-10s  %-12s  %s\n", j.ID, j.Status, truncate(j.Stage, 12), j.Name)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "GitLab group/project or URL (required)")
+	cmd.Flags().Int64Var(&id, "id", 0, "pipeline id (required)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "output as JSON")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("id")
+	return cmd
+}
+
+// ---- job ----
+
+func newCIJobCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "job",
+		Short: "Inspect CI/CD jobs",
+	}
+	cmd.AddCommand(newCIJobLogCmd())
+	return cmd
+}
+
+func newCIJobLogCmd() *cobra.Command {
+	var repo string
+	var job int64
+	var raw bool
+
+	cmd := &cobra.Command{
+		Use:     "log",
+		Short:   "Print the log (trace) of a job",
+		Example: "  clawflow ci job log --repo group/proj --job 67890",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, repo, err := newGitLabClientForRepo(repo)
+			if err != nil {
+				return err
+			}
+			log, err := client.GetJobLog(repo, job)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(log) == "" {
+				fmt.Fprintln(os.Stderr, "(empty log — job may not have started)")
+				return nil
+			}
+			// GitLab traces are peppered with ANSI color / cursor escapes and
+			// section_start/section_end fold markers. Strip both by default so
+			// redirecting to a file yields clean text; --raw keeps everything
+			// for terminal viewing.
+			if !raw {
+				log = stripANSI(log)
+				log = stripSections(log)
+			}
+			fmt.Print(log)
+			if !strings.HasSuffix(log, "\n") {
+				fmt.Println()
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&repo, "repo", "", "GitLab group/project or URL (required)")
+	cmd.Flags().Int64Var(&job, "job", 0, "job id (required)")
+	cmd.Flags().BoolVar(&raw, "raw", false, "keep ANSI color/cursor escape codes (default strips them)")
+	_ = cmd.MarkFlagRequired("repo")
+	_ = cmd.MarkFlagRequired("job")
+	return cmd
+}
+
+// ---- helpers ----
+
+func printJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+// ansiEscape matches CSI escape sequences (color, cursor moves, line erase)
+// that GitLab embeds in job traces, e.g. "\x1b[0m", "\x1b[32;1m", "\x1b[0K".
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+func stripANSI(s string) string {
+	return ansiEscape.ReplaceAllString(s, "")
+}
+
+// sectionMarker matches GitLab fold markers left in a trace once the trailing
+// ANSI erase is gone, e.g. "section_start:1620629123:step_script\r" or
+// "section_end:1620629130:step_script[collapsed=true]\r". The optional
+// trailing \r is consumed so the following log line isn't clobbered on redraw.
+var sectionMarker = regexp.MustCompile(`section_(?:start|end):\d+:[^\r\n]*\r?`)
+
+func stripSections(s string) string {
+	return sectionMarker.ReplaceAllString(s, "")
+}

--- a/cmd/clawflow/commands/ci_test.go
+++ b/cmd/clawflow/commands/ci_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import "testing"
+
+func TestStripANSI(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"\x1b[0Krunning\x1b[0;m", "running"},
+		{"\x1b[32;1mok\x1b[0m\n", "ok\n"},
+		{"plain text", "plain text"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := stripANSI(c.in); got != c.want {
+			t.Errorf("stripANSI(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStripSections(t *testing.T) {
+	// Marker + CR followed by real content on the same physical line.
+	in := "section_start:1782893292:prepare_script\rWaiting for pod\nsection_end:1782893298:prepare_script\rDone\n"
+	want := "Waiting for pod\nDone\n"
+	if got := stripSections(in); got != want {
+		t.Errorf("stripSections = %q, want %q", got, want)
+	}
+	// Collapsed-section option syntax must also be consumed.
+	if got := stripSections("section_start:1:step_script[collapsed=true]\rrun\n"); got != "run\n" {
+		t.Errorf("stripSections collapsed = %q", got)
+	}
+	// Non-marker text is untouched.
+	if got := stripSections("no markers here\n"); got != "no markers here\n" {
+		t.Errorf("stripSections passthrough = %q", got)
+	}
+}
+
+func TestShortSHA(t *testing.T) {
+	if got := shortSHA("3db92cf9abcdef"); got != "3db92cf9" {
+		t.Errorf("shortSHA long = %q, want 3db92cf9", got)
+	}
+	if got := shortSHA("abc"); got != "abc" {
+		t.Errorf("shortSHA short = %q, want abc", got)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("main", 24); got != "main" {
+		t.Errorf("truncate no-op = %q", got)
+	}
+	if got := truncate("release/v0.0.0-smoke-longbranch", 12); got != "release/v0.…" {
+		t.Errorf("truncate = %q", got)
+	}
+}

--- a/cmd/clawflow/commands/root.go
+++ b/cmd/clawflow/commands/root.go
@@ -46,6 +46,7 @@ entirely in VCS labels and comments. Run 'clawflow run' once, or schedule it.`,
 	root.AddCommand(NewBranchCmd())
 	root.AddCommand(NewStatusCmd())
 	root.AddCommand(NewPRCheckCmd())
+	root.AddCommand(NewCICmd())
 	root.AddCommand(NewLangCmd())
 	root.AddCommand(&cobra.Command{
 		Use:   "version",

--- a/cmd/clawflow/commands/vcs_client.go
+++ b/cmd/clawflow/commands/vcs_client.go
@@ -85,3 +85,50 @@ func newVCSClientForRepo(repoName string) (vcs.Client, string, config.Repo, erro
 	client, err := newVCSClient(repo)
 	return client, info.OwnerRepo, repo, err
 }
+
+// newGitLabClientForRepo resolves repoName to a concrete *gitlab.Client for
+// GitLab-only operations (CI/CD runners, pipelines, job logs) that have no
+// platform-agnostic vcs.Client equivalent. It errors when the resolved repo is
+// not a GitLab project. Resolution mirrors newVCSClientForRepo: configured repo
+// first, then a transient config inferred from a URL / owner/repo argument.
+//
+// These calls are reads, so — unlike newVCSClient — the client is never wrapped
+// in the Pilot budget decorator (which only gates writes).
+func newGitLabClientForRepo(repoName string) (*gitlab.Client, string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, "", err
+	}
+	build := func(repo config.Repo, canonical string) (*gitlab.Client, string, error) {
+		platform := repo.Platform
+		if platform == "" {
+			platform = "github"
+		}
+		if platform != "gitlab" {
+			return nil, "", fmt.Errorf("repo %q is not a GitLab project (platform=%q); ci commands are GitLab-only", canonical, platform)
+		}
+		if repo.BaseURL == "" {
+			return nil, "", fmt.Errorf("repo %q is gitlab but base_url is not set", canonical)
+		}
+		creds, err := config.LoadCredentials()
+		if err != nil {
+			return nil, "", fmt.Errorf("load credentials: %w", err)
+		}
+		return gitlab.New(creds.GitLabToken, repo.BaseURL), canonical, nil
+	}
+	if repo, ok := cfg.Repos[repoName]; ok {
+		return build(repo, repoName)
+	}
+	info, err := config.ParseRepoInput(repoName, cfg.Settings.GitLabHosts)
+	if err != nil {
+		return nil, "", fmt.Errorf("repo %q not in config and could not be parsed: %w", repoName, err)
+	}
+	if repo, ok := cfg.Repos[info.OwnerRepo]; ok {
+		return build(repo, info.OwnerRepo)
+	}
+	return build(config.Repo{
+		Platform: info.Platform,
+		BaseURL:  info.BaseURL,
+		Owner:    info.OwnerRepo,
+	}, info.OwnerRepo)
+}

--- a/internal/vcs/gitlab/cicd.go
+++ b/internal/vcs/gitlab/cicd.go
@@ -1,0 +1,169 @@
+package gitlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// GitLab CI/CD read helpers: runners, pipelines, jobs and job logs (traces).
+//
+// These are GitLab-specific — GitHub Actions has no equivalent object model —
+// so they live on the concrete *gitlab.Client rather than the platform-agnostic
+// vcs.Client interface. The `clawflow ci` commands call them directly after
+// asserting the target repo is a GitLab project.
+
+// Runner is a CI/CD runner registered to (or shared with) a project.
+type Runner struct {
+	ID          int64    `json:"id"`
+	Description string   `json:"description"`
+	Name        string   `json:"name"`
+	Active      bool     `json:"active"`
+	Paused      bool     `json:"paused"`
+	IsShared    bool     `json:"is_shared"`
+	RunnerType  string   `json:"runner_type"`
+	Online      bool     `json:"online"`
+	Status      string   `json:"status"`
+	IPAddress   string   `json:"ip_address"`
+	TagList     []string `json:"tag_list"`
+}
+
+// Pipeline is a single CI/CD pipeline run.
+type Pipeline struct {
+	ID        int64  `json:"id"`
+	IID       int64  `json:"iid"`
+	Ref       string `json:"ref"`
+	SHA       string `json:"sha"`
+	Status    string `json:"status"`
+	Source    string `json:"source"`
+	WebURL    string `json:"web_url"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	Duration  int    `json:"duration"`
+}
+
+// Job is a single job within a pipeline.
+type Job struct {
+	ID         int64   `json:"id"`
+	Name       string  `json:"name"`
+	Stage      string  `json:"stage"`
+	Status     string  `json:"status"`
+	Ref        string  `json:"ref"`
+	WebURL     string  `json:"web_url"`
+	CreatedAt  string  `json:"created_at"`
+	StartedAt  string  `json:"started_at"`
+	FinishedAt string  `json:"finished_at"`
+	Duration   float64 `json:"duration"`
+	Runner     *Runner `json:"runner"`
+}
+
+// PipelineListOpts filters ListPipelines. Empty fields are omitted.
+type PipelineListOpts struct {
+	Ref    string // branch/tag name
+	Status string // e.g. "success", "failed", "running", "pending"
+	Limit  int    // caps results, clamped to [1, 100]
+}
+
+// ListProjectRunners returns the runners available to the project
+// (project-specific plus shared/group runners).
+func (c *Client) ListProjectRunners(repo string) ([]Runner, error) {
+	path := fmt.Sprintf("/projects/%s/runners?per_page=100", projectID(repo))
+	data, status, err := c.doJSON("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("gitlab list runners: HTTP %d: %s", status, data)
+	}
+	var runners []Runner
+	if err := json.Unmarshal(data, &runners); err != nil {
+		return nil, err
+	}
+	return runners, nil
+}
+
+// ListPipelines returns pipelines for the project, newest first, filtered by opts.
+func (c *Client) ListPipelines(repo string, opts PipelineListOpts) ([]Pipeline, error) {
+	limit := opts.Limit
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q := url.Values{}
+	q.Set("per_page", fmt.Sprintf("%d", limit))
+	q.Set("order_by", "id")
+	q.Set("sort", "desc")
+	if opts.Ref != "" {
+		q.Set("ref", opts.Ref)
+	}
+	if opts.Status != "" {
+		q.Set("status", opts.Status)
+	}
+	path := fmt.Sprintf("/projects/%s/pipelines?%s", projectID(repo), q.Encode())
+	data, status, err := c.doJSON("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("gitlab list pipelines: HTTP %d: %s", status, data)
+	}
+	var pipelines []Pipeline
+	if err := json.Unmarshal(data, &pipelines); err != nil {
+		return nil, err
+	}
+	return pipelines, nil
+}
+
+// GetPipeline returns a single pipeline by its project-wide id.
+func (c *Client) GetPipeline(repo string, pipelineID int64) (Pipeline, error) {
+	path := fmt.Sprintf("/projects/%s/pipelines/%d", projectID(repo), pipelineID)
+	data, status, err := c.doJSON("GET", path, nil)
+	if err != nil {
+		return Pipeline{}, err
+	}
+	if status != 200 {
+		return Pipeline{}, fmt.Errorf("gitlab get pipeline %d: HTTP %d: %s", pipelineID, status, data)
+	}
+	var p Pipeline
+	if err := json.Unmarshal(data, &p); err != nil {
+		return Pipeline{}, err
+	}
+	return p, nil
+}
+
+// ListPipelineJobs returns the jobs of a pipeline.
+func (c *Client) ListPipelineJobs(repo string, pipelineID int64) ([]Job, error) {
+	path := fmt.Sprintf("/projects/%s/pipelines/%d/jobs?per_page=100", projectID(repo), pipelineID)
+	data, status, err := c.doJSON("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != 200 {
+		return nil, fmt.Errorf("gitlab list pipeline jobs: HTTP %d: %s", status, data)
+	}
+	var jobs []Job
+	if err := json.Unmarshal(data, &jobs); err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
+// GetJobLog returns the raw trace (console log) of a job. The trace endpoint
+// returns plain text, not JSON. An empty trace (job not yet started) yields "".
+func (c *Client) GetJobLog(repo string, jobID int64) (string, error) {
+	path := fmt.Sprintf("/projects/%s/jobs/%d/trace", projectID(repo), jobID)
+	data, status, err := c.doJSON("GET", path, nil)
+	if err != nil {
+		return "", err
+	}
+	if status == 404 {
+		return "", fmt.Errorf("gitlab job %d not found (or has no trace)", jobID)
+	}
+	if status != 200 {
+		return "", fmt.Errorf("gitlab get job trace: HTTP %d: %s", status, strings.TrimSpace(string(data)))
+	}
+	return string(data), nil
+}

--- a/internal/vcs/gitlab/cicd_test.go
+++ b/internal/vcs/gitlab/cicd_test.go
@@ -1,0 +1,169 @@
+package gitlab_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/vcs/gitlab"
+)
+
+func TestListProjectRunners(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/runners": func(w http.ResponseWriter, r *http.Request) {
+			jsonResp(w, 200, []map[string]any{
+				{"id": 11, "description": "shared-1", "active": true, "online": true, "status": "online", "runner_type": "instance_type", "tag_list": []string{"docker", "linux"}},
+				{"id": 22, "description": "proj-1", "active": true, "online": false, "status": "offline", "runner_type": "project_type"},
+			})
+		},
+	})
+
+	runners, err := client.ListProjectRunners("ns/group/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runners) != 2 {
+		t.Fatalf("expected 2 runners, got %d", len(runners))
+	}
+	if runners[0].ID != 11 || !runners[0].Online || runners[0].Status != "online" {
+		t.Errorf("runner[0] mismatch: %+v", runners[0])
+	}
+	if len(runners[0].TagList) != 2 || runners[0].TagList[0] != "docker" {
+		t.Errorf("runner[0] tags mismatch: %v", runners[0].TagList)
+	}
+	if runners[1].Online {
+		t.Errorf("runner[1] should be offline: %+v", runners[1])
+	}
+}
+
+func TestListProjectRunnersError(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/runners": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "forbidden", 403)
+		},
+	})
+	if _, err := client.ListProjectRunners("ns/group/repo"); err == nil {
+		t.Fatal("expected error on HTTP 403")
+	}
+}
+
+func TestListPipelines(t *testing.T) {
+	var gotQuery string
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/pipelines": func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			jsonResp(w, 200, []map[string]any{
+				{"id": 1001, "iid": 5, "ref": "main", "sha": "abc123", "status": "failed", "created_at": "2026-06-30T10:00:00Z"},
+				{"id": 1000, "iid": 4, "ref": "main", "sha": "def456", "status": "success", "created_at": "2026-06-29T10:00:00Z"},
+			})
+		},
+	})
+
+	pipelines, err := client.ListPipelines("ns/group/repo", gitlab.PipelineListOpts{Ref: "main", Status: "failed", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pipelines) != 2 {
+		t.Fatalf("expected 2 pipelines, got %d", len(pipelines))
+	}
+	if pipelines[0].ID != 1001 || pipelines[0].Status != "failed" {
+		t.Errorf("pipeline[0] mismatch: %+v", pipelines[0])
+	}
+	// Filters must reach the wire.
+	for _, want := range []string{"ref=main", "status=failed", "per_page=10"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
+func TestListPipelinesLimitClamp(t *testing.T) {
+	var gotQuery string
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/pipelines": func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			jsonResp(w, 200, []map[string]any{})
+		},
+	})
+	// Limit 0 → default 20; over-max clamps to 100.
+	if _, err := client.ListPipelines("ns/group/repo", gitlab.PipelineListOpts{Limit: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotQuery, "per_page=20") {
+		t.Errorf("limit 0 should default to 20, query=%q", gotQuery)
+	}
+	if _, err := client.ListPipelines("ns/group/repo", gitlab.PipelineListOpts{Limit: 500}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotQuery, "per_page=100") {
+		t.Errorf("limit 500 should clamp to 100, query=%q", gotQuery)
+	}
+}
+
+func TestGetPipelineAndJobs(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/pipelines/1001": func(w http.ResponseWriter, r *http.Request) {
+			jsonResp(w, 200, map[string]any{
+				"id": 1001, "iid": 5, "ref": "main", "sha": "abc123", "status": "failed",
+				"web_url": "https://gl/ns/group/repo/-/pipelines/1001",
+			})
+		},
+		"GET " + projectPath + "/pipelines/1001/jobs": func(w http.ResponseWriter, r *http.Request) {
+			jsonResp(w, 200, []map[string]any{
+				{"id": 5001, "name": "build", "stage": "build", "status": "success"},
+				{"id": 5002, "name": "test", "stage": "test", "status": "failed", "runner": map[string]any{"id": 22, "description": "proj-1"}},
+			})
+		},
+	})
+
+	p, err := client.GetPipeline("ns/group/repo", 1001)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ID != 1001 || p.Status != "failed" || p.WebURL == "" {
+		t.Errorf("pipeline mismatch: %+v", p)
+	}
+
+	jobs, err := client.ListPipelineJobs("ns/group/repo", 1001)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(jobs))
+	}
+	if jobs[1].Name != "test" || jobs[1].Status != "failed" {
+		t.Errorf("job[1] mismatch: %+v", jobs[1])
+	}
+	if jobs[1].Runner == nil || jobs[1].Runner.ID != 22 {
+		t.Errorf("job[1] runner mismatch: %+v", jobs[1].Runner)
+	}
+}
+
+func TestGetJobLog(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/jobs/5002/trace": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(200)
+			w.Write([]byte("Running with gitlab-runner\n$ make test\nFAIL\n"))
+		},
+	})
+
+	log, err := client.GetJobLog("ns/group/repo", 5002)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(log, "make test") || !strings.Contains(log, "FAIL") {
+		t.Errorf("unexpected log: %q", log)
+	}
+}
+
+func TestGetJobLogNotFound(t *testing.T) {
+	client := newTestClient(t, map[string]http.HandlerFunc{
+		"GET " + projectPath + "/jobs/9999/trace": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "404 Not Found", 404)
+		},
+	})
+	if _, err := client.GetJobLog("ns/group/repo", 9999); err == nil {
+		t.Fatal("expected error on HTTP 404")
+	}
+}


### PR DESCRIPTION
## 动机

排查 GitLab 流水线失败时，此前只能跳到 Web UI 翻 runner 状态和 job 日志。本 PR 为 ClawFlow 补上 CI/CD 维度的终端只读查询能力。

Closes #288

## 变更

新增 `clawflow ci` 命令组（GitLab 专属，GitHub repo 明确报错）：

| 命令 | 作用 |
|---|---|
| `ci runner list --repo <repo> [--json]` | 列出项目可用 runner（id / online / status / type / description+tags） |
| `ci pipeline list --repo <repo> [--ref --status --limit --json]` | 列出流水线（最新在前，可过滤） |
| `ci pipeline view --repo <repo> --id <pid> [--json]` | 流水线详情 + 其 job 列表 |
| `ci job log --repo <repo> --job <jid> [--raw]` | 打印 job trace，默认清洗 ANSI + section 标记 |

## 实现

- GitLab 专属类型/方法置于 `internal/vcs/gitlab/cicd.go`，**不进**平台无关的 `vcs.Client` 接口（GitHub Actions 无对应对象模型）
- 复用现有 `doJSON` + `PRIVATE-TOKEN` 模式，兼容自建 GitLab 11.11
- 命令层新增 `newGitLabClientForRepo`：解析具体 `*gitlab.Client`，非 gitlab 平台报错；因均为读操作不套 Pilot budget 装饰器
- **老版 API 字段缺失兜底**：runner `runner_type` 缺失时用 `is_shared` 显示 shared/project；pipeline 列表端点无 `created_at`，列表显示 SHA、`view` 显示时间戳
- job log 默认清洗 ANSI 转义码与 `section_start/section_end` 折叠标记，`--raw` 保留原样

## 测试

- `go test ./...` 全绿
- `internal/vcs/gitlab/cicd_test.go`：各方法 httptest mock，含错误路径 / limit 钳制 / 过滤参数上线校验
- `cmd/clawflow/commands/ci_test.go`：`stripANSI` / `stripSections` / `shortSHA` / `truncate` 单测
- **真实实例验证**（git.patsnap.com，服务端 11.11）：runner list / pipeline list+view / job log 全部可用，ANSI + section 清洗生效，`--raw` 保留原始输出

🤖 Generated with [Claude Code](https://claude.com/claude-code)