### PR TITLE
fix: validate base_branch and classify git fetch failures by cause

### DIFF
--- a/cmd/clawflow/commands/gitfetcherr.go
+++ b/cmd/clawflow/commands/gitfetcherr.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/zhoushoujianwork/clawflow/internal/branch"
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+	clog "github.com/zhoushoujianwork/clawflow/internal/log"
+)
+
+// gitFetchErrKind classifies why a `git fetch` failed. git exits 128 for a
+// missing remote ref, a rejected credential and an unreachable host alike, so
+// the exit status carries no signal — the classification has to come from the
+// stderr text (issue #300).
+type gitFetchErrKind int
+
+const (
+	gitFetchUnknown gitFetchErrKind = iota
+	// gitFetchRefNotFound: the remote answered, but has no such branch.
+	// Deterministic configuration error — retrying never helps.
+	gitFetchRefNotFound
+	// gitFetchAuth: reachable remote, rejected or missing credentials.
+	gitFetchAuth
+	// gitFetchNetwork: the remote could not be reached at all.
+	gitFetchNetwork
+)
+
+// classifyGitFetchError maps git's combined output to a gitFetchErrKind.
+// Ref-not-found is checked first: a wrong base_branch is the one cause the
+// operator can name precisely, and its markers never co-occur with the others.
+func classifyGitFetchError(output string) gitFetchErrKind {
+	lower := strings.ToLower(output)
+	contains := func(pats ...string) bool {
+		for _, p := range pats {
+			if strings.Contains(lower, p) {
+				return true
+			}
+		}
+		return false
+	}
+
+	switch {
+	case contains(
+		"couldn't find remote ref",
+		"couldn't find remote branch",
+		"unknown revision or path not in the working tree",
+		"no such ref was fetched",
+		"matched no remote refs",
+	):
+		return gitFetchRefNotFound
+	case contains(
+		"authentication failed",
+		"permission denied",
+		"could not read username",
+		"could not read password",
+		"invalid username or password",
+		"terminal prompts disabled",
+		"access denied",
+	):
+		return gitFetchAuth
+	case contains(
+		"could not resolve host",
+		"could not resolve hostname",
+		"connection timed out",
+		"connection refused",
+		"connection reset by peer",
+		"network is unreachable",
+		"does not appear to be a git repository",
+		"failed to connect to",
+		"no network response",
+	):
+		return gitFetchNetwork
+	}
+	return gitFetchUnknown
+}
+
+// describeGitFetchFailure renders a fetch failure with a cause-specific
+// explanation instead of the old blanket "without network access" wording,
+// which sent issue #300's investigation after SSH deploy keys for three weeks
+// while the real problem was base_branch: "origin".
+//
+// remoteDefault, when non-empty, is offered as the likely correct value.
+func describeGitFetchFailure(base, localPath, output string, remoteDefault string, err error) error {
+	switch classifyGitFetchError(output) {
+	case gitFetchRefNotFound:
+		msg := fmt.Sprintf(
+			"git fetch origin/%s: %v — the remote has no ref %q, "+
+				"so base_branch is likely misconfigured for this repo",
+			base, err, base)
+		if remoteDefault != "" && remoteDefault != base {
+			msg += fmt.Sprintf(" (the remote default branch is %q)", remoteDefault)
+		}
+		return fmt.Errorf("%s; fix base_branch in your clawflow config, "+
+			"then re-run — this is a configuration error, not a network problem", msg)
+	case gitFetchAuth:
+		return fmt.Errorf(
+			"git fetch origin/%s: %w — the remote rejected our credentials "+
+				"(check the SSH key / token available to %s)", base, err, localPath)
+	case gitFetchNetwork:
+		return fmt.Errorf(
+			"git fetch origin/%s: %w — the remote is unreachable, "+
+				"cannot refresh analysis code without network access", base, err)
+	}
+	return fmt.Errorf("git fetch origin/%s: %w — analysis blocked to avoid "+
+		"stale-code evaluation (see stderr above for git's own message)", base, err)
+}
+
+// warnInvalidBaseBranch validates a repo's configured base_branch against its
+// local clone once per scan and warns when the remote has no such branch.
+//
+// Cost is one local ref read in the healthy case; the ls-remote probe only
+// runs when the remote-tracking ref is missing. Warn-only by design: an
+// offline machine or a freshly cloned repo must not stop the scan.
+func warnInvalidBaseBranch(lg *clog.Logger, fullName string, repoCfg config.Repo) {
+	if !repoCfg.Enabled || repoCfg.LocalPath == "" {
+		return
+	}
+	v := branch.ValidateBase(repoCfg.LocalPath, repoCfg.BaseBranch)
+	if v.Valid() {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "  ⚠ %s: %s\n", fullName, v.Hint())
+	lg.Warn("run/base_branch_invalid",
+		"repo", fullName,
+		"base", v.Base,
+		"remote_default", v.RemoteDefault,
+	)
+}

