### PR TITLE
fix: 把 auto-merge 改成每轮 scan 的幂等收敛，兜住内联路径漏掉的 PR

### DIFF
--- a/cmd/clawflow/commands/automerge.go
+++ b/cmd/clawflow/commands/automerge.go
@@ -1,0 +1,280 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/snapshot"
+	"github.com/zhoushoujianwork/clawflow/internal/vcs"
+)
+
+// closesIssueRE extracts the issue number a PR body claims to close.
+// Matches GitHub/GitLab closing keywords case-insensitively, with or
+// without the `owner/repo` prefix omitted (cross-repo refs are ignored on
+// purpose — the sweep only converges PRs against their own repo's issue).
+var closesIssueRE = regexp.MustCompile(`(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)\b`)
+
+// extractClosesIssue returns the first issue number referenced by a closing
+// keyword in body, or 0 when there is none.
+func extractClosesIssue(body string) int {
+	m := closesIssueRE.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return 0
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
+}
+
+// isDraftPR reports whether a PR title marks it as work-in-progress. vcs.PR
+// carries no draft flag, so the title convention is all we have.
+func isDraftPR(title string) bool {
+	t := strings.ToUpper(strings.TrimSpace(title))
+	for _, p := range []string{"WIP:", "WIP ", "[WIP]", "DRAFT:", "[DRAFT]"} {
+		if strings.HasPrefix(t, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// autoMergeAttempt bundles everything one auto-merge attempt needs. It is
+// shared by two callers: the inline low-latency path in runPostAutomation
+// (right after implement produced agent-implemented) and the per-scan sweep
+// (sweepAutoMergePRs), so the two can't drift apart. See issue #299.
+type autoMergeAttempt struct {
+	client  vcs.Client
+	repo    string
+	repoCfg config.Repo
+	prNum   int
+	// issueNum is the issue the PR closes; comments land there. 0 means
+	// "unknown" and comments are posted on the PR itself.
+	issueNum int
+	prefix   string
+	// ciPoll, when true, checks CI exactly once instead of blocking up to
+	// repoCfg.CITimeout. The sweep sets it: it runs every pass, so a
+	// still-pending check is simply re-examined next time rather than
+	// eating the scan budget in 30s sleeps.
+	ciPoll bool
+	// quiet suppresses the "not mergeable" / "CI pending" comments. The
+	// sweep runs every pass, so commenting on a still-dirty PR each time
+	// would spam the issue; the inline path comments once and is done.
+	quiet bool
+}
+
+// notify posts body on the attempt's issue (or the PR when the issue is
+// unknown), skipping the write when an earlier comment already carries the
+// same PR marker. Best-effort: comment failures are logged, never fatal.
+func (a autoMergeAttempt) notify(body, marker string) {
+	if a.issueNum == 0 {
+		if err := a.client.PostPRComment(a.repo, a.prNum, body); err != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge comment: %v\n", a.prefix, err)
+		}
+		return
+	}
+	if marker != "" {
+		if existing, err := a.client.ListIssueComments(a.repo, a.issueNum); err == nil {
+			for _, c := range existing {
+				if strings.Contains(c, marker) {
+					fmt.Fprintf(os.Stderr, "%s · auto-merge: comment %q already present, staying silent\n", a.prefix, marker)
+					return
+				}
+			}
+		}
+	}
+	if err := a.client.PostIssueComment(a.repo, a.issueNum, body); err != nil {
+		fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge comment: %v\n", a.prefix, err)
+	}
+}
+
+// checkCI resolves the PR's CI state. The inline path blocks up to the
+// repo's ci_timeout (a fresh PR's checks have not started yet, and waiting
+// is what makes same-run auto-merge work). The sweep sets ciPoll and takes a
+// single reading: it will look again next pass, so blocking here would just
+// spend scan budget on sleeps.
+func (a autoMergeAttempt) checkCI() vcs.CIStatus {
+	if a.ciPoll {
+		status, err := a.client.GetCIStatus(a.repo, a.prNum)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ CI status check: %v\n", a.prefix, err)
+			return vcs.CIStatusPending
+		}
+		return status
+	}
+	timeout := a.repoCfg.CITimeout
+	if timeout <= 0 {
+		timeout = 600
+	}
+	return waitForCI(a.client, a.repo, a.prNum, timeout, a.prefix)
+}
+
+// attemptAutoMerge runs the full auto-merge sequence for one PR: optional CI
+// gate, mergeability check, merge with transient-race retry, then head-branch
+// cleanup. Returns true only when the merge landed.
+func attemptAutoMerge(a autoMergeAttempt) bool {
+	fmt.Fprintf(os.Stderr, "%s → auto-merge: PR #%d\n", a.prefix, a.prNum)
+
+	if a.repoCfg.CIRequired {
+		switch status := a.checkCI(); status {
+		case vcs.CIStatusSuccess, vcs.CIStatusNone:
+			// proceed to merge
+		case vcs.CIStatusFailure:
+			fmt.Fprintf(os.Stderr, "%s ✗ CI failed, skipping auto-merge\n", a.prefix)
+			if !a.quiet {
+				a.notify("🤖 CI failed on PR #"+strconv.Itoa(a.prNum)+". Skipping auto-merge.",
+					"CI failed on PR #"+strconv.Itoa(a.prNum))
+			}
+			return false
+		default:
+			fmt.Fprintf(os.Stderr, "%s ✗ CI still pending, skipping auto-merge\n", a.prefix)
+			if !a.quiet {
+				a.notify("🤖 CI did not pass within timeout for PR #"+strconv.Itoa(a.prNum)+". Skipping auto-merge.",
+					"CI did not pass within timeout for PR #"+strconv.Itoa(a.prNum))
+			}
+			return false
+		}
+	}
+
+	mergeStatus, err := a.client.GetPRMergeability(a.repo, a.prNum)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge: mergeability check failed: %v\n", a.prefix, err)
+		return false
+	}
+	if mergeStatus != vcs.MergeStatusClean {
+		fmt.Fprintf(os.Stderr, "%s ✗ PR not mergeable (%s)\n", a.prefix, mergeStatus)
+		if !a.quiet {
+			a.notify("🤖 PR #"+strconv.Itoa(a.prNum)+" is not mergeable (status: "+string(mergeStatus)+"). Skipping auto-merge.",
+				"PR #"+strconv.Itoa(a.prNum)+" is not mergeable")
+		}
+		return false
+	}
+
+	if err := mergeWithRetry(a.prefix,
+		func() error { return a.client.MergePR(a.repo, a.prNum) },
+		func() (vcs.MergeStatus, error) { return a.client.GetPRMergeability(a.repo, a.prNum) },
+		time.Sleep,
+	); err != nil {
+		// Keep this comment even in quiet mode, but dedup on the PR
+		// number so a repeatedly failing sweep doesn't stack identical
+		// notices every pass. The marker `🤖 Auto-merge failed for PR #N`
+		// is also Pilot Play 4's trigger contract — don't change its shape.
+		fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge failed: %v\n", a.prefix, err)
+		a.notify("🤖 Auto-merge failed for PR #"+strconv.Itoa(a.prNum)+": "+err.Error(),
+			"🤖 Auto-merge failed for PR #"+strconv.Itoa(a.prNum))
+		return false
+	}
+	// No success comment: the PR's merged state is already visible in the
+	// GitHub/GitLab UI.
+	fmt.Fprintf(os.Stderr, "%s ✓ auto-merged PR #%d\n", a.prefix, a.prNum)
+
+	// Clean up the remote head branch. Non-fatal: the merge already landed
+	// and a stale branch is housekeeping, not a failure.
+	if pr, err := a.client.GetPR(a.repo, a.prNum); err != nil {
+		fmt.Fprintf(os.Stderr, "%s ⚠ branch cleanup: lookup PR failed: %v\n", a.prefix, err)
+	} else if head := pr.HeadBranch; head != "" && head != a.repoCfg.BaseBranch {
+		if err := a.client.DeleteBranch(a.repo, head); err != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ branch cleanup: delete %s failed: %v\n", a.prefix, head, err)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s ✓ deleted branch %s\n", a.prefix, head)
+		}
+	}
+	return true
+}
+
+// sweepMaxMergesPerPass caps how many PRs one scan pass may merge per repo.
+// One-at-a-time keeps the blast radius small and matches Pilot Play 4's
+// "Max ONE per wake" rule; the next pass picks up the rest.
+const sweepMaxMergesPerPass = 1
+
+// sweepMaxCandidates caps how many open PRs get a GetPRMergeability call in
+// one pass. Mergeability is an N+1 request per candidate, so a repo with a
+// large open-PR backlog must not turn the sweep into an API storm.
+const sweepMaxCandidates = 10
+
+// sweepAutoMergePRs converges open PRs on an auto_merge repo that no inline
+// auto-merge ever claimed. Before issue #299 auto-merge only fired in the
+// instant an `implement` run emitted `agent-implemented`, with the PR number
+// parsed out of that run's stdout — so a PR created by an earlier pass (or by
+// a run that deliberately declined to open a duplicate PR) could never be
+// merged by anything. This makes auto-merge an idempotent state check rather
+// than a one-shot side effect.
+//
+// It is a no-op unless repoCfg.AutoMerge is set: repos without auto-merge
+// spend zero API calls here.
+func sweepAutoMergePRs(ctx context.Context, client vcs.Client, fullName string, repoCfg config.Repo) {
+	if !repoCfg.AutoMerge {
+		return
+	}
+	prefix := fmt.Sprintf("[%s]", fullName)
+	prs, err := client.ListOpenPRs(fullName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge sweep: list open PRs: %v\n", prefix, err)
+		runLog.Warn("run/automerge_sweep", "repo", fullName, "err", err.Error())
+		return
+	}
+
+	var candidates, merged, skipped int
+	for _, pr := range prs {
+		if ctx != nil && ctx.Err() != nil {
+			break
+		}
+		if candidates >= sweepMaxCandidates || merged >= sweepMaxMergesPerPass {
+			break
+		}
+		if isDraftPR(pr.Title) {
+			skipped++
+			continue
+		}
+		// A PR with no closing keyword isn't ClawFlow's to merge: it may be
+		// a human's in-flight work. The `Closes #N` link is the signal that
+		// an operator opened it to resolve a tracked issue.
+		issueNum := extractClosesIssue(pr.Body)
+		if issueNum == 0 {
+			skipped++
+			continue
+		}
+		candidates++
+		// Silent skip on non-clean: the sweep sees the same dirty PR every
+		// pass, so commenting here would spam the issue forever.
+		status, mErr := client.GetPRMergeability(fullName, pr.Number)
+		if mErr != nil {
+			fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge sweep: mergeability of PR #%d: %v\n", prefix, pr.Number, mErr)
+			skipped++
+			continue
+		}
+		if status != vcs.MergeStatusClean {
+			debugf("%s · auto-merge sweep: PR #%d not clean (%s), leaving it", prefix, pr.Number, status)
+			skipped++
+			continue
+		}
+		if snapshot.IsLocked(fullName, issueNum) {
+			debugf("%s · auto-merge sweep: issue #%d locked by another process, skipping PR #%d", prefix, issueNum, pr.Number)
+			skipped++
+			continue
+		}
+		if attemptAutoMerge(autoMergeAttempt{
+			client:   client,
+			repo:     fullName,
+			repoCfg:  repoCfg,
+			prNum:    pr.Number,
+			issueNum: issueNum,
+			prefix:   prefix,
+			ciPoll:   true,
+			quiet:    true,
+		}) {
+			merged++
+		} else {
+			skipped++
+		}
+	}
+
+	runLog.Info("run/automerge_sweep", "repo", fullName, "open_prs", len(prs), "candidates", candidates, "merged", merged, "skipped", skipped)
+	if merged > 0 {
+		fmt.Fprintf(os.Stderr, "%s ✓ auto-merge sweep: merged %d PR(s)\n", prefix, merged)
+	}
+}

