### PR TITLE
fix: clean up Claude Code sub-worktrees on operator exit

### DIFF
--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -2189,6 +2189,11 @@ func setupWorktree(repoCfg config.Repo, fullName string, issueNum int, startedAt
 		}
 		cleanup := func() {
 			fmt.Fprintln(os.Stderr, "  → cleanup: removing worktree")
+			// Clean up Claude Code CLI sub-worktrees created inside our worktree
+			// during operator execution (e.g. <wtPath>/.claude/worktrees/wf_*).
+			// These are NOT cleaned up by claude -p itself when run non-interactively,
+			// causing git to refuse branch deletion later (issue #297).
+			cleanClaudeWorktrees(localPath, existingPath)
 			rm := exec.Command("git", "-C", localPath, "worktree", "remove", "--force", existingPath)
 			rm.Stdout = os.Stderr
 			rm.Stderr = os.Stderr
@@ -2236,6 +2241,11 @@ func setupWorktree(repoCfg config.Repo, fullName string, issueNum int, startedAt
 	result := worktreeResult{Path: wtPath}
 	cleanup := func() {
 		fmt.Fprintln(os.Stderr, "  → cleanup: removing worktree")
+		// Clean up Claude Code CLI sub-worktrees created inside our worktree
+		// during operator execution (e.g. <wtPath>/.claude/worktrees/wf_*).
+		// These are NOT cleaned up by claude -p itself when run non-interactively,
+		// causing git to refuse branch deletion later (issue #297).
+		cleanClaudeWorktrees(localPath, wtPath)
 		rm := exec.Command("git", "-C", localPath, "worktree", "remove", "--force", wtPath)
 		rm.Stdout = os.Stderr
 		rm.Stderr = os.Stderr
@@ -2246,4 +2256,35 @@ func setupWorktree(repoCfg config.Repo, fullName string, issueNum int, startedAt
 		fmt.Fprintln(os.Stderr, "  ✓ worktree removed")
 	}
 	return result, cleanup, nil
+}
+
+// cleanClaudeWorktrees removes the sub-worktrees that Claude Code CLI creates
+// inside a ClawFlow worktree during non-interactive (claude -p) execution.
+// Claude Code creates these under <wtPath>/.claude/worktrees/wf_<uuid> for
+// tool-call isolation but does not clean them up after the process exits.
+// Without this cleanup, git refuses to delete the associated branches
+// (worktree-wf_<uuid>), breaking Play 1 branch cleanup (issue #297).
+//
+// localPath is the repo root (used for `git -C`).
+// wtPath is the ClawFlow worktree directory that may contain a .claude/worktrees/ subdir.
+func cleanClaudeWorktrees(localPath, wtPath string) {
+	claudeWtDir := filepath.Join(wtPath, ".claude", "worktrees")
+	entries, err := os.ReadDir(claudeWtDir)
+	if err != nil {
+		// Directory doesn't exist — nothing to clean, not an error.
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sub := filepath.Join(claudeWtDir, e.Name())
+		rm := exec.Command("git", "-C", localPath, "worktree", "remove", "--force", sub)
+		rm.Stderr = os.Stderr
+		if err := rm.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ claude worktree remove failed (%s): %v\n", sub, err)
+		} else {
+			fmt.Fprintf(os.Stderr, "  ✓ claude worktree removed: %s\n", sub)
+		}
+	}
 }

--- a/cmd/clawflow/commands/worktree.go
+++ b/cmd/clawflow/commands/worktree.go
@@ -142,10 +142,13 @@ func newWorktreePruneCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prune",
-		Short: "Remove persistent analysis worktrees left over from past runs",
+		Short: "Remove persistent analysis worktrees and orphan Claude sub-worktrees",
 		Long: `Scans ~/.clawflow/worktrees/*/analysis-* and removes analysis worktrees
-that are no longer needed. By default every found analysis worktree is removed;
-use --dry-run to preview what would be deleted without making any changes.
+that are no longer needed. Also scans every configured repo's local_path for
+orphan Claude Code CLI sub-worktrees (<local_path>/.claude/worktrees/wf_*) left
+behind by past implement operator runs (issue #297).
+
+By default every found worktree is removed; use --dry-run to preview.
 
 Analysis worktrees are persistent by design (they are reused across runs for
 performance), but they can accumulate over time and remain registered in the
@@ -154,7 +157,7 @@ to clean them up.`,
 		Example: `  # Preview what would be removed
   clawflow worktree prune --dry-run
 
-  # Remove all analysis worktrees
+  # Remove all analysis + orphan Claude worktrees
   clawflow worktree prune`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			home, err := os.UserHomeDir()
@@ -204,12 +207,56 @@ to clean them up.`,
 
 			if found == 0 {
 				fmt.Println("no analysis worktrees found")
-				return nil
-			}
-			if dryRun {
+			} else if dryRun {
 				fmt.Printf("\n%d analysis worktree(s) would be removed (re-run without --dry-run to apply)\n", found)
 			} else {
 				fmt.Printf("\n%d/%d analysis worktree(s) removed\n", removed, found)
+			}
+
+			// Phase 2: clean orphan Claude Code sub-worktrees from each repo's local_path.
+			cfg, err := config.Load()
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warn: could not load config, skipping claude worktree prune: %v\n", err)
+				return nil
+			}
+			claudeFound := 0
+			claudeRemoved := 0
+			for ownerRepo, repoCfg := range cfg.Repos {
+				if repoCfg.LocalPath == "" {
+					continue
+				}
+				localPath := expandHomeStr(repoCfg.LocalPath)
+				claudeWtDir := filepath.Join(localPath, ".claude", "worktrees")
+				subEntries, readErr := os.ReadDir(claudeWtDir)
+				if readErr != nil {
+					continue // directory absent — nothing to do
+				}
+				for _, sub := range subEntries {
+					if !sub.IsDir() {
+						continue
+					}
+					subPath := filepath.Join(claudeWtDir, sub.Name())
+					claudeFound++
+					if dryRun {
+						fmt.Printf("would remove claude worktree: %s (repo: %s)\n", subPath, ownerRepo)
+						continue
+					}
+					rmCmd := exec.Command("git", "-C", localPath, "worktree", "remove", "--force", subPath)
+					rmCmd.Stderr = cmd.ErrOrStderr()
+					if rmErr := rmCmd.Run(); rmErr != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "warn: claude worktree remove failed (%s): %v\n", subPath, rmErr)
+					} else {
+						fmt.Printf("removed claude worktree: %s\n", subPath)
+						claudeRemoved++
+					}
+				}
+			}
+			if claudeFound > 0 {
+				if dryRun {
+					fmt.Printf("%d orphan claude worktree(s) would be removed\n", claudeFound)
+				} else {
+					fmt.Printf("%d/%d orphan claude worktree(s) removed\n", claudeRemoved, claudeFound)
+				}
 			}
 			return nil
 		},


### PR DESCRIPTION
Fixes #297

## 问题

implement operator 执行完成后，Claude Code CLI（`claude -p`）在 ClawFlow worktree 内创建的次级 worktree（`.claude/worktrees/wf_<uuid>/`）未被清理。这些 worktree 的 git 注册项（分支名 `worktree-wf_<uuid>`）残留，导致 git 拒绝删除这些分支，使 `clawflow branch delete` 完全失效（0 deleted, N failed）。

## 修复

**方案 A（治本）— run.go**

在 `setupWorktree` 的两个 cleanup 闭包（resumed 路径和 fresh 路径）中，在移除顶层 ClawFlow worktree 之前，先调用新增的 `cleanClaudeWorktrees(localPath, wtPath)` 函数。该函数扫描 `.claude/worktrees/*` 下的所有子目录，对每个条目执行 `git -C <localPath> worktree remove --force`，清除 git 注册和目录。

cleanup 只在 `success/skipped-empty/no-marker/auth-error/output-limit` 路径调用，与现有条件一致——失败保留 worktree 用于 resume 的路径不受影响。

**方案 B（治存量）— worktree.go**

扩展 `clawflow worktree prune`，在清理 analysis worktree 之后，额外扫描每个配置了 `local_path` 的 repo 下的 `<local_path>/.claude/worktrees/`，对孤儿次级 worktree 执行同样的 `git worktree remove --force`。支持 `--dry-run` 预览。

用户可执行一次 `clawflow worktree prune` 清理现有的 11 个孤儿 worktree。

## 测试

所有现有单元测试通过（`go test ./internal/... ./cmd/clawflow/commands/...`）。