--- a/cmd/clawflow/commands/gitfetcherr_integration_test.go
+++ b/cmd/clawflow/commands/gitfetcherr_integration_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFetchRefNotFound_RealGit reproduces issue #300 end-to-end against a real
+// local clone: `git fetch origin origin` when base_branch is misconfigured as
+// "origin". It asserts the pipeline (runGitWithRetryOutput → classify →
+// describe) turns git's actual stderr into a config-error message.
+func TestFetchRefNotFound_RealGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	work := filepath.Join(root, "work")
+	clone := filepath.Join(root, "clone")
+
+	git := func(dir string, args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git(root, "init", "--bare", "--initial-branch=main", remote)
+	git(root, "init", "--initial-branch=main", work)
+	git(work, "config", "user.email", "t@example.com")
+	git(work, "config", "user.name", "t")
+	git(work, "commit", "--allow-empty", "-m", "init")
+	git(work, "remote", "add", "origin", remote)
+	git(work, "push", "-u", "origin", "main")
+	git(root, "clone", remote, clone)
+
+	out, err := runGitWithRetryOutput(func() *exec.Cmd {
+		return exec.Command("git", "-C", clone, "fetch", "origin", "origin")
+	})
+	if err == nil {
+		t.Fatal("fetching a nonexistent ref should fail")
+	}
+	if classifyGitFetchError(out) != gitFetchRefNotFound {
+		t.Fatalf("real git output not classified as ref-not-found: %q", out)
+	}
+
+	msg := describeGitFetchFailure("origin", clone, out, "main", err).Error()
+	if !strings.Contains(msg, "base_branch is likely misconfigured") {
+		t.Errorf("message should name base_branch: %s", msg)
+	}
+	if strings.Contains(msg, "without network access") {
+		t.Errorf("must not blame the network: %s", msg)
+	}
+
+	// Sanity: the correct branch fetches fine over the same path/credentials.
+	if _, err := runGitWithRetryOutput(func() *exec.Cmd {
+		return exec.Command("git", "-C", clone, "fetch", "origin", "main")
+	}); err != nil {
+		t.Fatalf("fetching origin/main should succeed: %v", err)
+	}
+}