--- a/cmd/clawflow/commands/automerge_test.go
+++ b/cmd/clawflow/commands/automerge_test.go
@@ -1,0 +1,311 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	"github.com/zhoushoujianwork/clawflow/internal/vcs"
+)
+
+func TestExtractClosesIssue(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"closes", "Closes #273", 273},
+		{"lowercase fixes", "some text\n\nfixes #12\n", 12},
+		{"resolves", "Resolves #7", 7},
+		{"fixed past tense", "Fixed #99", 99},
+		{"with colon", "Closes: #42", 42},
+		{"first of many wins", "Closes #5 and closes #6", 5},
+		{"plain reference is not a claim", "see #123 for context", 0},
+		{"empty", "", 0},
+		{"no digits", "closes #", 0},
+		{"word boundary", "encloses #5", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractClosesIssue(tc.body); got != tc.want {
+				t.Errorf("extractClosesIssue(%q) = %d, want %d", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsDraftPR(t *testing.T) {
+	for _, tc := range []struct {
+		title string
+		want  bool
+	}{
+		{"WIP: fix thing", true},
+		{"[WIP] fix thing", true},
+		{"Draft: fix thing", true},
+		{"wip something", true},
+		{"fix: real change", false},
+		{"", false},
+		{"swiping the cache", false},
+	} {
+		if got := isDraftPR(tc.title); got != tc.want {
+			t.Errorf("isDraftPR(%q) = %v, want %v", tc.title, got, tc.want)
+		}
+	}
+}
+
+// sweepFake is a minimal vcs.Client for exercising sweepAutoMergePRs. Only
+// the methods the sweep touches carry behaviour; the rest return
+// vcs.ErrNotSupported so an accidental extra call is loud in tests.
+type sweepFake struct {
+	openPRs []vcs.PR
+	// mergeability keyed by PR number; missing entries default to clean.
+	mergeability map[int]vcs.MergeStatus
+	ciStatus     vcs.CIStatus
+
+	listOpenPRCalls  int
+	mergeabilityCall int
+	merged           []int
+	deletedBranches  []string
+	comments         []string
+	existingComments []string
+	mergeErr         error
+}
+
+func (f *sweepFake) ListOpenPRs(repo string) ([]vcs.PR, error) {
+	f.listOpenPRCalls++
+	return f.openPRs, nil
+}
+
+func (f *sweepFake) GetPRMergeability(repo string, prNumber int) (vcs.MergeStatus, error) {
+	f.mergeabilityCall++
+	if s, ok := f.mergeability[prNumber]; ok {
+		return s, nil
+	}
+	return vcs.MergeStatusClean, nil
+}
+
+func (f *sweepFake) MergePR(repo string, prNumber int) error {
+	if f.mergeErr != nil {
+		return f.mergeErr
+	}
+	f.merged = append(f.merged, prNumber)
+	return nil
+}
+
+func (f *sweepFake) GetPR(repo string, prNumber int) (vcs.PR, error) {
+	for _, pr := range f.openPRs {
+		if pr.Number == prNumber {
+			return pr, nil
+		}
+	}
+	return vcs.PR{}, errors.New("no such PR")
+}
+
+func (f *sweepFake) DeleteBranch(repo string, branch string) error {
+	f.deletedBranches = append(f.deletedBranches, branch)
+	return nil
+}
+
+func (f *sweepFake) PostIssueComment(repo string, issueNumber int, body string) error {
+	f.comments = append(f.comments, body)
+	return nil
+}
+
+func (f *sweepFake) ListIssueComments(repo string, issueNumber int) ([]string, error) {
+	return f.existingComments, nil
+}
+
+func (f *sweepFake) GetCIStatus(repo string, prNumber int) (vcs.CIStatus, error) {
+	if f.ciStatus == "" {
+		return vcs.CIStatusNone, nil
+	}
+	return f.ciStatus, nil
+}
+
+// All remaining vcs.Client methods are unsupported stubs for sweep tests.
+func (f *sweepFake) ListOpenIssues(repo string) ([]vcs.Issue, error) { return nil, vcs.ErrNotSupported }
+func (f *sweepFake) ListIssues(repo string, state string, labels []string) ([]vcs.Issue, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) GetIssue(repo string, number int) (*vcs.Issue, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) ListIssueCommentsDetail(repo string, issueNumber int) ([]vcs.IssueComment, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) CloseIssue(repo string, issueNumber int) error { return vcs.ErrNotSupported }
+func (f *sweepFake) CreateIssue(repo string, title, body string) (vcs.Issue, error) {
+	return vcs.Issue{}, vcs.ErrNotSupported
+}
+func (f *sweepFake) UpdateIssue(repo string, issueNumber int, update vcs.IssueUpdate) (vcs.Issue, error) {
+	return vcs.Issue{}, vcs.ErrNotSupported
+}
+func (f *sweepFake) PostIssueCommentIdempotent(repo string, issueNumber int, body, runID string) error {
+	return vcs.ErrNotSupported
+}
+func (f *sweepFake) DeleteIssueComment(repo string, issueNumber int, commentID int64) error {
+	return vcs.ErrNotSupported
+}
+func (f *sweepFake) ListIssuesByBodyKeyword(repo string, keyword string) ([]vcs.Issue, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) SearchIssues(repo, query, state string, limit int) ([]vcs.Issue, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) AddSubIssue(repo string, parentNumber int, subIssueID int64) error {
+	return vcs.ErrNotSupported
+}
+func (f *sweepFake) ListSubIssues(repo string, issueNumber int) ([]vcs.Issue, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) GetParentIssue(repo string, issueNumber int) (*vcs.Issue, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) UploadAttachment(repo string, filePath string) (string, error) {
+	return "", vcs.ErrNotSupported
+}
+func (f *sweepFake) GetIssueLabels(repo string, issueNumber int) ([]string, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) AddLabel(repo string, issueNumber int, labels ...string) error {
+	return vcs.ErrNotSupported
+}
+func (f *sweepFake) RemoveLabel(repo string, issueNumber int, labels ...string) error {
+	return vcs.ErrNotSupported
+}
+func (f *sweepFake) InitLabels(repo string, labels []vcs.Label) error { return vcs.ErrNotSupported }
+func (f *sweepFake) ListPRs(repo string, state string) ([]vcs.PR, error) {
+	return nil, vcs.ErrNotSupported
+}
+func (f *sweepFake) PRExistsForIssue(repo string, issueNumber int) (bool, error) {
+	return false, vcs.ErrNotSupported
+}
+func (f *sweepFake) CreatePR(repo string, opts vcs.PRCreateOpts) (vcs.PR, error) {
+	return vcs.PR{}, vcs.ErrNotSupported
+}
+func (f *sweepFake) PostPRComment(repo string, prNumber int, body string) error {
+	return vcs.ErrNotSupported
+}
+func (f *sweepFake) ClosePR(repo string, prNumber int) error { return vcs.ErrNotSupported }
+
+func TestSweepAutoMergePRs_DisabledCostsNoAPICalls(t *testing.T) {
+	f := &sweepFake{openPRs: []vcs.PR{{Number: 1, Body: "Closes #2"}}}
+	sweepAutoMergePRs(context.Background(), f, "o/r", config.Repo{AutoMerge: false})
+	if f.listOpenPRCalls != 0 {
+		t.Errorf("expected 0 ListOpenPRs calls when auto_merge is off, got %d", f.listOpenPRCalls)
+	}
+	if len(f.merged) != 0 {
+		t.Errorf("expected no merges, got %v", f.merged)
+	}
+}
+
+func TestSweepAutoMergePRs_MergesCleanCandidate(t *testing.T) {
+	f := &sweepFake{openPRs: []vcs.PR{
+		{Number: 273, Title: "fix: thing", Body: "Closes #272", HeadBranch: "fix/issue-272"},
+	}}
+	sweepAutoMergePRs(context.Background(), f, "o/r", config.Repo{AutoMerge: true, BaseBranch: "main"})
+	if len(f.merged) != 1 || f.merged[0] != 273 {
+		t.Fatalf("expected PR 273 merged, got %v", f.merged)
+	}
+	if len(f.deletedBranches) != 1 || f.deletedBranches[0] != "fix/issue-272" {
+		t.Errorf("expected head branch deleted, got %v", f.deletedBranches)
+	}
+	if len(f.comments) != 0 {
+		t.Errorf("expected no comments on success, got %v", f.comments)
+	}
+}
+
+func TestSweepAutoMergePRs_DirtyIsSilentlySkipped(t *testing.T) {
+	f := &sweepFake{
+		openPRs:      []vcs.PR{{Number: 10, Body: "Closes #9"}},
+		mergeability: map[int]vcs.MergeStatus{10: vcs.MergeStatusConflict},
+	}
+	sweepAutoMergePRs(context.Background(), f, "o/r", config.Repo{AutoMerge: true})
+	if len(f.merged) != 0 {
+		t.Errorf("expected no merge for dirty PR, got %v", f.merged)
+	}
+	if len(f.comments) != 0 {
+		t.Errorf("dirty PR must not be commented on every pass, got %v", f.comments)
+	}
+}
+
+func TestSweepAutoMergePRs_SkipsPRsWithoutClosingKeyword(t *testing.T) {
+	f := &sweepFake{openPRs: []vcs.PR{
+		{Number: 1, Title: "chore: human WIP", Body: "just some work"},
+		{Number: 2, Title: "WIP: not ready", Body: "Closes #3"},
+	}}
+	sweepAutoMergePRs(context.Background(), f, "o/r", config.Repo{AutoMerge: true})
+	if f.mergeabilityCall != 0 {
+		t.Errorf("expected no mergeability calls for non-candidates, got %d", f.mergeabilityCall)
+	}
+	if len(f.merged) != 0 {
+		t.Errorf("expected no merges, got %v", f.merged)
+	}
+}
+
+func TestSweepAutoMergePRs_CapsMergesPerPass(t *testing.T) {
+	f := &sweepFake{openPRs: []vcs.PR{
+		{Number: 1, Body: "Closes #11", HeadBranch: "a"},
+		{Number: 2, Body: "Closes #12", HeadBranch: "b"},
+		{Number: 3, Body: "Closes #13", HeadBranch: "c"},
+	}}
+	sweepAutoMergePRs(context.Background(), f, "o/r", config.Repo{AutoMerge: true})
+	if len(f.merged) != sweepMaxMergesPerPass {
+		t.Errorf("expected at most %d merge(s) per pass, got %v", sweepMaxMergesPerPass, f.merged)
+	}
+}
+
+func TestSweepAutoMergePRs_FailureCommentIsDeduped(t *testing.T) {
+	f := &sweepFake{
+		openPRs:  []vcs.PR{{Number: 5, Body: "Closes #4"}},
+		mergeErr: errors.New("HTTP 403: Resource not accessible by integration"),
+		existingComments: []string{
+			"🤖 Auto-merge failed for PR #5: HTTP 403: Resource not accessible by integration",
+		},
+	}
+	sweepAutoMergePRs(context.Background(), f, "o/r", config.Repo{AutoMerge: true})
+	if len(f.comments) != 0 {
+		t.Errorf("expected the duplicate failure comment to be suppressed, got %v", f.comments)
+	}
+}
+
+func TestSweepAutoMergePRs_FailureCommentPostedOnce(t *testing.T) {
+	f := &sweepFake{
+		openPRs:  []vcs.PR{{Number: 5, Body: "Closes #4"}},
+		mergeErr: errors.New("HTTP 403: Resource not accessible by integration"),
+	}
+	sweepAutoMergePRs(context.Background(), f, "o/r", config.Repo{AutoMerge: true})
+	if len(f.comments) != 1 || !strings.Contains(f.comments[0], "Auto-merge failed for PR #5") {
+		t.Fatalf("expected one failure comment carrying the Play 4 marker, got %v", f.comments)
+	}
+}
+
+// TestSweepAutoMergePRs_PendingCIDoesNotBlock guards the sweep against
+// waitForCI's 30s sleep loop: a pending check must yield immediately and be
+// re-examined on the next pass.
+func TestSweepAutoMergePRs_PendingCIDoesNotBlock(t *testing.T) {
+	f := &sweepFake{
+		openPRs:  []vcs.PR{{Number: 8, Body: "Closes #7"}},
+		ciStatus: vcs.CIStatusPending,
+	}
+	done := make(chan struct{})
+	go func() {
+		sweepAutoMergePRs(context.Background(), f, "o/r",
+			config.Repo{AutoMerge: true, CIRequired: true, CITimeout: 600})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sweep blocked on pending CI — it must poll once and move on")
+	}
+	if len(f.merged) != 0 {
+		t.Errorf("expected no merge while CI is pending, got %v", f.merged)
+	}
+	if len(f.comments) != 0 {
+		t.Errorf("pending CI must stay silent in sweep mode, got %v", f.comments)
+	}
+}

--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -704,8 +704,19 @@ func scanRepoOnce(ctx context.Context, reg *operator.Registry, fullName string, 
 		}
 	}
 
-	// MVP: skip PRs. All 3 built-in operators target issues. When a
-	// pr-target operator appears we'll add the same loop over ListOpenPRs.
+	// MVP: no PR-target operators yet. All built-in operators target
+	// issues. When a pr-target operator appears we'll add the same
+	// (subject × operator) loop over ListOpenPRs.
+	//
+	// PRs do get one pass here though: the auto-merge convergence sweep.
+	// It only runs when this repo has auto_merge enabled, and it exists
+	// because auto-merge used to be an inline side effect of a single
+	// `implement` run — a PR that missed that instant was never merged by
+	// anything (issue #299). Gated on executeHere so a `--repo`-narrowed
+	// run doesn't merge PRs across the whole config.
+	if executeHere && onlyIssue == 0 {
+		sweepAutoMergePRs(ctx, client, fullName, repoCfg)
+	}
 
 	// Snapshot every issue (open + closed) for the dashboard — same shape
 	// as POST /api/repo/refresh-issues so the cron path and the manual
@@ -1327,84 +1338,25 @@ func runPostAutomation(j *runJob, outcome, output, prefix string) {
 		fmt.Fprintf(os.Stderr, "%s ✓ auto-approved\n", prefix)
 	}
 
-	// Auto-merge: after implement produces agent-implemented, wait CI then merge
+	// Auto-merge: after implement produces agent-implemented, wait CI then
+	// merge. This is the low-latency path — the PR number comes straight
+	// from the run's stdout. sweepAutoMergePRs is the per-scan backstop for
+	// every PR this path misses (issue #299); both share attemptAutoMerge so
+	// the two can't drift.
 	if outcome == "agent-implemented" && j.repoCfg.AutoMerge {
 		prNum := extractPRNumber(output)
 		if prNum == 0 {
-			fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge: could not extract PR number from output\n", prefix)
+			fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge: could not extract PR number from output (sweep will retry next pass)\n", prefix)
 			return
 		}
-		fmt.Fprintf(os.Stderr, "%s → auto-merge: PR #%d\n", prefix, prNum)
-
-		if j.repoCfg.CIRequired {
-			ciTimeout := j.repoCfg.CITimeout
-			if ciTimeout <= 0 {
-				ciTimeout = 600
-			}
-			status := waitForCI(j.client, j.repo, prNum, ciTimeout, prefix)
-			switch status {
-			case vcs.CIStatusSuccess, vcs.CIStatusNone:
-				// proceed to merge
-			case vcs.CIStatusFailure:
-				_ = j.client.PostIssueComment(j.repo, j.sub.Number,
-					"🤖 CI failed on PR #"+strconv.Itoa(prNum)+". Skipping auto-merge.")
-				fmt.Fprintf(os.Stderr, "%s ✗ CI failed, skipping auto-merge\n", prefix)
-				return
-			default:
-				_ = j.client.PostIssueComment(j.repo, j.sub.Number,
-					"🤖 CI did not pass within timeout for PR #"+strconv.Itoa(prNum)+". Skipping auto-merge.")
-				fmt.Fprintf(os.Stderr, "%s ✗ CI timeout, skipping auto-merge\n", prefix)
-				return
-			}
-		}
-
-		mergeStatus, err := j.client.GetPRMergeability(j.repo, prNum)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge: mergeability check failed: %v\n", prefix, err)
-			return
-		}
-		if mergeStatus != vcs.MergeStatusClean {
-			_ = j.client.PostIssueComment(j.repo, j.sub.Number,
-				"🤖 PR #"+strconv.Itoa(prNum)+" is not mergeable (status: "+string(mergeStatus)+"). Skipping auto-merge.")
-			fmt.Fprintf(os.Stderr, "%s ✗ PR not mergeable (%s)\n", prefix, mergeStatus)
-			return
-		}
-
-		if err := mergeWithRetry(prefix,
-			func() error { return j.client.MergePR(j.repo, prNum) },
-			func() (vcs.MergeStatus, error) { return j.client.GetPRMergeability(j.repo, prNum) },
-			time.Sleep,
-		); err != nil {
-			// Keep the failure comment: the user explicitly enabled
-			// auto_merge, the merge attempt failed, and the reason
-			// (auth, branch protection, network) isn't otherwise
-			// surfaced on the PR. This is the one auto-merge comment
-			// that pulls real weight.
-			fmt.Fprintf(os.Stderr, "%s ⚠ auto-merge failed: %v\n", prefix, err)
-			_ = j.client.PostIssueComment(j.repo, j.sub.Number,
-				"🤖 Auto-merge failed for PR #"+strconv.Itoa(prNum)+": "+err.Error())
-			return
-		}
-		// No success comment: the PR's "merged by clawflow-bot" state
-		// is already shown in GitHub/GitLab UI. Adding a comment on
-		// top was redundant noise.
-		fmt.Fprintf(os.Stderr, "%s ✓ auto-merged PR #%d\n", prefix, prNum)
-
-		// Clean up the remote head branch once the merge lands. We read
-		// the PR again instead of reusing an earlier fetch because the
-		// mergeability check happened before merge and the branch name
-		// lives on the PR object anyway. Failures here are non-fatal:
-		// the merge already succeeded, and stale branches are a minor
-		// housekeeping issue, not something worth surfacing on the issue.
-		if pr, err := j.client.GetPR(j.repo, prNum); err != nil {
-			fmt.Fprintf(os.Stderr, "%s ⚠ branch cleanup: lookup PR failed: %v\n", prefix, err)
-		} else if head := pr.HeadBranch; head != "" && head != j.repoCfg.BaseBranch {
-			if err := j.client.DeleteBranch(j.repo, head); err != nil {
-				fmt.Fprintf(os.Stderr, "%s ⚠ branch cleanup: delete %s failed: %v\n", prefix, head, err)
-			} else {
-				fmt.Fprintf(os.Stderr, "%s ✓ deleted branch %s\n", prefix, head)
-			}
-		}
+		attemptAutoMerge(autoMergeAttempt{
+			client:   j.client,
+			repo:     j.repo,
+			repoCfg:  j.repoCfg,
+			prNum:    prNum,
+			issueNum: j.sub.Number,
+			prefix:   prefix,
+		})
 	}
 
 	// Tracking issue: after decompose creates sub-issues, add progress-check


### PR DESCRIPTION
Fixes #299

## 问题

auto-merge 此前只是 implement 算子的一次性内联副作用：触发条件是 outcome == agent-implemented，PR 号只能从当次 claude stdout 里 extractPRNumber 解析。任何一轮没走到那一步（等价 PR 已存在、无 marker、write-back 超时），PR 就永久失去被合并的机会 —— 而 scan 阶段没有任何算子的 target 是 PR，ready-for-agent 也已被消耗，形成双向死锁。PR #273 正是这样滞留了 56 天。

## 改动

按 issue 建议的方向 1 落地，把 auto-merge 从「事件」变成「幂等的状态收敛」。

**新增 automerge.go**

- sweepAutoMergePRs() 在 scanRepoOnce 里对 auto_merge: true 的仓库每轮跑一次：ListOpenPRs → 跳过 draft/WIP → 用新增的 closesIssueRE 解析 Closes/Fixes/Resolves #N → GetPRMergeability 必须 clean → 复用 mergeWithRetry 合并 + 删分支。AutoMerge == false 时零 API 调用。

- attemptAutoMerge() 把原来内联的 CI 门禁 / mergeability / merge-retry / 分支清理整段抽出来，内联路径和 sweep 共用同一实现，避免两份逻辑漂移。

**噪音与配额控制**

- 每轮每仓库最多合并 1 个 PR（sweepMaxMergesPerPass），与 Pilot Play 4 对齐；候选上限 10 个。

- 非 clean 的 PR 静默跳过、不评论。

- ciPoll 标志：sweep 只查一次 CI 就返回，不进 waitForCI 的 30s sleep 循环。

- 失败评论去重，保留 Play 4 的 marker 形状。

- 新增结构化日志 run/automerge_sweep。

## 测试

go test ./... 全绿。13 个新用例覆盖：extractClosesIssue 表驱动、isDraftPR、sweep 行为（AutoMerge=false 零调用、clean 合并、dirty 静默、无 closing keyword 跳过、配额、去重、pending CI 不阻塞）。

## 未验证

没有跑真实的 clawflow run（环境禁止执行新二进制）。需要确认 ListOpenPRs 返回的 Body 字段是否带 PR 正文，建议先在测试仓库观察 run.log。