### PR TITLE
fix: 算子评论末尾自动附带 ClawFlow 推广链接

### DIFF
--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -33,6 +33,32 @@ const (
 // the caller can handle each case appropriately.
 var ErrNoOutcomeMarker = errors.New("operator produced no outcome marker")
 
+// repoURL is the canonical ClawFlow open-source repository URL. Extracted as a
+// package-level constant so the promo footer (and any future references) share
+// one source of truth instead of hardcoding the literal in multiple places.
+const repoURL = "https://github.com/zhoushoujianwork/clawflow"
+
+// promoFooter is appended to the end of every operator-generated comment as a
+// low-noise promotion of the ClawFlow open-source repo (issue #290). It uses a
+// markdown inline link so the raw URL is hidden behind readable copy. Applied
+// centrally in runWriteBack so it covers all comment-producing operators
+// without touching each SKILL.md prompt.
+const promoFooter = "\n\n---\n\n由 [ClawFlow](" + repoURL + ") 自动生成"
+
+// appendPromoFooter appends the promo footer to a non-empty comment body. It is
+// idempotent-safe against re-appending: if the body already ends with the
+// footer it is returned unchanged. Empty bodies are returned as-is so the empty
+// guard in runWriteBack still skips the comment post.
+func appendPromoFooter(body string) string {
+	if body == "" {
+		return body
+	}
+	if strings.HasSuffix(body, promoFooter) {
+		return body
+	}
+	return body + promoFooter
+}
+
 // outcomeRE matches a "<!-- clawflow:outcome=<label> --> " line. The runner
 // parses these from the operator's stdout to learn which terminal label to
 // add. Word chars + hyphens cover the conventions GitHub/GitLab labels use.
@@ -255,6 +281,11 @@ func Run(ctx context.Context, op *Operator, sub *Subject, v VCS, opts RunOptions
 // via a goroutine in Run.
 func runWriteBack(v VCS, op *Operator, sub *Subject, opts RunOptions, body, outcome string) error {
 	if body != "" {
+		// Append the ClawFlow promo footer before persisting/posting so the
+		// on-disk comment.md matches what actually lands on the issue, and so
+		// every comment-producing operator picks it up centrally (issue #290).
+		body = appendPromoFooter(body)
+
 		// Persist the comment body to disk before attempting VCS write-back.
 		// If all retries are exhausted the output is not lost — it can be
 		// recovered from comment.md in the run directory (issue #278).

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -313,6 +313,59 @@ func TestRun_OutcomeMarker_StripsAndAddsLabel(t *testing.T) {
 	}
 }
 
+// TestRun_PromoFooter_AppendedToComment verifies that the posted comment ends
+// with the ClawFlow promo footer (issue #290) and that appending the footer
+// does not interfere with outcome marker parsing / label application.
+func TestRun_PromoFooter_AppendedToComment(t *testing.T) {
+	op := &Operator{
+		Name:      "evaluate-bug",
+		LockLabel: "agent-running",
+		Outcomes:  []string{"agent-evaluated"},
+	}
+	sub := &Subject{Number: 42, Labels: []string{"bug"}}
+	v := newFakeVCS()
+
+	body := "## Eval\n\nRepro: 8/10\n\n<!-- clawflow:outcome=agent-evaluated -->\n"
+	_, _, err := Run(context.Background(), op, sub, v, RunOptions{
+		Repo: "r",
+		RunFunc: func(context.Context, string, string, time.Duration, io.Writer, string, ...string) (string, error) {
+			return body, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if len(v.comments) != 1 {
+		t.Fatalf("want 1 comment, got %d", len(v.comments))
+	}
+	if !strings.HasSuffix(v.comments[0].body, promoFooter) {
+		t.Errorf("comment should end with promo footer; got %q", v.comments[0].body)
+	}
+	if !strings.Contains(v.comments[0].body, "[ClawFlow]("+repoURL+")") {
+		t.Errorf("footer should contain markdown inline repo link; got %q", v.comments[0].body)
+	}
+	// Footer must not break outcome parsing.
+	if !slices.Contains(v.labels[42], "agent-evaluated") {
+		t.Errorf("agent-evaluated should still be added; labels = %v", v.labels[42])
+	}
+}
+
+// TestAppendPromoFooter_Idempotent verifies the footer is not stacked twice and
+// that empty bodies pass through untouched (so the empty-body guard still fires).
+func TestAppendPromoFooter_Idempotent(t *testing.T) {
+	if got := appendPromoFooter(""); got != "" {
+		t.Errorf("empty body should stay empty; got %q", got)
+	}
+	once := appendPromoFooter("hello")
+	twice := appendPromoFooter(once)
+	if once != twice {
+		t.Errorf("footer should not stack: once=%q twice=%q", once, twice)
+	}
+	if !strings.HasSuffix(once, promoFooter) {
+		t.Errorf("footer not appended; got %q", once)
+	}
+}
+
 func TestRun_OutcomeMarker_NotInWhitelist_SkipsLabel(t *testing.T) {
 	op := &Operator{
 		Name:      "evaluate-bug",


### PR DESCRIPTION
Fixes #290

## 改动内容
在 `internal/operator/runner.go` 的 `runWriteBack` 写回环节集中追加推广 footer，覆盖所有产生评论的算子，无需逐个改 SKILL.md。

- 新增包级常量 `repoURL` 与 `promoFooter`（`由 [ClawFlow](https://github.com/zhoushoujianwork/clawflow) 自动生成`），markdown 内嵌链接隐藏裸 URL。
- 新增 `appendPromoFooter` helper：空 body 原样返回（保留空评论跳过逻辑），已含 footer 则不重复叠加。
- footer 在落盘 comment.md 之前追加，保证磁盘副本与实际评论一致。
- footer 在 parseOutcome 之后追加，不干扰 outcome marker 解析。

## 测试
- `go test ./internal/operator/...` 通过。
- 新增 `TestRun_PromoFooter_AppendedToComment`（断言评论以 footer 结尾、含内嵌链接、不影响 outcome label）与 `TestAppendPromoFooter_Idempotent`（空 body 直通、不重复叠加）。
- 注：其余包的构建失败是预存在的 `web/dist` 未构建问题，与本改动无关。

## 未处理（open question）
按 issue 表述仅覆盖 operator 算子评论。chat / pilot 出口暂未纳入；是否需要 config 开关关闭 footer 亦未实现，如需可后续跟进。