--- a/cmd/clawflow/commands/gitfetcherr_test.go
+++ b/cmd/clawflow/commands/gitfetcherr_test.go
@@ -1,0 +1,99 @@
+package commands
+
+import "strings"
+
+import "testing"
+
+func TestClassifyGitFetchError(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   gitFetchErrKind
+	}{
+		{
+			// The exact issue #300 signature: base_branch was "origin".
+			name:   "misconfigured base branch",
+			output: "fatal: couldn't find remote ref origin\n",
+			want:   gitFetchRefNotFound,
+		},
+		{
+			name:   "unknown revision",
+			output: "fatal: ambiguous argument 'origin/nope': unknown revision or path not in the working tree.",
+			want:   gitFetchRefNotFound,
+		},
+		{
+			name:   "http auth rejected",
+			output: "remote: Invalid username or password.\nfatal: Authentication failed for 'https://github.com/o/r/'",
+			want:   gitFetchAuth,
+		},
+		{
+			name:   "ssh key rejected",
+			output: "git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
+			want:   gitFetchAuth,
+		},
+		{
+			name:   "dns failure",
+			output: "ssh: Could not resolve hostname github.com: nodename nor servname provided",
+			want:   gitFetchNetwork,
+		},
+		{
+			name:   "connect timeout",
+			output: "ssh: connect to host github.com port 22: Connection timed out",
+			want:   gitFetchNetwork,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   gitFetchUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyGitFetchError(tc.output); got != tc.want {
+				t.Errorf("classifyGitFetchError(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDescribeGitFetchFailure_RefNotFoundNamesConfig(t *testing.T) {
+	err := describeGitFetchFailure("origin", "/tmp/clone",
+		"fatal: couldn't find remote ref origin\n", "main", errTestExit128)
+	msg := err.Error()
+
+	for _, want := range []string{"base_branch", "misconfigured", `"main"`} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q: %s", want, msg)
+		}
+	}
+	// The regression this test guards: issue #300's blanket network wording.
+	if strings.Contains(msg, "without network access") {
+		t.Errorf("ref-not-found must not be reported as a network problem: %s", msg)
+	}
+}
+
+func TestDescribeGitFetchFailure_NetworkKeepsNetworkWording(t *testing.T) {
+	err := describeGitFetchFailure("main", "/tmp/clone",
+		"ssh: Could not resolve hostname github.com", "main", errTestExit128)
+	if !strings.Contains(err.Error(), "network access") {
+		t.Errorf("network failure should say so: %s", err)
+	}
+}
+
+func TestDescribeGitFetchFailure_AuthNamesCredentials(t *testing.T) {
+	err := describeGitFetchFailure("main", "/tmp/clone",
+		"fatal: Authentication failed for 'https://github.com/o/r/'", "main", errTestExit128)
+	msg := err.Error()
+	if !strings.Contains(msg, "credentials") {
+		t.Errorf("auth failure should name credentials: %s", msg)
+	}
+	if strings.Contains(msg, "network access") {
+		t.Errorf("auth failure must not be reported as network: %s", msg)
+	}
+}
+
+var errTestExit128 = errTestExit(128)
+
+type errTestExit int
+
+func (e errTestExit) Error() string { return "exit status 128" }

--- a/cmd/clawflow/commands/run.go
+++ b/cmd/clawflow/commands/run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	rootmod "github.com/zhoushoujianwork/clawflow"
 	"github.com/zhoushoujianwork/clawflow/internal/api"
+	"github.com/zhoushoujianwork/clawflow/internal/branch"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
 	clog "github.com/zhoushoujianwork/clawflow/internal/log"
 	"github.com/zhoushoujianwork/clawflow/internal/operator"
@@ -322,6 +323,12 @@ func runOnce(ctx context.Context, onlyRepo string, onlyIssue int, timeout time.D
 			debugf("repo %s has no bound_machine and require_binding is set, skipping", fullName)
 			continue
 		}
+		// Warn early when base_branch names a ref the remote doesn't have.
+		// Without this the misconfiguration only surfaces as an exit-128
+		// fetch failure inside every analysis operator, round after round
+		// (issue #300). Warn-only: never block a scan on it.
+		warnInvalidBaseBranch(lg, fullName, repoCfg)
+
 		executeHere := onlyRepo == "" || onlyRepo == fullName
 		repoPending, repoJobs, err := scanRepoOnce(scanCtx, reg, fullName, repoCfg, executeHere, onlyIssue, &globalIssues)
 		if err != nil {
@@ -1687,10 +1694,11 @@ func ensureAnalysisWorktree(repoCfg config.Repo, fullName string) (worktreeResul
 
 		fmt.Fprintf(os.Stderr, "  → analysis worktree: initializing at %s\n", wtPath)
 		fmt.Fprintf(os.Stderr, "  → analysis worktree: fetching origin/%s\n", base)
-		if err := runGitWithRetry(func() *exec.Cmd {
+		if out, err := runGitWithRetryOutput(func() *exec.Cmd {
 			return exec.Command("git", "-C", localPath, "fetch", "origin", base)
 		}); err != nil {
-			return worktreeResult{}, func() {}, fmt.Errorf("git fetch origin/%s: %w — cannot initialize analysis worktree without network access", base, err)
+			return worktreeResult{}, func() {}, describeGitFetchFailure(
+				base, localPath, out, branch.RemoteDefaultBranch(localPath), err)
 		}
 
 		if err := runGitWithRetry(func() *exec.Cmd {
@@ -1709,10 +1717,11 @@ func ensureAnalysisWorktree(repoCfg config.Repo, fullName string) (worktreeResul
 	} else {
 		// Existing worktree: fetch + reset to latest origin/<base>.
 		fmt.Fprintf(os.Stderr, "  → analysis worktree: refreshing to origin/%s\n", base)
-		if err := runGitWithRetry(func() *exec.Cmd {
+		if out, err := runGitWithRetryOutput(func() *exec.Cmd {
 			return exec.Command("git", "-C", localPath, "fetch", "origin", base)
 		}); err != nil {
-			return worktreeResult{}, func() {}, fmt.Errorf("git fetch origin/%s: %w — analysis blocked to avoid stale-code evaluation", base, err)
+			return worktreeResult{}, func() {}, describeGitFetchFailure(
+				base, localPath, out, branch.RemoteDefaultBranch(localPath), err)
 		}
 
 		resetCmd := exec.Command("git", "-C", wtPath, "reset", "--hard", "origin/"+base)
@@ -2035,6 +2044,16 @@ func runBoundedGit(cmd *exec.Cmd, timeout time.Duration) error {
 }
 
 func runGitWithRetry(makeCmd func() *exec.Cmd) error {
+	_, err := runGitWithRetryOutput(makeCmd)
+	return err
+}
+
+// runGitWithRetryOutput is runGitWithRetry plus the git combined output of the
+// final attempt. Callers that need to classify *why* git failed (network vs
+// auth vs "remote has no such ref") need the stderr text — the exit status
+// alone is exit 128 for all three, which is what made the base_branch
+// misconfiguration in issue #300 read as a network outage for three weeks.
+func runGitWithRetryOutput(makeCmd func() *exec.Cmd) (string, error) {
 	const maxGitRetries = 5
 	const baseGitDelay = 100 * time.Millisecond
 
@@ -2057,7 +2076,7 @@ func runGitWithRetry(makeCmd func() *exec.Cmd) error {
 
 		err := runBoundedGit(cmd, gitAttemptTimeout)
 		if err == nil {
-			return nil
+			return buf.String(), nil
 		}
 
 		output := buf.String()
@@ -2065,10 +2084,10 @@ func runGitWithRetry(makeCmd func() *exec.Cmd) error {
 			// Permanent error (incl. attempt timeout) — return
 			// immediately, no retry. A timeout won't fix itself by
 			// retrying and would only delay surfacing the failure.
-			return err
+			return output, err
 		}
 		if attempt == maxGitRetries {
-			return fmt.Errorf("%w (retried %d times after git lock conflicts)", err, maxGitRetries)
+			return output, fmt.Errorf("%w (retried %d times after git lock conflicts)", err, maxGitRetries)
 		}
 
 		// Exponential backoff: baseGitDelay * 2^attempt, capped at 5 s,
@@ -2084,7 +2103,7 @@ func runGitWithRetry(makeCmd func() *exec.Cmd) error {
 			attempt+1, maxGitRetries, delay.Round(time.Millisecond))
 		time.Sleep(delay)
 	}
-	return nil // unreachable
+	return "", nil // unreachable
 }
 
 // setupWorktree provisions a git worktree for the implement operator.
@@ -2168,10 +2187,14 @@ func setupWorktree(repoCfg config.Repo, fullName string, issueNum int, startedAt
 	// runGitWithRetry handles transient git lock conflicts from concurrent
 	// parallel implement jobs on the same repo.
 	fmt.Fprintf(os.Stderr, "  → setup: fetching origin/%s\n", base)
-	if err := runGitWithRetry(func() *exec.Cmd {
+	if out, err := runGitWithRetryOutput(func() *exec.Cmd {
 		return exec.Command("git", "-C", localPath, "fetch", "origin", base)
 	}); err != nil {
-		fmt.Fprintf(os.Stderr, "  ⚠ fetch failed (continuing): %v\n", err)
+		// Non-fatal here (we can still start from a cached origin/<base>),
+		// but name the cause so a misconfigured base_branch is visible in
+		// the implement path too, not just the analysis path.
+		fmt.Fprintf(os.Stderr, "  ⚠ fetch failed (continuing): %v\n",
+			describeGitFetchFailure(base, localPath, out, branch.RemoteDefaultBranch(localPath), err))
 	}
 
 	fmt.Fprintf(os.Stderr, "  → setup: creating worktree at %s\n", wtPath)

--- a/internal/branch/validate.go
+++ b/internal/branch/validate.go
@@ -1,0 +1,118 @@
+package branch
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// lsRemoteTimeout bounds the single network probe ValidateBase may make. A var
+// so tests can shrink it.
+var lsRemoteTimeout = 15 * time.Second
+
+// BaseValidation reports whether a repo's configured base_branch actually
+// exists on the remote. A misconfigured value (e.g. base_branch: "origin")
+// makes every `git fetch origin <base>` fail with exit 128 forever, which
+// silently blocks analysis operators round after round (issue #300).
+type BaseValidation struct {
+	Base string // the base branch name that was checked
+
+	// LocalRefExists is true when refs/remotes/origin/<base> is present in
+	// the local clone — the cheap, offline-safe signal.
+	LocalRefExists bool
+
+	// RemoteRefExists is true when `git ls-remote --heads origin <base>`
+	// lists the branch. Only consulted when LocalRefExists is false, so a
+	// clone that simply hasn't fetched yet isn't reported as misconfigured.
+	RemoteRefExists bool
+
+	// RemoteChecked is false when the ls-remote probe itself failed
+	// (offline, missing credentials) — in that case "invalid" is unproven
+	// and callers must not treat the result as a config error.
+	RemoteChecked bool
+
+	// RemoteDefault is the remote's default branch (from
+	// refs/remotes/origin/HEAD), when resolvable — the suggested fix value.
+	RemoteDefault string
+}
+
+// Valid reports whether the base branch resolves to a real ref. It is true
+// when the local remote-tracking ref exists, when the remote lists the
+// branch, or when the remote could not be probed at all (unproven → treated
+// as valid so offline machines never block on this check).
+func (v BaseValidation) Valid() bool {
+	if v.LocalRefExists || v.RemoteRefExists {
+		return true
+	}
+	return !v.RemoteChecked
+}
+
+// Hint returns a human-readable remediation string when the base branch is
+// definitely wrong, or "" when it is valid/unproven.
+func (v BaseValidation) Hint() string {
+	if v.Valid() {
+		return ""
+	}
+	msg := fmt.Sprintf("base_branch %q does not exist on origin", v.Base)
+	if v.RemoteDefault != "" {
+		msg += fmt.Sprintf("; the remote default branch is %q", v.RemoteDefault)
+	}
+	return msg + " — fix base_branch in ~/.clawflow/config/config.yaml or from the dashboard repo page"
+}
+
+// ValidateBase checks whether origin/<base> resolves for the clone at
+// localPath. The local remote-tracking ref is checked first (pure local read,
+// microseconds); only when it is missing do we pay for one `ls-remote` probe
+// to tell "not fetched yet" apart from "remote has no such branch".
+//
+// localPath must be a git clone; an empty localPath yields a zero-value
+// result with RemoteChecked=false, i.e. Valid()==true (nothing to check).
+func ValidateBase(localPath, base string) BaseValidation {
+	if base == "" {
+		base = "main"
+	}
+	v := BaseValidation{Base: base}
+	if localPath == "" {
+		return v
+	}
+	v.RemoteDefault = RemoteDefaultBranch(localPath)
+
+	if _, err := gitOut(localPath, "rev-parse", "--verify", "--quiet",
+		"refs/remotes/origin/"+base); err == nil {
+		v.LocalRefExists = true
+		return v
+	}
+
+	// Bounded: this runs on the scan path and on every snapshot write, so a
+	// black-holed remote must not wedge either. headlessEnv already stops git
+	// from waiting on a credential prompt; the deadline covers the rest.
+	ctx, cancel := context.WithTimeout(context.Background(), lsRemoteTimeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, "git", "ls-remote", "--heads", "origin", base)
+	c.Dir = localPath
+	c.Env = headlessEnv()
+	out, err := c.Output()
+	if err != nil {
+		// Offline / no credentials / timed out / not a git dir — unproven,
+		// not invalid.
+		return v
+	}
+	v.RemoteChecked = true
+	v.RemoteRefExists = strings.Contains(string(out), "refs/heads/"+base)
+	return v
+}
+
+// RemoteDefaultBranch resolves the remote's default branch from the local
+// clone's refs/remotes/origin/HEAD symref (written at clone time, refreshed by
+// `git remote set-head`). Returns "" when it cannot be resolved — callers use
+// it only to enrich a warning message, never as a decision input.
+func RemoteDefaultBranch(localPath string) string {
+	out, err := gitOut(localPath, "symbolic-ref", "--short", "--quiet",
+		"refs/remotes/origin/HEAD")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimPrefix(strings.TrimSpace(out), "origin/")
+}

--- a/internal/branch/validate_test.go
+++ b/internal/branch/validate_test.go
@@ -1,0 +1,107 @@
+package branch
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// newClonePair builds a bare "remote" with a single `main` commit plus a clone
+// of it, and returns the clone path. Mirrors the setup style of
+// TestListMergedIntegration.
+func newClonePair(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	work := filepath.Join(root, "work")
+	clone := filepath.Join(root, "clone")
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run(root, "init", "--bare", "--initial-branch=main", remote)
+	run(root, "init", "--initial-branch=main", work)
+	run(work, "config", "user.email", "t@example.com")
+	run(work, "config", "user.name", "t")
+	run(work, "commit", "--allow-empty", "-m", "init")
+	run(work, "remote", "add", "origin", remote)
+	run(work, "push", "-u", "origin", "main")
+	run(root, "clone", remote, clone)
+	return clone
+}
+
+func TestValidateBase_ExistingBranch(t *testing.T) {
+	clone := newClonePair(t)
+	v := ValidateBase(clone, "main")
+	if !v.LocalRefExists {
+		t.Fatalf("expected origin/main to resolve locally: %+v", v)
+	}
+	if !v.Valid() {
+		t.Errorf("main should be valid: %+v", v)
+	}
+	if v.Hint() != "" {
+		t.Errorf("valid base should produce no hint, got %q", v.Hint())
+	}
+}
+
+// The issue #300 case: base_branch was literally "origin".
+func TestValidateBase_MisconfiguredBranch(t *testing.T) {
+	clone := newClonePair(t)
+	v := ValidateBase(clone, "origin")
+	if v.LocalRefExists || v.RemoteRefExists {
+		t.Fatalf("origin should not resolve as a branch: %+v", v)
+	}
+	if !v.RemoteChecked {
+		t.Fatalf("local remote should have been probed: %+v", v)
+	}
+	if v.Valid() {
+		t.Errorf("base_branch \"origin\" must be reported invalid: %+v", v)
+	}
+	if hint := v.Hint(); hint == "" {
+		t.Error("invalid base should produce a remediation hint")
+	}
+}
+
+func TestValidateBase_EmptyLocalPathIsUnproven(t *testing.T) {
+	v := ValidateBase("", "whatever")
+	if !v.Valid() {
+		t.Errorf("no local clone means nothing to validate: %+v", v)
+	}
+}
+
+func TestValidateBase_UnreachableRemoteIsUnproven(t *testing.T) {
+	dir := t.TempDir() // not a git repo at all
+	v := ValidateBase(dir, "main")
+	if v.RemoteChecked {
+		t.Fatalf("probe should have failed: %+v", v)
+	}
+	if !v.Valid() {
+		t.Errorf("unprovable base must not be flagged invalid: %+v", v)
+	}
+}
+
+func TestValidateBase_DefaultsToMain(t *testing.T) {
+	clone := newClonePair(t)
+	if v := ValidateBase(clone, ""); v.Base != "main" || !v.Valid() {
+		t.Errorf("empty base should default to main: %+v", v)
+	}
+}
+
+func TestRemoteDefaultBranch(t *testing.T) {
+	clone := newClonePair(t)
+	if got := RemoteDefaultBranch(clone); got != "main" {
+		t.Errorf("RemoteDefaultBranch = %q, want main", got)
+	}
+	if got := RemoteDefaultBranch(t.TempDir()); got != "" {
+		t.Errorf("non-git dir should yield empty, got %q", got)
+	}
+}

--- a/internal/snapshot/repos_basebranch_test.go
+++ b/internal/snapshot/repos_basebranch_test.go
@@ -1,0 +1,104 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/zhoushoujianwork/clawflow/internal/config"
+)
+
+// makeClone builds a bare remote with a `main` branch plus a clone of it,
+// returning the clone path.
+func makeClone(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	work := filepath.Join(root, "work")
+	clone := filepath.Join(root, "clone")
+	git := func(dir string, args ...string) {
+		t.Helper()
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	git(root, "init", "--bare", "--initial-branch=main", remote)
+	git(root, "init", "--initial-branch=main", work)
+	git(work, "config", "user.email", "t@example.com")
+	git(work, "config", "user.name", "t")
+	git(work, "commit", "--allow-empty", "-m", "init")
+	git(work, "remote", "add", "origin", remote)
+	git(work, "push", "-u", "origin", "main")
+	git(root, "clone", remote, clone)
+	return clone
+}
+
+func readRepoViews(t *testing.T) map[string]RepoView {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(DataDir(), "repos.json"))
+	if err != nil {
+		t.Fatalf("read repos.json: %v", err)
+	}
+	var views []RepoView
+	if err := json.Unmarshal(raw, &views); err != nil {
+		t.Fatalf("unmarshal repos.json: %v", err)
+	}
+	byName := make(map[string]RepoView, len(views))
+	for _, v := range views {
+		byName[v.FullName] = v
+	}
+	return byName
+}
+
+// A base_branch of "origin" (the issue #300 misconfiguration) must be flagged
+// in repos.json so the dashboard can render it, while a correct one is not.
+func TestWriteRepos_FlagsInvalidBaseBranch(t *testing.T) {
+	clone := makeClone(t)
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(DataDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{Repos: map[string]config.Repo{
+		"o/bad":  {Enabled: true, LocalPath: clone, BaseBranch: "origin"},
+		"o/good": {Enabled: true, LocalPath: clone, BaseBranch: "main"},
+	}}
+	if err := WriteRepos(cfg); err != nil {
+		t.Fatalf("WriteRepos: %v", err)
+	}
+
+	views := readRepoViews(t)
+	if bad := views["o/bad"]; bad.BaseBranchValid || bad.BaseBranchHint == "" {
+		t.Errorf("misconfigured base should be flagged with a hint: %+v", bad)
+	}
+	if good := views["o/good"]; !good.BaseBranchValid || good.BaseBranchHint != "" {
+		t.Errorf("correct base should be clean: %+v", good)
+	}
+}
+
+// Repos without a local clone can't be validated; they must not be flagged.
+func TestWriteRepos_NoLocalPathStaysValid(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(DataDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Repos: map[string]config.Repo{
+		"o/remote-only": {Enabled: true, BaseBranch: "whatever"},
+		"o/disabled":    {Enabled: false, BaseBranch: "origin"},
+	}}
+	if err := WriteRepos(cfg); err != nil {
+		t.Fatalf("WriteRepos: %v", err)
+	}
+	for name, v := range readRepoViews(t) {
+		if !v.BaseBranchValid {
+			t.Errorf("%s should not be flagged (unvalidatable): %+v", name, v)
+		}
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/zhoushoujianwork/clawflow/internal/branch"
 	"github.com/zhoushoujianwork/clawflow/internal/config"
 	"github.com/zhoushoujianwork/clawflow/internal/operator"
 	"github.com/zhoushoujianwork/clawflow/internal/project"
@@ -212,6 +213,14 @@ type RepoView struct {
 	// and flag the primary without a separate API call.
 	Projects       []string `json:"projects,omitempty"`
 	PrimaryProject string   `json:"primary_project,omitempty"`
+	// BaseBranchValid is false only when the remote was reachable and
+	// confirmed to have no such branch — a configuration error that makes
+	// every analysis operator on this repo fail with exit 128 (issue #300).
+	// Offline/unprobed repos stay true so the dashboard doesn't cry wolf.
+	BaseBranchValid bool `json:"base_branch_valid"`
+	// BaseBranchHint carries the remediation text when BaseBranchValid is
+	// false; empty otherwise.
+	BaseBranchHint string `json:"base_branch_hint,omitempty"`
 }
 
 // OperatorView is the dashboard-facing view of one loaded operator.
@@ -633,6 +642,17 @@ func WriteRepos(cfg *config.Config) error {
 				primaryName = primary.Name
 			}
 		}
+		// Validate base_branch for repos with a local clone. Local-ref hit
+		// is the fast path; ValidateBase only reaches the network when the
+		// remote-tracking ref is absent, and reports "valid" whenever the
+		// remote can't be probed.
+		baseValid, baseHint := true, ""
+		if r.Enabled && r.LocalPath != "" {
+			if v := branch.ValidateBase(r.LocalPath, r.BaseBranch); !v.Valid() {
+				baseValid, baseHint = false, v.Hint()
+			}
+		}
+
 		views = append(views, RepoView{
 			FullName:       name,
 			Platform:       r.Platform,
@@ -643,8 +663,10 @@ func WriteRepos(cfg *config.Config) error {
 			AutoApprove:    r.AutoApprove,
 			AutoMerge:      r.AutoMerge,
 			BoundMachine:   r.BoundMachine,
-			Projects:       projectNames,
-			PrimaryProject: primaryName,
+			Projects:        projectNames,
+			PrimaryProject:  primaryName,
+			BaseBranchValid: baseValid,
+			BaseBranchHint:  baseHint,
 		})
 	}
 	return writeJSON(filepath.Join(DataDir(), "repos.json"), views)

--- a/web/src/routes/_app.repos.$.tsx
+++ b/web/src/routes/_app.repos.$.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
-import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off, FolderOpen, FolderKanban } from 'lucide-react'
+import { ChevronLeft, ExternalLink, MessageSquare, Download, Loader2, RotateCw, Link2, Link2Off, FolderOpen, FolderKanban, AlertTriangle } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
@@ -29,6 +29,8 @@ interface Repo {
   auto_merge: boolean
   bound_machine?: string
   primary_project?: string
+  base_branch_valid?: boolean
+  base_branch_hint?: string
 }
 export const Route = createFileRoute('/_app/repos/$')({
   component: RepoDetail,
@@ -290,7 +292,20 @@ function RepoDetail() {
                 {repo.platform || 'github'}
               </span>
               <span>·</span>
-              <span className="font-mono">base: {repo.base_branch}</span>
+              {repo.base_branch_valid === false ? (
+                <span
+                  className="inline-flex items-center gap-1 font-mono text-destructive"
+                  title={repo.base_branch_hint || 'base_branch does not exist on origin'}
+                >
+                  <AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                  base: {repo.base_branch}
+                  <span className="sr-only">
+                    {repo.base_branch_hint || 'base_branch does not exist on origin'}
+                  </span>
+                </span>
+              ) : (
+                <span className="font-mono">base: {repo.base_branch}</span>
+              )}
               {owningProjects.length === 1 && (
                 <>
                   <span>·</span>

--- a/web/src/routes/_app.repos.index.tsx
+++ b/web/src/routes/_app.repos.index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useDocumentTitle } from '../lib/useDocumentTitle'
-import { FolderOpen, FolderKanban, Plus, Trash2, Link2, Link2Off, Search, X, Check, Loader2 } from 'lucide-react'
+import { FolderOpen, FolderKanban, Plus, Trash2, Link2, Link2Off, Search, X, Check, Loader2, AlertTriangle } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { repoUrl, type RepoInfoMap, type Platform } from '../lib/vcsUrls'
 import { VcsIcon } from '../components/VcsIcon'
@@ -20,6 +20,8 @@ interface Repo {
   auto_approve: boolean
   auto_merge: boolean
   bound_machine?: string
+  base_branch_valid?: boolean
+  base_branch_hint?: string
 }
 
 interface RunEntry {
@@ -471,7 +473,22 @@ function RepoList() {
                   <td className="px-4 py-2 text-muted-foreground text-xs tabular-nums">
                     {lastActivityMap[r.full_name] ? timeAgo(lastActivityMap[r.full_name]) : '—'}
                   </td>
-                  <td className="px-4 py-2 text-muted-foreground font-mono text-xs">{r.base_branch}</td>
+                  <td className="px-4 py-2 font-mono text-xs">
+                    {r.base_branch_valid === false ? (
+                      <span
+                        className="inline-flex items-center gap-1 text-destructive"
+                        title={r.base_branch_hint || 'base_branch does not exist on origin'}
+                      >
+                        <AlertTriangle className="w-3.5 h-3.5" aria-hidden="true" />
+                        <span>{r.base_branch}</span>
+                        <span className="sr-only">
+                          {r.base_branch_hint || 'base_branch does not exist on origin'}
+                        </span>
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">{r.base_branch}</span>
+                    )}
+                  </td>
                   <td className="px-4 py-2">
                     <GitSyncCell
                       repo={r.full_name}


### PR DESCRIPTION
Fixes #300

## 问题

`base_branch` 被误配成远端不存在的 ref（如 `origin`）时，`git fetch origin origin` 每轮必然 exit 128，而错误文案被硬编码为 `— cannot initialize analysis worktree without network access`。两件事叠加：配置错误全链路无校验，且错误定性把排查方向带向了 SSH deploy key，持续 3 周。

## 改动

**1. `base_branch` 校验（`internal/branch/validate.go`，新增）**

`ValidateBase` 先读本地 `refs/remotes/origin/<base>`（纯本地、微秒级），仅当本地 ref 缺失时才付一次 `ls-remote` 探测，用来区分「还没 fetch」和「远端确实没这个分支」。探测本身失败（离线 / 无凭证 / 超时）时结论是「未证实」而非「无效」—— 离线机器和刚 clone 的仓库不会被误报。探测有 15s 上限，配合 `headlessEnv` 保证不会卡在凭证提示上。

**2. scan 阶段告警（`run.go`）**

每轮对每个 enabled 且有 local_path 的仓库校验一次，不一致时 stderr 告警 + `run/base_branch_invalid` 结构化日志，并给出远端默认分支作为建议值。仅告警，不阻塞 scan。

**3. git fetch 错误分类（`gitfetcherr.go`，新增）**

`runGitWithRetryOutput` 把 git 合并输出返回给调用方 —— 这是修复文案的前置条件，因为 missing ref / 凭证被拒 / 主机不可达三者的 exit code 都是 128，只有 stderr 文本能区分。`runGitWithRetry` 保留为它的薄封装，现有调用方行为不变。

`classifyGitFetchError` 分四类，`describeGitFetchFailure` 按类出文案：ref-not-found 明确点出 `base_branch is likely misconfigured` 并附远端默认分支；只有真正的网络失败才保留 network access 措辞。两处分析 worktree 路径都接上了，implement 路径的 fetch 失败仍是 WARN 后继续（行为不变），但 WARN 内容现在也能指出串配。

**4. Dashboard 标红（`snapshot.go` + `web/`）**

`repos.json` 新增 `base_branch_valid` / `base_branch_hint`；仓库列表和详情页在无效时渲染警告徽标，`title` 与 `sr-only` 均带完整修复说明（屏幕阅读器可达，不依赖颜色单独传递信息）。

未做 issue 建议的第 3 项（`config-error` 终态 / 熔断改造）—— 那是独立的状态机改动，且 evaluate 分析指出现有熔断本身是有效的，被 patrol 摘 label 抵消了，值得单独一个 issue。

## 验证

`go test ./...` 全绿。新增测试：

- `TestClassifyGitFetchError` — 表驱动覆盖四类（含 issue 里的原始 `fatal: couldn't find remote ref origin`）
- `TestDescribeGitFetchFailure_*` — 断言 ref-not-found 文案含 `base_branch` 且**不含** `without network access`（本 issue 的回归点），auth/network 各自的措辞正确
- `TestFetchRefNotFound_RealGit` — 真实本地 bare repo + clone 跑一次 `git fetch origin origin`，走完整链路（`runGitWithRetryOutput` → classify → describe），并验证同一 clone、同一路径下 `fetch origin main` 成功（对齐 issue 里的两侧对照）
- `TestValidateBase_*` — 正确分支 / 串配 `origin` / 无 local_path / 非 git 目录 / 空值默认 main
- `TestWriteRepos_FlagsInvalidBaseBranch`、`TestWriteRepos_NoLocalPathStaysValid` — repos.json 落盘字段

运行时验证（按 testing.md，隔离的 `HOME` + 本地 bare remote，未触碰真实配置）：

- `base_branch: origin` → scan 输出 `⚠ local/badbase: base_branch "origin" does not exist on origin; the remote default branch is "main" — fix base_branch in ...`
- `~/.clawflow/logs/run.log` 出现 `WARN run/base_branch_invalid repo=local/badbase base=origin remote_default=main`
- `repos.json` → `"base_branch_valid": false` + 完整 hint
- 改回 `base_branch: main` → 告警消失，`base_branch_valid: true`，hint 为空

前端 `pnpm build`（含 `tsc --noEmit`）通过。徽标的视觉呈现未在浏览器中人工确认，仅经类型检查与构建验证。