### PR TITLE
fix: 保留类型标签，仅清理显式声明的一次性流程标签 (#292)

### DIFF
--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -58,6 +58,13 @@ type Trigger struct {
 	LabelsRequired    []string
 	LabelsRequiredAny []string // OR semantics: at least one must be present (empty = no constraint)
 	LabelsExcluded    []string
+	// LabelsConsumed lists trigger labels that are one-shot flow markers and
+	// should be removed after the operator writes back its outcome (e.g.
+	// "ready-for-agent"). Only labels declared here are cleaned up. Persistent
+	// classification labels used as triggers (e.g. "bug"/"feat") are left
+	// untouched by declaring them in LabelsRequired but NOT here — that keeps
+	// type labels and flow-status labels independent (issue #292).
+	LabelsConsumed []string
 	// AppliesTo is the sub-issue structure constraint: "" or "any" = no
 	// constraint (back-compat), "parent" = subject must have sub-issues,
 	// "leaf" = subject must have none. See the AppliesTo constants.
@@ -74,6 +81,7 @@ type frontmatter struct {
 			LabelsRequired    []string `yaml:"labels_required"`
 			LabelsRequiredAny []string `yaml:"labels_required_any"`
 			LabelsExcluded    []string `yaml:"labels_excluded"`
+			LabelsConsumed    []string `yaml:"labels_consumed"`
 			AppliesTo         string   `yaml:"applies_to"`
 		} `yaml:"trigger"`
 		LockLabel string   `yaml:"lock_label"`
@@ -131,6 +139,7 @@ func Parse(data []byte, source string) (*Operator, error) {
 			LabelsRequired:    fm.Operator.Trigger.LabelsRequired,
 			LabelsRequiredAny: fm.Operator.Trigger.LabelsRequiredAny,
 			LabelsExcluded:    fm.Operator.Trigger.LabelsExcluded,
+			LabelsConsumed:    fm.Operator.Trigger.LabelsConsumed,
 			AppliesTo:         appliesTo,
 		},
 		LockLabel: fm.Operator.LockLabel,

--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -315,11 +315,15 @@ func runWriteBack(v VCS, op *Operator, sub *Subject, opts RunOptions, body, outc
 			return fmt.Errorf("add outcome label %q: %w", outcome, err)
 		} else {
 			fmt.Fprintf(os.Stderr, "  ✓ outcome label %q added\n", outcome)
-			if len(op.Trigger.LabelsRequired) > 0 {
-				if err := v.RemoveLabel(opts.Repo, sub.Number, op.Trigger.LabelsRequired...); err != nil {
-					fmt.Fprintf(os.Stderr, "  ⚠ trigger label cleanup failed: %v\n", err)
+			// Only remove labels the operator explicitly declares as one-shot
+			// flow markers (LabelsConsumed). Persistent classification labels
+			// used as triggers (e.g. "bug"/"feat") stay put so type labels and
+			// flow-status labels remain independent (issue #292).
+			if len(op.Trigger.LabelsConsumed) > 0 {
+				if err := v.RemoveLabel(opts.Repo, sub.Number, op.Trigger.LabelsConsumed...); err != nil {
+					fmt.Fprintf(os.Stderr, "  ⚠ consumed label cleanup failed: %v\n", err)
 				} else {
-					fmt.Fprintf(os.Stderr, "  ✓ trigger labels removed: %v\n", op.Trigger.LabelsRequired)
+					fmt.Fprintf(os.Stderr, "  ✓ consumed labels removed: %v\n", op.Trigger.LabelsConsumed)
 				}
 			}
 		}

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -490,6 +490,7 @@ func TestRun_OutcomeMarker_RemovesTriggerLabels(t *testing.T) {
 		LockLabel: "agent-running",
 		Trigger: Trigger{
 			LabelsRequired: []string{"ready-for-agent"},
+			LabelsConsumed: []string{"ready-for-agent"},
 		},
 		Outcomes: []string{"agent-implemented", "agent-failed", "agent-skipped"},
 	}
@@ -528,12 +529,61 @@ func TestRun_OutcomeMarker_RemovesTriggerLabels(t *testing.T) {
 	}
 }
 
+// TestRun_OutcomeMarker_PreservesTypeTriggerLabel is the regression test for
+// issue #292: a persistent classification label (e.g. "bug") used as a trigger
+// but NOT declared in LabelsConsumed must survive write-back. Only labels
+// explicitly listed in LabelsConsumed are one-shot flow markers that get
+// removed. This keeps type labels and flow-status labels independent.
+func TestRun_OutcomeMarker_PreservesTypeTriggerLabel(t *testing.T) {
+	op := &Operator{
+		Name:      "evaluate-bug",
+		LockLabel: "agent-running",
+		Trigger: Trigger{
+			LabelsRequired: []string{"bug"},
+			// No LabelsConsumed: "bug" is a type label, not a flow marker.
+		},
+		Outcomes: []string{"agent-evaluated", "agent-skipped"},
+	}
+	sub := &Subject{Number: 42, Labels: []string{"bug"}}
+	v := newFakeVCS()
+	// Seed the existing "bug" label so we can assert it survives write-back
+	// (the fake tracks state in v.labels).
+	v.labels[42] = []string{"bug"}
+
+	body := "## 🔍 Evaluation\n\nConfidence below threshold.\n\n<!-- clawflow:outcome=agent-skipped -->\n"
+	_, _, err := Run(context.Background(), op, sub, v, RunOptions{
+		Repo: "r",
+		RunFunc: func(context.Context, string, string, time.Duration, io.Writer, string, ...string) (string, error) {
+			return body, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	// Outcome label should be added.
+	if !slices.Contains(v.labels[42], "agent-skipped") {
+		t.Errorf("agent-skipped should be added; labels = %v", v.labels[42])
+	}
+
+	// The "bug" type label must NOT be removed — it was not declared consumed.
+	if !slices.Contains(v.labels[42], "bug") {
+		t.Errorf("bug type label should be preserved; labels = %v", v.labels[42])
+	}
+
+	// RemoveLabel must not be called at all when nothing is consumed.
+	if v.removeLabelCals != 0 {
+		t.Errorf("RemoveLabel called %d times, want 0 (no consumed labels)", v.removeLabelCals)
+	}
+}
+
 func TestRun_OutcomeAgentClosed_ClosesIssue(t *testing.T) {
 	op := &Operator{
 		Name:      "track-progress",
 		LockLabel: "agent-running",
 		Trigger: Trigger{
 			LabelsRequired: []string{"progress-check"},
+			LabelsConsumed: []string{"progress-check"},
 		},
 		Outcomes: []string{"agent-closed", "agent-watching"},
 	}

--- a/skills/decompose/SKILL.md
+++ b/skills/decompose/SKILL.md
@@ -6,6 +6,7 @@ operator:
     target: "issue"
     applies_to: "leaf"
     labels_required: ["ready-for-agent", "tracking"]
+    labels_consumed: ["ready-for-agent"]
     labels_excluded: ["agent-decomposed", "agent-running", "agent-failed", "agent-skipped"]
   outcomes: ["agent-decomposed", "agent-skipped"]
 ---

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -6,6 +6,7 @@ operator:
     target: "issue"
     applies_to: "leaf"
     labels_required: ["ready-for-agent"]
+    labels_consumed: ["ready-for-agent"]
     labels_excluded: ["agent-implemented", "agent-skipped", "agent-failed", "agent-running", "tracking"]
   outcomes: ["agent-implemented", "agent-failed", "agent-skipped"]
 ---

--- a/skills/reply-comment/SKILL.md
+++ b/skills/reply-comment/SKILL.md
@@ -5,6 +5,7 @@ operator:
   trigger:
     target: "issue"
     labels_required: ["agent-mentioned"]
+    labels_consumed: ["agent-mentioned"]
     labels_excluded: ["agent-replied", "agent-skipped", "agent-failed", "agent-running"]
   outcomes: ["agent-replied"]
 ---

--- a/skills/track-progress/SKILL.md
+++ b/skills/track-progress/SKILL.md
@@ -6,6 +6,7 @@ operator:
     target: "issue"
     applies_to: "parent"
     labels_required: ["progress-check"]
+    labels_consumed: ["progress-check"]
     labels_excluded: ["agent-closed", "agent-running", "agent-failed"]
   outcomes: ["agent-closed", "agent-watching"]
 ---


### PR DESCRIPTION
Fixes #292

## 问题
写回阶段 `runWriteBack` 无条件删除 `op.Trigger.LabelsRequired`，导致 `evaluate-bug` 触发用的 `bug` 类型标签在添加 `agent-skipped` 时被一并移除。类型标签（bug/feat）与一次性流程标签（ready-for-agent 等）共用 labels_required，cleanup 无法区分。

## 改动
- 新增 `trigger.labels_consumed` 字段（Trigger 结构 + frontmatter 解析）。
- `runWriteBack` 改为只删除 `LabelsConsumed` 中声明的标签；未声明则不删任何触发标签。向后兼容：老 skill 未声明即不再删除，符合期望语义。
- 为消费一次性流程标签的算子显式声明 labels_consumed：`implement`/`decompose`(ready-for-agent)、`track-progress`(progress-check)、`reply-comment`(agent-mentioned)。
- `evaluate-bug`/`evaluate-feat`/`reply-question`/`classify` 不声明 → 保留 bug/feat/question 类型标签（其 labels_excluded 已足以防重触发）。

## 测试
- 新增 `TestRun_OutcomeMarker_PreservesTypeTriggerLabel`：labels_required=[bug] 未声明 consumed 时，写回后 bug 保留、agent-skipped 已加、RemoveLabel 零调用。
- 更新既有 `TestRun_OutcomeMarker_RemovesTriggerLabels` / `TestRun_OutcomeAgentClosed_ClosesIssue` 使用 labels_consumed。
- `go test ./...` 全部通过（build 需临时占位 web/dist，已在验证后清理；该前置与本改动无关）。