### PR TITLE
fix(run): 算子完成后立即刷新 runs.json，Dashboard 不再卡在 running

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -1195,6 +1195,15 @@ func runOneOperator(ctx context.Context, j *runJob, timeout time.Duration) (didF
 	if err := snapshot.WriteRunMeta(runDir, rm); err != nil {
 		fmt.Fprintf(os.Stderr, "%s ⚠ run meta: %v\n", prefix, err)
 	}
+	// Rewrite runs.json on the terminal transition too. The dashboard's Running
+	// list reads runs.json (not meta.json), and until now the only post-run
+	// rebuild was the end-of-pass Phase 3 write — so a finished operator kept
+	// showing "running" until every sibling in the pass also finished (or a
+	// sibling's emitStage incidentally re-walked the metas). Refreshing here
+	// flips this row to its final status immediately on completion.
+	if _, err := snapshot.WriteRunsIndex(50); err != nil {
+		fmt.Fprintf(os.Stderr, "%s ⚠ snapshot runs index (%s): %v\n", prefix, rm.Status, err)
+	}
 	// Upgrade to WARN for non-success statuses so deployment.md patrol's
 	// "grep -E ERROR|WARN" actively catches failures (issue #204).
 	logFn := runLog.Info


### PR DESCRIPTION
## 问题

Dashboard 的 Running 列表读的是聚合文件 `runs.json`，而不是每个算子的 `meta.json`。单个算子跑完时只写自己的 `meta.json`，**不重建 `runs.json`**。

之前 `runs.json` 的重建只发生在：
1. 运行中的 stage 流转（`emitStage`）
2. 整轮 pass 结束的 Phase 3（`WriteRunsIndex` at `run.go` 的 `wg.Wait()` 之后）

所以一个算子完成后，要等到**同批的兄弟算子**触发 stage/占位、或**整轮结束**才会翻成终态。如果它是这一批里最后/最长的任务（比如别的 implement 还在跑），它就一直显示 "running" —— 表现为"在等一组一起结束"。

## 修复

在终态 `WriteRunMeta(runDir, rm)` 之后补一次 `WriteRunsIndex(50)`，让每个算子一完成就立刻把自己那行翻成终态（success / failed / skipped-empty / no-marker / auth-error / output-limit / rate-limited）。

- 覆盖所有终态：落在 switch 赋值之后、统一的 `WriteRunMeta` 处。
- 无新增竞态：`WriteRunsIndex` 本来就被并行 job 的 `emitStage` 并发调用。
- 原有 Phase 3 收尾写入保留作兜底。

## 测试

- `go build` 通过。
- 行为验证：算子完成后 5s 内 Dashboard 该行即翻终态，不再等整批。

🤖 Generated with [Claude Code](https://claude.com/claude-code)