### PR TITLE
fix: rebind VCS client context for write-back + tolerate comment-post failure

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -1025,6 +1025,19 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 		resumeCtx = buildResumeContext(wtResult)
 	}
 
+	// Rebind the VCS client's request context before execution + write-back.
+	// The client was configured in scanRepoOnce with the scan-phase budget
+	// (scanCtx, clamped to 5–15 min via scanPhaseBudget). An implement run
+	// can take tens of minutes, by which point scanCtx has long expired.
+	// If we don't rebind, the write-back HTTP calls (post comment, add label)
+	// inherit that dead context and fail immediately with "context deadline
+	// exceeded" — the retry added in #278 never fires because retry.Do bails
+	// out on ctx.Err() before the first attempt. Rebind to this operator's
+	// full run context so write-back gets a live budget (issue #293).
+	if rc, ok := j.client.(interface{ SetRequestContext(context.Context) }); ok {
+		rc.SetRequestContext(ctx)
+	}
+
 	output, outcome, runErr := operator.Run(ctx, j.op, j.sub, j.client, operator.RunOptions{
 		Repo:          j.repo,
 		Workdir:       workdir,

--- a/internal/operator/runner.go
+++ b/internal/operator/runner.go
@@ -300,9 +300,20 @@ func runWriteBack(v VCS, op *Operator, sub *Subject, opts RunOptions, body, outc
 
 		emitStage(opts.StageFunc, StagePostingComment)
 		if err := v.PostIssueCommentIdempotent(opts.Repo, sub.Number, body, opts.RunID); err != nil {
-			return fmt.Errorf("post result comment: %w", err)
+			// Downgrade a comment-post failure to a WARN instead of aborting
+			// write-back. Previously a POST timeout (context deadline exceeded)
+			// returned here and the outcome-label write below never ran, so a
+			// PR that was already opened by `implement` never got its
+			// `agent-implemented` label — the issue stayed `ready-for-agent`
+			// and the next scan re-triggered the operator, opening a duplicate
+			// PR and burning tokens again (issue #293). The comment body is
+			// already persisted to comment.md above and can be recovered, so
+			// the outcome label (the thing that actually gates re-triggering)
+			// must take priority over the cosmetic comment.
+			fmt.Fprintf(os.Stderr, "  ⚠ post result comment failed (continuing to label): %v\n", err)
+		} else {
+			fmt.Fprintf(os.Stderr, "  ✓ comment posted (%d chars)\n", len(body))
 		}
-		fmt.Fprintf(os.Stderr, "  ✓ comment posted (%d chars)\n", len(body))
 	}
 
 	if outcome != "" {

--- a/internal/operator/runner_test.go
+++ b/internal/operator/runner_test.go
@@ -313,6 +313,46 @@ func TestRun_OutcomeMarker_StripsAndAddsLabel(t *testing.T) {
 	}
 }
 
+// TestRun_CommentPostFails_OutcomeLabelStillApplied is the issue #293
+// regression: when posting the result comment fails (e.g. POST hits
+// "context deadline exceeded" in write-back), the outcome label must still
+// be applied. Otherwise an `implement` run that already opened a PR leaves
+// the issue on `ready-for-agent`, and the next scan re-triggers the
+// operator and opens a duplicate PR. The comment body is persisted to
+// comment.md so it isn't lost; the label is what actually gates
+// re-triggering, so it takes priority.
+func TestRun_CommentPostFails_OutcomeLabelStillApplied(t *testing.T) {
+	op := &Operator{
+		Name:      "implement",
+		LockLabel: "agent-running",
+		Outcomes:  []string{"agent-implemented"},
+		Trigger:   Trigger{LabelsRequired: []string{"ready-for-agent"}},
+	}
+	sub := &Subject{Number: 50, Labels: []string{"ready-for-agent"}}
+	v := newFakeVCS()
+	v.errOnComment = true // simulate POST comment timeout
+
+	body := "## Done\n\nOpened PR.\n\n<!-- clawflow:outcome=agent-implemented -->\n"
+	_, outcome, err := Run(context.Background(), op, sub, v, RunOptions{
+		Repo: "r",
+		RunFunc: func(context.Context, string, string, time.Duration, io.Writer, string, ...string) (string, error) {
+			return body, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("comment failure should not fail the run; got: %v", err)
+	}
+	if outcome != "agent-implemented" {
+		t.Errorf("want outcome agent-implemented, got %q", outcome)
+	}
+	if !slices.Contains(v.labels[50], "agent-implemented") {
+		t.Errorf("agent-implemented must be applied despite comment failure; labels = %v", v.labels[50])
+	}
+	if slices.Contains(v.labels[50], "ready-for-agent") {
+		t.Errorf("ready-for-agent trigger label should be removed; labels = %v", v.labels[50])
+	}
+}
+
 // TestRun_PromoFooter_AppendedToComment verifies that the posted comment ends
 // with the ClawFlow promo footer (issue #290) and that appending the footer
 // does not interfere with outcome marker parsing / label application.


### PR DESCRIPTION
Fixes #293

## 根因
write-back 阶段的 POST comment 命中 `context deadline exceeded`：

1. `scanRepoOnce` 用 `scanCtx`（`scanPhaseBudget` clamp 到 5-15min）通过 `SetRequestContext` 绑定到 VCS client。
2. 同一 client 实例被存进 `runJob`，execution 阶段一直复用。
3. `implement` 跑几十分钟后 `scanCtx` 早已过期。
4. write-back 的 `PostIssueCommentIdempotent` 走 `retry.Do(c.reqContext(), ...)`，而 `reqContext()` 返回的是那个已死的 `scanCtx`，`retry.Do` 开头 `ctx.Err()!=nil` 直接返回，#278 的重试一次都没发生。
5. comment 失败 → `runWriteBack` 提前 return → `agent-implemented` 标签永远没落 → issue 停在 `ready-for-agent` → 下轮重触发重复 PR。

## 改动
1. **`run.go`**：进入 `operator.Run` 前对 `j.client` 重新 `SetRequestContext(ctx)`，用本算子的完整 run context 替换过期的 `scanCtx`，让 write-back 拿到有效预算（#278 的重试才能真正生效）。
2. **`runner.go`**：comment-post 失败降级为 WARN 而非中断 write-back。comment body 已落盘到 comment.md 可恢复；outcome 标签才是决定是否重触发的关键，优先保证它被写入。
3. **`runner_test.go`**：新增回归测试，模拟 comment POST 失败，断言 `agent-implemented` 仍被写入、trigger label 被移除。

## 测试
- `go test ./internal/operator/...` 全绿，新增测试 `TestRun_CommentPostFails_OutcomeLabelStillApplied` 通过。
- `go build ./...` + `go vet` 通过（临时 stub web/dist 后验证，未改动 embed）。
- 纯 runner 内部逻辑改动，无运行时/前端表面，未跑端到端 SOP。